### PR TITLE
state guard for set definitions

### DIFF
--- a/src/amuse/rfi/core.py
+++ b/src/amuse/rfi/core.py
@@ -886,7 +886,12 @@ class CodeInterface(OptionalAttributes):
             instance.parameter.name = newvalue
         """
         pass
-    
+
+    def before_new_set_instance(self):
+        """
+        (Can be) called everytime just before a new set is created
+        """
+        pass    
     
 
 class CodeWithDataDirectories(object):


### PR DESCRIPTION
proposed state  guard for set (grids, particle sets etc) definitions in code, along the lines of:

    object.define_grid('forcings',axes_names = axes_names, state_guard="before_new_set_instance")

currently there is no default, because setting a default "before_new_set_instance" method doesn't work with test_interface.py (wants a before_new_set_instance  it in InCodeComponentImplementation, while a normal code will fail in that case (something with the state model)

