### PR TITLE
support both rc.threaded and rc.threads

### DIFF
--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -1185,10 +1185,17 @@ class MpiChannel(AbstractMessageChannel):
     @classmethod
     def ensure_mpi_initialized(cls):
         if not MPI.Is_initialized():
-            if rc.threaded:
-                MPI.Init_thread(MPI.THREAD_MULTIPLE)
-            else:
-                MPI.Init()
+            try:
+                if rc.threaded:
+                    MPI.Init_thread(MPI.THREAD_MULTIPLE)
+                else:
+                    MPI.Init()
+            except AttributeError:
+                if rc.threads:
+                    MPI.Init_thread(MPI.THREAD_MULTIPLE)
+                else:
+                    MPI.Init()
+    
         cls.register_finalize_code()
 
     @classmethod

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -1185,13 +1185,15 @@ class MpiChannel(AbstractMessageChannel):
     @classmethod
     def ensure_mpi_initialized(cls):
         if not MPI.Is_initialized():
-            if self.is_threaded():
+            if cls.is_threaded():
                 MPI.Init_thread(MPI.THREAD_MULTIPLE)
             else:
                 MPI.Init()
         cls.register_finalize_code()
 
-    def is_threaded(self):
+    @classmethod
+    def is_threaded(cls):
+        #We want this for backwards compatibility with mpi4py versions < 2.0.0
         try:
             return rc.threaded
         except AttributeError:


### PR DESCRIPTION
This PR should resolve #26. It adds support for mpi4py 2.0.0 which seems to have dropped the variable `rc.threaded` in favor of `rc.threads`.