### PR TITLE
Memof fix

### DIFF
--- a/src/amuse/test/amusetest.py
+++ b/src/amuse/test/amusetest.py
@@ -8,7 +8,6 @@ import inspect
 from amuse.support import exceptions
 from amuse.support import literature
 from amuse.support import options
-from amuse.units.si import no_unit
 from amuse.units.quantities import Quantity
 from amuse.units.quantities import to_quantity
 from amuse.units.quantities import is_quantity

--- a/src/amuse/units/core.py
+++ b/src/amuse/units/core.py
@@ -526,6 +526,7 @@ class no_system(object):
         return cls.ALL[name]
         
 class none_unit(unit):
+    __metaclass__ = MultitonMetaClass
     def __init__(self, name,  symbol):
         self.name = name
         self.symbol = symbol

--- a/src/amuse/units/quantities.py
+++ b/src/amuse/units/quantities.py
@@ -660,7 +660,7 @@ class VectorQuantity(Quantity):
         >>> print vector
         [1.0, 2.0, 3.0, 4.0] kg
         """
-        append_number = numpy.array(scalar_quantity.value_in(self.unit))
+        append_number = numpy.array(scalar_quantity.value_in(self.unit)) # fix for deg, unitless
         # The following lines make sure that appending vectors works as expected,
         # e.g. ([]|units.m).append([1,2,3]|units.m) -> [[1,2,3]] | units.m
         # e.g. ([[1,2,3]]|units.m).append([4,5,6]|units.m) -> [[1,2,3],[4,5,6]] | units.m

--- a/src/amuse/units/si.py
+++ b/src/amuse/units/si.py
@@ -11,8 +11,8 @@ mol = core.base_unit('amount of substance', 'mole', 'mol', system)
 cd = core.base_unit('luminous intensity', 'candela', 'cd', system)
 
 no_system = core.no_system
-no_unit = core.none_unit('no unit','none')
 none = core.none_unit('none','none')
+no_unit = none
 
 named = core.named_unit
 


### PR DESCRIPTION
fix for fail of:

```
import numpy
from amuse.units import units

n=10000

for i in range(n):
  vec_i = numpy.random.random(size=[3]) | units.none
  print i, vec_i, vec_i.lengths(), vec_i.lengths().value_in(units.none)
```
another way to fix this would be to replace the various instances of none_unit('none','none') in e.g. to_simple_form in units/core.py...