### PR TITLE
Walltime fix

### DIFF
--- a/src/amuse/community/fi/src/buildnearlist.f90
+++ b/src/amuse/community/fi/src/buildnearlist.f90
@@ -55,7 +55,7 @@ subroutine epscal(option)
   enddo
   nsavg=nstot/(up-low+1)
 
-  if(verbosity.GT.0) print*,'<epscal> < a > t:',nsmin,nsavg,nsmax,nstot
+  if(verbosity.GT.0) print*,'<epscal> mn,av,mx:',nsmin,nsavg,nsmax
 
 end subroutine
 
@@ -91,7 +91,7 @@ subroutine hsmcal
     nnmin=MIN(nnmin,inear)
   enddo
   nnavg=nntot/(up-low+1)
-  if(verbosity.GT.0) print*,'<hsmcal> < a > t:',nnmin,nnavg,nnmax,nntot
+  if(verbosity.GT.0) print*,'<hsmcal> mn,av,mx:',nnmin,nnavg,nnmax
 
 end subroutine
 

--- a/src/amuse/community/fi/src/buildtree.f90
+++ b/src/amuse/community/fi/src/buildtree.f90
@@ -275,7 +275,7 @@ subroutine loadtree5(option,startcell)
   incells=totcell
   if(verbosity.GT.0) then
     write(*,'(" <loadtree> time:", 3f8.2)') mintime,maxtime,tottime
-    print*,'<loadtree> ',option,incells
+    print*,'<loadtree> option, parts, cells: ',option,iupper-ilower+1, incells
   endif
 end subroutine loadtree5
 

--- a/src/amuse/community/fi/src/buildtree.f90
+++ b/src/amuse/community/fi/src/buildtree.f90
@@ -208,7 +208,7 @@ subroutine loadtree5(option,startcell)
 !$omp reduction( MIN : mintime) & 
 !$omp reduction( MAX : maxtime) &
 !$omp reduction(+ : totredu,totcell,totbody,tottime) if(hcell-lcell.gt.maxthread)
-  call cpu_time(time1)
+  call wall_time(time1)
   mythread=0
   totalthread=1
 !$ mythread=omp_get_thread_num()    
@@ -260,7 +260,7 @@ subroutine loadtree5(option,startcell)
   totcell=totcell+checkcell
   totbody=totbody+checkbody
   totredu=totredu+checkredu
-  call cpu_time(time2)
+  call wall_time(time2)
   mintime=MIN(mintime,time2-time1)
   maxtime=MAX(maxtime,time2-time1)
   tottime=tottime+time2-time1

--- a/src/amuse/community/fi/src/density.f90
+++ b/src/amuse/community/fi/src/density.f90
@@ -354,7 +354,7 @@ subroutine densnhsmooth
 !$omp end parallel 
   nnavg=nntot/nsphact
   if(verbosity.GT.0) print*,'<densnhsmooth> parts,searches', nsphact,totalsearches 
-  if(verbosity.GT.0) print*,'<densnhsmooth> < a > t',nnmin,nnavg,nnmax
+  if(verbosity.GT.0) print*,'<densnhsmooth> mn,av,mx:',nnmin,nnavg,nnmax
   if(verbosity.GT.0) then
     write(*,'(" <densnhsmooth> time:", 3f8.2)') maxtime,mintime,tottime
     print*,'<densnhsmooth> max iter, fails:',imax,jtot

--- a/src/amuse/community/fi/src/density.f90
+++ b/src/amuse/community/fi/src/density.f90
@@ -311,7 +311,7 @@ subroutine densnhsmooth
 !$omp reduction( max : imax,nnmax,maxtime) &
 !$omp reduction(+ : jtot,nntot,tottime,totalsearches,drhosum,niter) &
 !$omp reduction( min : nnmin,mintime) 
-  call cpu_time(time1)
+  call wall_time(time1)
   ncalls=0;nsearches=0
 !$omp do schedule(guided,1) 
   do chunk=1,nchunk
@@ -346,7 +346,7 @@ subroutine densnhsmooth
     enddo
   enddo
 !$omp enddo nowait
-  call cpu_time(time2)
+  call wall_time(time2)
   mintime=MIN(mintime,time2-time1)
   maxtime=MAX(maxtime,time2-time1)
   tottime=tottime+time2-time1

--- a/src/amuse/community/fi/src/density.f90
+++ b/src/amuse/community/fi/src/density.f90
@@ -354,7 +354,7 @@ subroutine densnhsmooth
 !$omp end parallel 
   nnavg=nntot/nsphact
   if(verbosity.GT.0) print*,'<densnhsmooth> parts,searches', nsphact,totalsearches 
-  if(verbosity.GT.0) print*,'<densnhsmooth> < a > t',nnmin,nnavg,nnmax,nntot
+  if(verbosity.GT.0) print*,'<densnhsmooth> < a > t',nnmin,nnavg,nnmax
   if(verbosity.GT.0) then
     write(*,'(" <densnhsmooth> time:", 3f8.2)') maxtime,mintime,tottime
     print*,'<densnhsmooth> max iter, fails:',imax,jtot

--- a/src/amuse/community/fi/src/density.f90
+++ b/src/amuse/community/fi/src/density.f90
@@ -353,7 +353,7 @@ subroutine densnhsmooth
   totalsearches=totalsearches+nsearches
 !$omp end parallel 
   nnavg=nntot/nsphact
-  if(verbosity.GT.0) print*,'<densnhsmooth> parts,searches', nsphact,totalsearches 
+  if(verbosity.GT.0) print*,'<densnhsmooth> parts,searches:', nsphact,totalsearches 
   if(verbosity.GT.0) print*,'<densnhsmooth> mn,av,mx:',nnmin,nnavg,nnmax
   if(verbosity.GT.0) then
     write(*,'(" <densnhsmooth> time:", 3f8.2)') maxtime,mintime,tottime

--- a/src/amuse/community/fi/src/entdot.f90
+++ b/src/amuse/community/fi/src/entdot.f90
@@ -53,7 +53,7 @@ subroutine omp_entdotaccsphco
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<dentacc> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<dentacc> < a > t',nnmin,nnavg,nnmax,nntot
+ if(verbosity.GT.0) print*,'<dentacc> < a > t',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <dentacc> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_entdotaccsphco iter count")
 end
@@ -113,7 +113,7 @@ totalsearches=0
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<accsph> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<accsph> < a > t',nnmin,nnavg,nnmax,nntot
+ if(verbosity.GT.0) print*,'<accsph> < a > t',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <accsph> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_accsphco iter count")
 end
@@ -174,7 +174,7 @@ subroutine omp_entdot
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<entdot> parts,searches', nsphact,totalsearches
- if(verbosity.GT.0) print*,'<entdot> < a > t',nnmin,nnavg,nnmax,nntot
+ if(verbosity.GT.0) print*,'<entdot> < a > t',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <entdot> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_entdot iter count")
 end
@@ -591,7 +591,7 @@ subroutine omp_ethdotaccsphco
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<dethacc> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<dethacc> < a > t',nnmin,nnavg,nnmax,nntot
+ if(verbosity.GT.0) print*,'<dethacc> < a > t',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <dethacc> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_ethdotaccsphco iter count")
 end
@@ -651,7 +651,7 @@ subroutine omp_ethdotco
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<deth> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<deth> < a > t',nnmin,nnavg,nnmax,nntot
+ if(verbosity.GT.0) print*,'<deth> < a > t',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <deth> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_ethdotco iter count")
 end

--- a/src/amuse/community/fi/src/entdot.f90
+++ b/src/amuse/community/fi/src/entdot.f90
@@ -22,7 +22,7 @@ subroutine omp_entdotaccsphco
 !$omp reduction( + : tottime,nntot,totalsearches,niter) & 
 !$omp reduction( MIN : mintime,nnmin) & 
 !$omp reduction( MAX : maxtime,nnmax)
- call cpu_time(time1)
+ call wall_time(time1)
  ncalls=0;nsearches=0
 !$omp do schedule(guided,1)
  do chunk=1,nchunk
@@ -45,7 +45,7 @@ subroutine omp_entdotaccsphco
   enddo
  enddo
 !$omp enddo nowait  
- call cpu_time(time2)
+ call wall_time(time2)
  mintime=MIN(mintime,time2-time1)
  maxtime=MAX(maxtime,time2-time1)
  tottime=tottime+time2-time1
@@ -82,7 +82,7 @@ totalsearches=0
 !$omp reduction( + : tottime,nntot,niter) & 
 !$omp reduction( MIN : mintime,nnmin) & 
 !$omp reduction( MAX : maxtime,nnmax)
- call cpu_time(time1)
+ call wall_time(time1)
  ncalls=0;nsearches=0
 !$omp do schedule(guided,1)
  do chunk=1,nchunk
@@ -105,6 +105,7 @@ totalsearches=0
   enddo
  enddo
 !$omp enddo nowait  
+ call wall_time(time2)
  mintime=MIN(mintime,time2-time1)
  maxtime=MAX(maxtime,time2-time1)
  tottime=tottime+time2-time1
@@ -142,7 +143,7 @@ subroutine omp_entdot
 !$omp reduction( + : tottime,nntot, niter) & 
 !$omp reduction( MIN : mintime,nnmin) & 
 !$omp reduction( MAX : maxtime,nnmax)
- call cpu_time(time1)
+ call wall_time(time1)
  ncalls=0;nsearches=0
 !$omp do schedule(guided,1)
  do chunk=1,nchunk
@@ -165,13 +166,12 @@ subroutine omp_entdot
   enddo
  enddo
 !$omp enddo nowait  
- call cpu_time(time2)
+ call wall_time(time2)
  mintime=MIN(mintime,time2-time1)
  maxtime=MAX(maxtime,time2-time1)
  tottime=tottime+time2-time1
  totalsearches=totalsearches+nsearches
 !$omp end parallel
- call cpu_time(utime2)
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<entdot> parts,searches', nsphact,totalsearches
  if(verbosity.GT.0) print*,'<entdot> < a > t',nnmin,nnavg,nnmax,nntot
@@ -560,7 +560,7 @@ subroutine omp_ethdotaccsphco
 !$omp reduction( + : tottime,nntot,totalsearches,niter) & 
 !$omp reduction( MIN : mintime,nnmin) & 
 !$omp reduction( MAX : maxtime,nnmax)
- call cpu_time(time1)
+ call wall_time(time1)
  ncalls=0;nsearches=0
 !$omp do schedule(guided,1)
  do chunk=1,nchunk
@@ -583,7 +583,7 @@ subroutine omp_ethdotaccsphco
   enddo
  enddo
 !$omp enddo nowait  
- call cpu_time(time2)
+ call wall_time(time2)
  mintime=MIN(mintime,time2-time1)
  maxtime=MAX(maxtime,time2-time1)
  tottime=tottime+time2-time1
@@ -620,7 +620,7 @@ subroutine omp_ethdotco
 !$omp reduction( + : tottime,nntot,totalsearches,niter) & 
 !$omp reduction( MIN : mintime,nnmin) & 
 !$omp reduction( MAX : maxtime,nnmax)
- call cpu_time(time1)
+ call wall_time(time1)
  ncalls=0;nsearches=0
 !$omp do schedule(guided,1)
  do chunk=1,nchunk
@@ -643,7 +643,7 @@ subroutine omp_ethdotco
   enddo
  enddo
 !$omp enddo nowait  
- call cpu_time(time2)
+ call wall_time(time2)
  mintime=MIN(mintime,time2-time1)
  maxtime=MAX(maxtime,time2-time1)
  tottime=tottime+time2-time1

--- a/src/amuse/community/fi/src/entdot.f90
+++ b/src/amuse/community/fi/src/entdot.f90
@@ -53,7 +53,7 @@ subroutine omp_entdotaccsphco
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<dentacc> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<dentacc> < a > t',nnmin,nnavg,nnmax
+ if(verbosity.GT.0) print*,'<dentacc> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <dentacc> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_entdotaccsphco iter count")
 end
@@ -113,7 +113,7 @@ totalsearches=0
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<accsph> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<accsph> < a > t',nnmin,nnavg,nnmax
+ if(verbosity.GT.0) print*,'<accsph> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <accsph> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_accsphco iter count")
 end
@@ -174,7 +174,7 @@ subroutine omp_entdot
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<entdot> parts,searches', nsphact,totalsearches
- if(verbosity.GT.0) print*,'<entdot> < a > t',nnmin,nnavg,nnmax
+ if(verbosity.GT.0) print*,'<entdot> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <entdot> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_entdot iter count")
 end
@@ -591,7 +591,7 @@ subroutine omp_ethdotaccsphco
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<dethacc> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<dethacc> < a > t',nnmin,nnavg,nnmax
+ if(verbosity.GT.0) print*,'<dethacc> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <dethacc> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_ethdotaccsphco iter count")
 end
@@ -651,7 +651,7 @@ subroutine omp_ethdotco
 !$omp end parallel
  nnavg=nntot/nsphact
  if(verbosity.GT.0) print*,'<deth> parts,searches', nsphact,totalsearches 
- if(verbosity.GT.0) print*,'<deth> < a > t',nnmin,nnavg,nnmax
+ if(verbosity.GT.0) print*,'<deth> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <deth> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_ethdotco iter count")
 end

--- a/src/amuse/community/fi/src/entdot.f90
+++ b/src/amuse/community/fi/src/entdot.f90
@@ -52,7 +52,7 @@ subroutine omp_entdotaccsphco
  totalsearches=totalsearches+nsearches
 !$omp end parallel
  nnavg=nntot/nsphact
- if(verbosity.GT.0) print*,'<dentacc> parts,searches', nsphact,totalsearches 
+ if(verbosity.GT.0) print*,'<dentacc> parts,searches:', nsphact,totalsearches 
  if(verbosity.GT.0) print*,'<dentacc> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <dentacc> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_entdotaccsphco iter count")
@@ -112,7 +112,7 @@ totalsearches=0
  totalsearches=totalsearches+nsearches
 !$omp end parallel
  nnavg=nntot/nsphact
- if(verbosity.GT.0) print*,'<accsph> parts,searches', nsphact,totalsearches 
+ if(verbosity.GT.0) print*,'<accsph> parts,searches:', nsphact,totalsearches 
  if(verbosity.GT.0) print*,'<accsph> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <accsph> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_accsphco iter count")
@@ -173,7 +173,7 @@ subroutine omp_entdot
  totalsearches=totalsearches+nsearches
 !$omp end parallel
  nnavg=nntot/nsphact
- if(verbosity.GT.0) print*,'<entdot> parts,searches', nsphact,totalsearches
+ if(verbosity.GT.0) print*,'<entdot> parts,searches:', nsphact,totalsearches
  if(verbosity.GT.0) print*,'<entdot> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <entdot> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_entdot iter count")
@@ -590,7 +590,7 @@ subroutine omp_ethdotaccsphco
  totalsearches=totalsearches+nsearches
 !$omp end parallel
  nnavg=nntot/nsphact
- if(verbosity.GT.0) print*,'<dethacc> parts,searches', nsphact,totalsearches 
+ if(verbosity.GT.0) print*,'<dethacc> parts,searches:', nsphact,totalsearches 
  if(verbosity.GT.0) print*,'<dethacc> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <dethacc> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_ethdotaccsphco iter count")
@@ -650,7 +650,7 @@ subroutine omp_ethdotco
  totalsearches=totalsearches+nsearches
 !$omp end parallel
  nnavg=nntot/nsphact
- if(verbosity.GT.0) print*,'<deth> parts,searches', nsphact,totalsearches 
+ if(verbosity.GT.0) print*,'<deth> parts,searches:', nsphact,totalsearches 
  if(verbosity.GT.0) print*,'<deth> mn,av,mx:',nnmin,nnavg,nnmax
  if(verbosity.GT.0) write(*,'(" <deth> time:", 3f8.2)') mintime,maxtime,tottime
  if(niter.NE.nsphact) call terror("inconsistent omp_ethdotco iter count")

--- a/src/amuse/community/fi/src/ethstep.f90
+++ b/src/amuse/community/fi/src/ethstep.f90
@@ -159,7 +159,7 @@ subroutine extrapeth(dt)
 !$omp reduction(+ : tottime) & 
 !$omp reduction(max : jmax,imax,maxtime)	&
 !$omp reduction(min : mintime)
-  call cpu_time(time1)
+  call wall_time(time1)
 !$omp do
   do p=1,nsph
    if(rho(p).EQ.0) cycle
@@ -199,7 +199,7 @@ subroutine extrapeth(dt)
    derad(p)=drad  
   enddo
 !$omp enddo nowait 
-  call cpu_time(time2)
+  call wall_time(time2)
   mintime=MIN(mintime,time2-time1)
   maxtime=MAX(maxtime,time2-time1)
   tottime=tottime+time2-time1
@@ -238,7 +238,7 @@ subroutine exstep2(pc)
 !$omp reduction(+ : eradiate,snheat,efuvheat,eradcool,tottime) & 
 !$omp reduction(max : jmax,imax,maxtime)	 &
 !$omp reduction(min : mintime) 
-        call cpu_time(time1)
+        call wall_time(time1)
 !$omp do
   do k=1,nsphact
    p=pactive(k)
@@ -272,7 +272,7 @@ subroutine exstep2(pc)
    endif 
   enddo
 !$omp enddo nowait 
-  call cpu_time(time2)
+  call wall_time(time2)
   mintime=MIN(mintime,time2-time1)
   maxtime=MAX(maxtime,time2-time1)
   tottime=tottime+time2-time1

--- a/src/amuse/community/fi/src/feedback.f90
+++ b/src/amuse/community/fi/src/feedback.f90
@@ -66,7 +66,7 @@ subroutine pp_feedback(dt,tnu)
 !$      mythread=omp_get_thread_num()
 !$      totalthread=omp_get_num_threads()
   allocate(p_acc(nsph,3))
-  call cpu_time(time1)
+  call wall_time(time1)
   p_acc(1:nsph,1:3)=0.
 !$omp do reduction(+ : lsnheat)
  do i=1,npp   
@@ -97,7 +97,7 @@ subroutine pp_feedback(dt,tnu)
   endif
  enddo
 !$omp enddo nowait
- call cpu_time(time2)
+ call wall_time(time2)
 
 if(nsphact.GT.0) then
   p_acc(1:pactive(1)-1,1:3)=0.

--- a/src/amuse/community/fi/src/fuvflux.f90
+++ b/src/amuse/community/fi/src/fuvflux.f90
@@ -27,7 +27,7 @@ subroutine fuvflux
 !$omp reduction( + : nttotfuv,tottime,totalsearches,niter) & 
 !$omp reduction( MIN : ntminfuv, mintime) &
 !$omp reduction( MAX : ntmaxfuv, maxtime)
-  call cpu_time(time1)
+  call wall_time(time1)
   ncalls=0;nsearches=0		
 !$omp do schedule(guided,1)
   do k=1,nchunk
@@ -62,7 +62,7 @@ subroutine fuvflux
     enddo  
   enddo	  
 !$omp enddo nowait 
-  call cpu_time(time2)
+  call wall_time(time2)
   mintime=MIN(mintime,time2-time1)
   maxtime=MAX(maxtime,time2-time1)
   tottime=tottime+time2-time1
@@ -71,7 +71,7 @@ subroutine fuvflux
   ntavgfuv=nttotfuv/nsphact
   if(verbosity.GT.0) then
     print*,'<fuvflux> searches', nsphact,totalsearches
-    write(*,'(" <fuvflux> time:", 3f8.2)') maxtime,mintime
+    write(*,'(" <fuvflux> time:", 3f8.2)') maxtime,mintime,tottime
     print*,'<fuvflux> < a > t:',ntminfuv,ntavgfuv,ntmaxfuv,nttotfuv
   endif
   if(niter.NE.nsphact) call terror("fuvflux inconsistent iter count")

--- a/src/amuse/community/fi/src/fuvflux.f90
+++ b/src/amuse/community/fi/src/fuvflux.f90
@@ -70,7 +70,7 @@ subroutine fuvflux
 !$omp end parallel
   ntavgfuv=nttotfuv/nsphact
   if(verbosity.GT.0) then
-    print*,'<fuvflux> searches', nsphact,totalsearches
+    print*,'<fuvflux> parts,searches:', nsphact,totalsearches
     write(*,'(" <fuvflux> time:", 3f8.2)') maxtime,mintime,tottime
     print*,'<fuvflux> mn,av,mx:',ntminfuv,ntavgfuv,ntmaxfuv
   endif

--- a/src/amuse/community/fi/src/fuvflux.f90
+++ b/src/amuse/community/fi/src/fuvflux.f90
@@ -72,7 +72,7 @@ subroutine fuvflux
   if(verbosity.GT.0) then
     print*,'<fuvflux> searches', nsphact,totalsearches
     write(*,'(" <fuvflux> time:", 3f8.2)') maxtime,mintime,tottime
-    print*,'<fuvflux> < a > t:',ntminfuv,ntavgfuv,ntmaxfuv,nttotfuv
+    print*,'<fuvflux> < a > t:',ntminfuv,ntavgfuv,ntmaxfuv
   endif
   if(niter.NE.nsphact) call terror("fuvflux inconsistent iter count")
 end subroutine

--- a/src/amuse/community/fi/src/fuvflux.f90
+++ b/src/amuse/community/fi/src/fuvflux.f90
@@ -72,7 +72,7 @@ subroutine fuvflux
   if(verbosity.GT.0) then
     print*,'<fuvflux> searches', nsphact,totalsearches
     write(*,'(" <fuvflux> time:", 3f8.2)') maxtime,mintime,tottime
-    print*,'<fuvflux> < a > t:',ntminfuv,ntavgfuv,ntmaxfuv
+    print*,'<fuvflux> mn,av,mx:',ntminfuv,ntavgfuv,ntmaxfuv
   endif
   if(niter.NE.nsphact) call terror("fuvflux inconsistent iter count")
 end subroutine

--- a/src/amuse/community/fi/src/globals.h
+++ b/src/amuse/community/fi/src/globals.h
@@ -114,9 +114,10 @@
       INTEGER sfrfilenr,bhfilenr,erasenr
       PARAMETER(sfrfilenr=23,bhfilenr=24,erasenr=25)
       
-      INTEGER root,nbodies,incells,nttot,ntmin,ntmax,ntavg,nsteps,       &
-     &  stepout,steplog,incellsg,targetnn,nstot,nsmin,nsmax,nsavg,       &
-     &  nttotfuv,ntminfuv,ntmaxfuv,ntavgfuv
+      INTEGER*8 nttot,nttotfuv,nstot
+      INTEGER root,nbodies,incells,ntmin,ntmax,ntavg,nsteps,             &
+     &  stepout,steplog,incellsg,targetnn,nsmin,nsmax,nsavg,             &
+     &  ntminfuv,ntmaxfuv,ntavgfuv
       LOGICAL usequad,usesph,fixthalo,selfgrav,adaptive_eps, directsum,  &
      &  isotherm
       REAL bh_tol,eps,rsize,rmin,tnow,tpos,dtime,tiny,                   &
@@ -134,7 +135,7 @@
       COMMON/paramcom/ nbodies,nsnap
       COMMON/cellcom/ rmin(ndim),rsize,incells,incellsg
       COMMON/pointers/ root
-      COMMON/forcecom/ nttot,ntmin,ntmax,ntavg,nttotfuv,ntminfuv,        &
+      COMMON/forcecom/ nttot,nttotfuv,ntmin,ntmax,ntavg,ntminfuv,        &
      &  ntmaxfuv,ntavgfuv
       COMMON/softcom/ nstot,nsmin,nsmax,nsavg
       COMMON/timecom/ tnow,tpos
@@ -177,7 +178,8 @@
       COMMON/interpoc/ deldr2i
       COMMON/skerncom/ wsmooth(0:1+ninterp),dwsmooth(0:1+ninterp)
       
-      INTEGER nntot,nnmin,nnmax,nnavg
+      INTEGER*8 nntot
+      INTEGER nnmin,nnmax,nnavg
       
       COMMON/neighcom/ nntot,nnmin,nnmax,nnavg
       

--- a/src/amuse/community/fi/src/gravity.f90
+++ b/src/amuse/community/fi/src/gravity.f90
@@ -98,7 +98,7 @@
 !$omp end parallel
   ntavg=nttot/npactive
   if(verbosity.GT.0) then
-   print*,'<accgrav> searches', npactive,totalsearches
+   print*,'<accgrav> parts,searches:', npactive,totalsearches
    write(*,'(" <accgrav> time:", 3f8.2)') maxtime,mintime, tottime
    print*,'<accgrav> mn,av,mx:',ntmin,ntavg,ntmax
   endif

--- a/src/amuse/community/fi/src/gravity.f90
+++ b/src/amuse/community/fi/src/gravity.f90
@@ -53,7 +53,7 @@
 !$omp reduction( + : nttot, esofttot,tottime,totalsearches,niter) & 
 !$omp reduction( MIN : ntmin,mintime) &
 !$omp reduction( MAX : ntmax,maxtime)
-   call cpu_time(time1)
+   call wall_time(time1)
    ncalls=0;nsearches=0		
 !$omp do schedule(guided,1)
    do k=1,nchunk
@@ -90,7 +90,7 @@
     enddo  
    enddo	  
 !$omp enddo nowait 
-   call cpu_time(time2)
+   call wall_time(time2)
    mintime=MIN(mintime,time2-time1)
    maxtime=MAX(maxtime,time2-time1)
    tottime=tottime+time2-time1
@@ -99,7 +99,7 @@
   ntavg=nttot/npactive
   if(verbosity.GT.0) then
    print*,'<accgrav> searches', npactive,totalsearches
-   write(*,'(" <accgrav> time:", 2f8.2)') maxtime,mintime
+   write(*,'(" <accgrav> time:", 3f8.2)') maxtime,mintime, tottime
    print*,'<accgrav> < a > t:',ntmin,ntavg,ntmax,nttot
   endif
   if(niter.NE.npactive) call terror("accgrav inconsistent iter count")
@@ -120,7 +120,7 @@
 ! and in the acc. (hence they do not experience grav acc)
 ! this could be changed later to be more flexible)
  
-   call cpu_time(utime1)
+   call wall_time(utime1)
    if(tnow.GE.tpm) then 
     call pmgrav(nbodies,mass,pos)
     vmax=maxval(vel(1:nbodies,1:3))
@@ -128,20 +128,20 @@
     if(verbosity.GT.0) print*,'<pmaccgrav> timestep:',dtpm
     tpm=tpm+dtpm
    endif
-   call cpu_time(utime2)
+   call wall_time(utime2)
 !$omp parallel  &
 !$omp private(p,i,time1,time2) &
 !$omp reduction( + : tottime) &
 !$omp reduction( MIN : mintime) & 
 !$omp reduction( MAX : maxtime)
-   call cpu_time(time1)
+   call wall_time(time1)
 !$omp do schedule(guided,200)
    do i=1,npactive
     p=pactive(i) 
     if(mass(p).GT.0) call pmgravsum(p,option)
    enddo
 !$omp enddo nowait 
-   call cpu_time(time2)
+   call wall_time(time2)
    mintime=MIN(mintime,time2-time1)
    maxtime=MAX(maxtime,time2-time1)
    tottime=tottime+time2-time1

--- a/src/amuse/community/fi/src/gravity.f90
+++ b/src/amuse/community/fi/src/gravity.f90
@@ -100,7 +100,7 @@
   if(verbosity.GT.0) then
    print*,'<accgrav> searches', npactive,totalsearches
    write(*,'(" <accgrav> time:", 3f8.2)') maxtime,mintime, tottime
-   print*,'<accgrav> < a > t:',ntmin,ntavg,ntmax,nttot
+   print*,'<accgrav> < a > t:',ntmin,ntavg,ntmax
   endif
   if(niter.NE.npactive) call terror("accgrav inconsistent iter count")
  end subroutine

--- a/src/amuse/community/fi/src/gravity.f90
+++ b/src/amuse/community/fi/src/gravity.f90
@@ -100,7 +100,7 @@
   if(verbosity.GT.0) then
    print*,'<accgrav> searches', npactive,totalsearches
    write(*,'(" <accgrav> time:", 3f8.2)') maxtime,mintime, tottime
-   print*,'<accgrav> < a > t:',ntmin,ntavg,ntmax
+   print*,'<accgrav> mn,av,mx:',ntmin,ntavg,ntmax
   endif
   if(niter.NE.npactive) call terror("accgrav inconsistent iter count")
  end subroutine

--- a/src/amuse/community/fi/src/io-old.f
+++ b/src/amuse/community/fi/src/io-old.f
@@ -314,7 +314,6 @@ C=======================================================================
 
         IF(bdummy) THEN
 	 print*,'  > detailed info: loud =.TRUE.'   
-         print*,'  >  (< a > t: min average max total)'
 	ELSE
 	 print*,'  > sparse info: loud=.FALSE.' 
         ENDIF
@@ -525,7 +524,6 @@ C=======================================================================
 		
         IF(bdummy) THEN
 	 print*,'  > detailed info: loud =.TRUE.'   
-         print*,'  >  (< a > t: min average max total)'
 	ELSE
 	 print*,'  > sparse info: loud=.FALSE.' 
         ENDIF

--- a/src/amuse/community/fi/src/io.f90
+++ b/src/amuse/community/fi/src/io.f90
@@ -126,10 +126,10 @@ subroutine outlog(istep)
   else
     write(ulog,'("time, ncells = ",(1pe17.9),i9)') tnow,incellsg
   endif
-  write(ulog,'("nttot,ntmin,ntmax,ntavg = ",4i9)') nttot,ntmin,ntmax,ntavg
-  write(ulog,'("nntot,ntmin,ntmax,ntavg = ",4i9)') nntot,nnmin,nnmax,nnavg
+  write(ulog,'("nttot,ntmin,ntmax,ntavg = ",4i12)') nttot,ntmin,ntmax,ntavg
+  write(ulog,'("nntot,ntmin,ntmax,ntavg = ",4i12)') nntot,nnmin,nnmax,nnavg
   if(adaptive_eps) &
-    write(ulog,'("nstot,ntmin,ntmax,ntavg = ",4i9)') nstot,nsmin,nsmax,nsavg
+    write(ulog,'("nstot,ntmin,ntmax,ntavg = ",4i12)') nstot,nsmin,nsmax,nsavg
   if(usesph) then
     tstepbin(1:20)=0
     do p=1,nsph

--- a/src/amuse/community/fi/src/io2.f90
+++ b/src/amuse/community/fi/src/io2.f90
@@ -393,9 +393,9 @@ write(uboddump) n
       write(uboddump)  nbodies,nsnap
       write(uboddump)  rmin,rsize,incells,incellsg
       write(uboddump)  root
-      write(uboddump)  nttot,ntmin,ntmax,ntavg,nttotfuv,ntminfuv,        &
+      write(uboddump)  int(nttot),ntmin,ntmax,ntavg,int(nttotfuv),ntminfuv,        &
    ntmaxfuv,ntavgfuv
-      write(uboddump)  nstot,nsmin,nsmax,nsavg
+      write(uboddump)  int(nstot),nsmin,nsmax,nsavg
       write(uboddump)  tnow,tpos
       write(uboddump)  tiny
       write(uboddump)  mtot,etot,ektot,eptot,mstar,mgas,snheat,esofttot, &
@@ -410,7 +410,7 @@ write(uboddump) n
       write(uboddump)  massres
       write(uboddump)  deldr2i
       write(uboddump)  wsmooth,dwsmooth
-      write(uboddump)  nntot,nnmin,nnmax,nnavg
+      write(uboddump)  int(nntot),nnmin,nnmax,nnavg
       write(uboddump)  hboxsize
       write(uboddump)  poshalo,masshalo
       write(uboddump)  eradiate,trad,meanmwt,     &
@@ -469,7 +469,7 @@ end subroutine
 
 subroutine readdump(n) 
  include 'globals.h' 
- integer ioerror,n,i 
+ integer ioerror,n,i,idummy,idummy2
  real dummy 
  logical ldummy
  open(unit=uboddump,file=dumpfile,status='OLD',form='UNFORMATTED',iostat=ioerror) 
@@ -501,9 +501,12 @@ read(uboddump) n
       read(uboddump)  nbodies,nsnap
       read(uboddump)  rmin,rsize,incells,incellsg
       read(uboddump)  root
-      read(uboddump)  nttot,ntmin,ntmax,ntavg,nttotfuv,ntminfuv,        &
+      read(uboddump)  idummy,ntmin,ntmax,ntavg,idummy2,ntminfuv,        &
    ntmaxfuv,ntavgfuv
-      read(uboddump)  nstot,nsmin,nsmax,nsavg
+      nttot=idummy ! nttot, nstot, nttotfuv, nntot=8byte int, io format expects 4
+      nttotfuv=idummy2
+      read(uboddump)  idummy,nsmin,nsmax,nsavg
+      nstot=idummy
       read(uboddump)  tnow,tpos
       read(uboddump)  tiny
       read(uboddump)  mtot,etot,ektot,eptot,mstar,mgas,snheat,esofttot, &
@@ -518,7 +521,8 @@ read(uboddump) n
       read(uboddump)  massres
       read(uboddump)  deldr2i
       read(uboddump)  wsmooth,dwsmooth
-      read(uboddump)  nntot,nnmin,nnmax,nnavg
+      read(uboddump)  idummy,nnmin,nnmax,nnavg
+      nntot=idummy 
       read(uboddump)  hboxsize
       read(uboddump)  poshalo,masshalo
       read(uboddump)  eradiate,trad,meanmwt,     &

--- a/src/amuse/community/fi/src/io2.f90
+++ b/src/amuse/community/fi/src/io2.f90
@@ -393,9 +393,9 @@ write(uboddump) n
       write(uboddump)  nbodies,nsnap
       write(uboddump)  rmin,rsize,incells,incellsg
       write(uboddump)  root
-      write(uboddump)  int(nttot),ntmin,ntmax,ntavg,int(nttotfuv),ntminfuv,        &
+      write(uboddump)  nttot,ntmin,ntmax,ntavg,nttotfuv,ntminfuv,        &
    ntmaxfuv,ntavgfuv
-      write(uboddump)  int(nstot),nsmin,nsmax,nsavg
+      write(uboddump)  nstot,nsmin,nsmax,nsavg
       write(uboddump)  tnow,tpos
       write(uboddump)  tiny
       write(uboddump)  mtot,etot,ektot,eptot,mstar,mgas,snheat,esofttot, &
@@ -410,7 +410,7 @@ write(uboddump) n
       write(uboddump)  massres
       write(uboddump)  deldr2i
       write(uboddump)  wsmooth,dwsmooth
-      write(uboddump)  int(nntot),nnmin,nnmax,nnavg
+      write(uboddump)  nntot,nnmin,nnmax,nnavg
       write(uboddump)  hboxsize
       write(uboddump)  poshalo,masshalo
       write(uboddump)  eradiate,trad,meanmwt,     &
@@ -501,12 +501,9 @@ read(uboddump) n
       read(uboddump)  nbodies,nsnap
       read(uboddump)  rmin,rsize,incells,incellsg
       read(uboddump)  root
-      read(uboddump)  idummy,ntmin,ntmax,ntavg,idummy2,ntminfuv,        &
+      read(uboddump)  nttot,ntmin,ntmax,ntavg,nttotfuv,ntminfuv,        &
    ntmaxfuv,ntavgfuv
-      nttot=idummy ! nttot, nstot, nttotfuv, nntot=8byte int, io format expects 4
-      nttotfuv=idummy2
-      read(uboddump)  idummy,nsmin,nsmax,nsavg
-      nstot=idummy
+      read(uboddump)  nstot,nsmin,nsmax,nsavg
       read(uboddump)  tnow,tpos
       read(uboddump)  tiny
       read(uboddump)  mtot,etot,ektot,eptot,mstar,mgas,snheat,esofttot, &
@@ -521,8 +518,7 @@ read(uboddump) n
       read(uboddump)  massres
       read(uboddump)  deldr2i
       read(uboddump)  wsmooth,dwsmooth
-      read(uboddump)  idummy,nnmin,nnmax,nnavg
-      nntot=idummy 
+      read(uboddump)  nntot,nnmin,nnmax,nnavg
       read(uboddump)  hboxsize
       read(uboddump)  poshalo,masshalo
       read(uboddump)  eradiate,trad,meanmwt,     &

--- a/src/amuse/community/fi/src/util.f90
+++ b/src/amuse/community/fi/src/util.f90
@@ -238,6 +238,10 @@ function rtime()
   rtime=(ttot+float(c)/float(cr))/3600.0
 end function
 
+subroutine wall_time(x)
+  real :: x
+  x=rtime()*3600.
+end subroutine
 
 subroutine aggtimers(k)
  integer k,i

--- a/src/amuse/community/fi/src/util.f90
+++ b/src/amuse/community/fi/src/util.f90
@@ -239,7 +239,7 @@ function rtime()
 end function
 
 subroutine wall_time(x)
-  real :: x
+  real :: x,rtime
   x=rtime()*3600.
 end subroutine
 


### PR DESCRIPTION
this pull fixes some issues with the reporting of wallclock times and counters with fi (mainly handy to diagnose large runs). Only visible with redirection="none" or "file" and with:
parameter verbosity=99