### PR TITLE
Value in reference fix

### DIFF
--- a/src/amuse/units/core.py
+++ b/src/amuse/units/core.py
@@ -297,7 +297,7 @@ class unit(object):
         elif self._compare_bases(x):
             this_factor = self.factor * 1.0
             other_factor = x.factor
-            return this_factor / other_factor
+            return 1*(this_factor == other_factor) or this_factor / other_factor
         else:
             raise IncompatibleUnitsException(x, self)
       

--- a/src/amuse/units/quantities.py
+++ b/src/amuse/units/quantities.py
@@ -213,10 +213,7 @@ class Quantity(object):
 
         """
         value_of_unit_in_another_unit = self.unit.value_in(unit)
-        if value_of_unit_in_another_unit == 1.0:
-            return self.number * 1
-        else:
-            return self.number * value_of_unit_in_another_unit
+        return self.number * value_of_unit_in_another_unit
 
     def __abs__(self):
         """

--- a/src/amuse/units/quantities.py
+++ b/src/amuse/units/quantities.py
@@ -214,7 +214,7 @@ class Quantity(object):
         """
         value_of_unit_in_another_unit = self.unit.value_in(unit)
         if value_of_unit_in_another_unit == 1.0:
-            return self.number
+            return self.number * 1
         else:
             return self.number * value_of_unit_in_another_unit
 

--- a/test/core_tests/test_grids.py
+++ b/test/core_tests/test_grids.py
@@ -586,7 +586,7 @@ class TestGridFactories(amusetest.TestCase):
     def test1(self):
         grid1 = datamodel.new_cartesian_grid( (4,5), 1.0 | units.m)
         grid2 = datamodel.new_regular_grid( (4,5), [4.0,5.0] | units.m)
-        grid3 = datamodel.new_rectilinear_grid( (4,5), [numpy.arange(5) | units.m,numpy.arange(6) | units.m])
+        grid3 = datamodel.new_rectilinear_grid( (4,5), [numpy.arange(5.) | units.m,numpy.arange(6.) | units.m])
         
         self.assertEqual(grid1.position,grid2.position)
         self.assertEqual(grid2.position,grid3.position)

--- a/test/core_tests/test_quantities.py
+++ b/test/core_tests/test_quantities.py
@@ -398,6 +398,17 @@ class TestQuantities(amusetest.TestCase):
         b=new_quantity_nonone(a,2*units.none)
         self.assertEqual(len(a),len(b))
 
+    def test34(self):
+        a= [1,2,3,4,5] | units.m
+        x= a.value_in(units.cm)
+        x[0]=-1
+        self.assertEqual(a, [1,2,3,4,5] | units.m)
+
+        a= [1,2,3,4,5] | units.m
+        x= a.value_in(units.m)
+        x[0]=-1
+        self.assertEqual(a, [1,2,3,4,5] | units.m)
+
 
 class TestAdaptingVectorQuantities(amusetest.TestCase):
 

--- a/test/core_tests/test_unit_conversion.py
+++ b/test/core_tests/test_unit_conversion.py
@@ -89,7 +89,7 @@ class TestUnitConversions(amusetest.TestCase):
             expected_message = "Cannot express m / s in s / m, the units do not have the same bases")
     
     def test12(self):
-        self.assertEquals((1234 | g).as_string_in(g), '1234.0 g')
+        self.assertEquals((1234 | g).as_string_in(g), '1234 g')
         self.assertEquals((1234 | g).as_string_in(kg), '1.234 kg')
         self.assertEquals((1.234 | kg).as_string_in(g), '1234.0 g')
         self.assertEquals((1.0 | km * s**-1).as_string_in(m / s), '1000.0 m / s')


### PR DESCRIPTION
this  fixes inconsistent behaviour, namely:
```b= a.value_in(units.m)```
returns a reference if a.unit=units.m or a copy if not
This has to be conistent, otherwise one needs to remember and track the definitions of quantities...

getting a reference to the data is always possible with a.number

there is a second fix to simplify value_in