### PR TITLE
Two small bug fixes

### DIFF
--- a/src/amuse/community/bonsai/src/src/octree.cpp
+++ b/src/amuse/community/bonsai/src/src/octree.cpp
@@ -4,9 +4,15 @@
 /*********************************/
 /*********************************/
 
-void octree::set_src_directory(string src_dir) {                                                                                                                                 
-    this->src_directory = (char*)src_dir.c_str();                                                                                                                                
-}   
+void octree::set_src_directory(string src_dir) {
+  fprintf(stderr, "In the function to set src_directory to %s", src_dir.c_str());
+  if (this->src_directory != NULL)
+  {
+    delete[] this->src_directory;
+  }
+  this->src_directory = new char[src_dir.length()+1];
+  strcpy(this->src_directory, src_dir.c_str());
+}
 
 double octree::get_time() {
   struct timeval Tvalue;

--- a/src/amuse/community/hacs64/src/Makefile
+++ b/src/amuse/community/hacs64/src/Makefile
@@ -17,6 +17,7 @@ NVCCFLAGS += -Xcompiler="-Wall"
 #NVCCFLAGS += -Xopencc="-O0"
 #NVCCFLAGS += -G
 #NVCCFLAGS := -O0 -g -D_DEBUG -deviceemu -maxrregcount=32 $(CUDAINCLUDE)
+NVCCFLAGS += -D_FORCE_INLINES
 CUDA_LIBS = -lcudart  -L $(CUDAPATH)/lib -L $(CUDAPATH)/lib64
 
 OPENMP_CFLAGS ?= -fopenmp

--- a/src/amuse/couple/multiples.py
+++ b/src/amuse/couple/multiples.py
@@ -1781,7 +1781,7 @@ def find_nn3(plist, field, G):
         phimin = 0.0 | nbody_system.energy
         dxmin = 1.e30
         pmin = None
-        j = numpy.argmin(phi)
+        j = numpy.argmin(phi.number)
         phimin = phi[j]
         dxmin = dx[j]
         pmin = p


### PR DESCRIPTION
hacs64 wouldn't compile on Ubuntu 16.04 without -D_FORCE_INLINES

There was a memory handling bug in the bonsai interface.