### PR TITLE
adding orbital_elements_for_rel_posvel_arrays and tests

### DIFF
--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -217,11 +217,11 @@ def orbital_elements_for_rel_posvel_arrays(rel_position, rel_velocity, total_mas
     
     neg_ecc_arg = (rel_position.cross(rel_velocity)**2).sum(axis=-1)/(G * total_masses * semimajor_axis)   
     filter_ecc0 = (1. <= neg_ecc_arg)
-    eccentricity = numpy.zeros_like(separation)
     if one_particle:
         if filter_ecc0: eccentricity = 0.
         else: eccentricity = numpy.sqrt( 1.0 - neg_ecc_arg)
     else:
+        eccentricity = numpy.zeros(separation.shape)
         eccentricity[~filter_ecc0] = numpy.sqrt( 1.0 - neg_ecc_arg)
         eccentricity[filter_ecc0] = 0.
     
@@ -235,8 +235,7 @@ def orbital_elements_for_rel_posvel_arrays(rel_position, rel_velocity, total_mas
     else: inc = numpy.arccos(mom[:,2]/mom.lengths())
     
     # Longitude of ascending nodes, with reference direction along x-axis
-    long_asc_node = numpy.zeros_like(separation, dtype=numpy.float)
-    asc_node_matrix_unit = numpy.zeros_like(rel_position, dtype=numpy.float)
+    asc_node_matrix_unit = numpy.zeros(rel_position.shape)
     z_vectors = numpy.zeros([n_vec,3])
     z_vectors[:,2] = 1.
     z_vectors = z_vectors | units.none
@@ -256,8 +255,6 @@ def orbital_elements_for_rel_posvel_arrays(rel_position, rel_velocity, total_mas
         long_asc_node = numpy.arctan2(asc_node_matrix_unit[:,1],asc_node_matrix_unit[:,0])
     
     # Argument of periapsis using eccentricity a.k.a. Laplace-Runge-Lenz vector
-    arg_per_mat = numpy.zeros_like(long_asc_node, dtype=numpy.float)
-    cos_arg_per = numpy.zeros_like(long_asc_node, dtype=numpy.float)
     mu = G*total_masses
     pos_unit_vecs = normalize_vector(rel_position,
                                      separation,
@@ -278,10 +275,11 @@ def orbital_elements_for_rel_posvel_arrays(rel_position, rel_velocity, total_mas
             arg_per_mat = 0.
             cos_arg_per = 1.
     else:
+        arg_per_mat = numpy.zeros(long_asc_node.shape)
+        cos_arg_per = numpy.zeros(long_asc_node.shape)
         arg_per_mat[~filter_non0_ecc] = 0.
         cos_arg_per[~filter_non0_ecc] = 1.
     
-    e_vecs_unit = numpy.zeros_like(rel_position, dtype=numpy.float)
     if one_particle:
         if filter_non0_ecc:
             e_vecs_unit = e_vecs/e_vecs.lengths()
@@ -300,11 +298,12 @@ def orbital_elements_for_rel_posvel_arrays(rel_position, rel_velocity, total_mas
                 if filter_negative_zmom: 
                     arg_per_mat = 2.*numpy.pi - arg_per_mat
     else:
+        e_vecs_unit = numpy.zeros(rel_position.shape)
         e_vecs_unit[filter_non0_ecc] = normalize_vector(e_vecs[filter_non0_ecc],
                                                         e_vecs[filter_non0_ecc].lengths(),
                                                         one_dim=one_particle)
         cos_arg_per = numpy.einsum('ij,ji->i', e_vecs_unit[filter_non0_ecc], asc_node_matrix_unit[filter_non0_ecc].T)
-        e_cross_an = numpy.zeros_like(e_vecs_unit, dtype=numpy.float)
+        e_cross_an = numpy.zeros(e_vecs_unit.shape)
         e_cross_an[filter_non0_ecc] = (e_vecs_unit[filter_non0_ecc]|units.none).cross(asc_node_matrix_unit[filter_non0_ecc]|units.none)
         filter_non0_e_cross_an = ((e_cross_an|units.none).lengths() != 0.)
         ss = -numpy.sign(numpy.einsum('ij,ji->i',mom_unit_vecs[filter_non0_e_cross_an], e_cross_an[filter_non0_e_cross_an].T))
@@ -325,12 +324,12 @@ def normalize_vector(vecs, norm, one_dim = False):
     normalize array of vector quantities
     """
     if one_dim:
-        vecs_norm = numpy.zeros_like(vecs, dtype=numpy.float)
+        vecs_norm = numpy.zeros(vecs.shape)
         vecs_norm[0] = vecs[0]/norm
         vecs_norm[1] = vecs[1]/norm
         vecs_norm[2] = vecs[2]/norm
     else:
-        vecs_norm = numpy.zeros_like(vecs, dtype=numpy.float)
+        vecs_norm = numpy.zeros(vecs.shape)
         vecs_norm[:,0] = vecs[:,0]/norm
         vecs_norm[:,1] = vecs[:,1]/norm
         vecs_norm[:,2] = vecs[:,2]/norm

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -302,11 +302,13 @@ def orbital_elements_for_rel_posvel_arrays(rel_position, rel_velocity, total_mas
         e_vecs_unit[filter_non0_ecc] = normalize_vector(e_vecs[filter_non0_ecc],
                                                         numpy.linalg.norm(e_vecs[filter_non0_ecc], axis=1),
                                                         one_dim=one_particle)
-        cos_arg_per = numpy.einsum('ij,ji->i', e_vecs_unit[filter_non0_ecc], asc_node_matrix_unit[filter_non0_ecc].T)
+        #~ cos_arg_per = numpy.einsum('ij,ji->i', e_vecs_unit[filter_non0_ecc], asc_node_matrix_unit[filter_non0_ecc].T)
+        cos_arg_per = (e_vecs_unit[filter_non0_ecc]*asc_node_matrix_unit[filter_non0_ecc]).sum(axis=-1)
         e_cross_an = numpy.zeros(e_vecs_unit.shape)
         e_cross_an[filter_non0_ecc] = numpy.cross(e_vecs_unit[filter_non0_ecc],asc_node_matrix_unit[filter_non0_ecc])
         filter_non0_e_cross_an = (numpy.linalg.norm(e_cross_an, axis=1)!= 0.)
-        ss = -numpy.sign(numpy.einsum('ij,ji->i',mom_unit_vecs[filter_non0_e_cross_an], e_cross_an[filter_non0_e_cross_an].T))
+        #~ ss = -numpy.sign(numpy.einsum('ij,ji->i',mom_unit_vecs[filter_non0_e_cross_an], e_cross_an[filter_non0_e_cross_an].T))
+        ss = -numpy.sign((mom_unit_vecs[filter_non0_e_cross_an]*e_cross_an[filter_non0_e_cross_an]).sum(axis=-1))
         sin_arg_per = ss*(numpy.linalg.norm(e_cross_an[filter_non0_e_cross_an], axis=1))
         arg_per_mat[filter_non0_e_cross_an] = numpy.arctan2(sin_arg_per,cos_arg_per)
         

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -178,3 +178,172 @@ def orbital_elements_from_binary( binary, G=nbody_system.G):
 
         
     return mass1, mass2, semimajor_axis, eccentricity, true_anomaly, inclination, long_asc_node, arg_per
+
+def orbital_elements_for_rel_posvel_arrays(rel_position, rel_velocity, total_masses, G=nbody_system.G):
+    """
+    Orbital elements from array of relative positions and velocities vectors,
+    based on orbital_elements_from_binary and adapted to work for arrays (each line
+    characterises a two body problem).
+    
+    For circular orbits (eccentricity=0): returns argument of pericenter = 0.
+    
+    For equatorial orbits (inclination=0): longitude of ascending node = 0,
+        argument of pericenter = arctan2(e_y,e_x).
+    
+    :argument rel_position: array of vectors of relative positions of the two-body systems
+    :argument rel_velocity: array of vectors of relative velocities of the two-body systems
+    :argument total_masses: array of total masses for two-body systems
+    :argument G: gravitational constant
+    
+    :output semimajor_axis: array of semi-major axes
+    :output eccentricity: array of eccentricities
+    :output period: array of orbital periods
+    :output inc: array of inclinations [radians]
+    :output long_asc_node: array of longitude of ascending nodes [radians]
+    :output arg_per_mat: array of argument of pericenters [radians]
+    """
+    separation = rel_position.lengths()
+    if numpy.shape(separation) is (): 
+        one_particle = True
+        n_vec = 1
+    else: 
+        one_particle = False
+        n_vec = len(rel_position)
+    
+    speed_squared = rel_velocity.lengths_squared()
+    
+    semimajor_axis = (G * total_masses * separation / \
+        (2. * G * total_masses - separation * speed_squared)).as_quantity_in(units.AU)
+    
+    neg_ecc_arg = (rel_position.cross(rel_velocity)**2).sum(axis=-1)/(G * total_masses * semimajor_axis)   
+    filter_ecc0 = (1. <= neg_ecc_arg)
+    eccentricity = numpy.zeros_like(separation.value_in(units.m))
+    if one_particle:
+        if filter_ecc0: eccentricity = 0.
+        else: eccentricity = numpy.sqrt( 1.0 - neg_ecc_arg)
+    else:
+        eccentricity[~filter_ecc0] = numpy.sqrt( 1.0 - neg_ecc_arg)
+        eccentricity[filter_ecc0] = 0.
+    
+    period = (2 * numpy.pi * (semimajor_axis**1.5) / ((G * total_masses).sqrt())).as_quantity_in(units.yr)
+    
+    # angular momentum
+    mom = rel_position.cross(rel_velocity)        
+    
+    # inclination
+    if one_particle: inc = numpy.arccos(mom[2]/mom.lengths()) 
+    else: inc = numpy.arccos(mom[:,2]/mom.lengths())
+    
+    # Longitude of ascending nodes, with reference direction along x-axis
+    long_asc_node = numpy.zeros_like(numpy.array(separation.value_in(units.m)))
+    asc_node_matrix_unit = numpy.zeros_like(numpy.array(rel_position.value_in(units.m)))
+    z_vectors = numpy.zeros([n_vec,3])
+    z_vectors[:,2] = 1.
+    z_vectors = z_vectors | units.none
+    ascending_node_vectors = z_vectors.cross(mom)
+    filter_non0_incl = (ascending_node_vectors.lengths().number>0.)
+    if one_particle:
+        if ~filter_non0_incl: 
+            asc_node_matrix_unit = numpy.array([1.,0.,0.])
+        else:
+            an_vectors_len = ascending_node_vectors.lengths()
+            asc_node_matrix_unit = normalize_vector(ascending_node_vectors,
+                                                    an_vectors_len,
+                                                    units.AU**2/units.yr)[0,:]
+        long_asc_node = numpy.arctan2(asc_node_matrix_unit[1],asc_node_matrix_unit[0])
+    else:
+        asc_node_matrix_unit[~filter_non0_incl] = numpy.array([1.,0.,0.])
+        an_vectors_len = ascending_node_vectors[filter_non0_incl].lengths()
+        asc_node_matrix_unit[filter_non0_incl] = normalize_vector(ascending_node_vectors[filter_non0_incl],
+                                                              an_vectors_len,
+                                                              units.AU**2/units.yr)
+        long_asc_node = numpy.arctan2(asc_node_matrix_unit[:,1],asc_node_matrix_unit[:,0])
+    
+    # Argument of periapsis using eccentricity a.k.a. Laplace-Runge-Lenz vector
+    arg_per_mat = numpy.zeros_like(long_asc_node)
+    cos_arg_per = numpy.zeros_like(long_asc_node)
+    mu = G*total_masses
+    pos_unit_vecs = normalize_vector(rel_position,
+                                     separation,
+                                     units.AU,
+                                     one_dim=one_particle)
+    mom_len = mom.lengths()
+    mom_unit_vecs = normalize_vector(mom,
+                                     mom_len,
+                                     units.AU**2/units.yr,
+                                     one_dim=one_particle)
+    e_vecs = (normalize_vector(rel_velocity.cross(mom),
+                               mu,
+                               units.AU**3/units.yr**2,
+                               one_dim=one_particle) - pos_unit_vecs) | units.none
+    
+    # Argument of pericenter cannot be determined for e = 0,
+    # in this case return 0.0 and 1.0 for the cosines
+    filter_non0_ecc = (e_vecs.lengths() > 1.e-15)
+    if one_particle:
+        if ~filter_non0_ecc: 
+            arg_per_mat = 0.
+            cos_arg_per = 1.
+    else:
+        arg_per_mat[~filter_non0_ecc] = 0.
+        cos_arg_per[~filter_non0_ecc] = 1.
+    
+    e_vecs_unit = numpy.zeros_like(numpy.array(rel_position.value_in(units.m)))
+    if one_particle:
+        if filter_non0_ecc:
+            e_vecs_unit = e_vecs/e_vecs.lengths()
+            cos_arg_per = e_vecs_unit.dot(asc_node_matrix_unit.T)
+            e_cross_an = (e_vecs_unit|units.none).cross(asc_node_matrix_unit|units.none)
+            filter_non0_e_cross_an = ((e_cross_an|units.none).lengths() != 0.)
+            if filter_non0_e_cross_an:
+                ss = -numpy.sign(numpy.dot(mom_unit_vecs, e_cross_an.T))
+                sin_arg_per = ss*(e_cross_an|units.none).lengths()
+                arg_per_mat = numpy.arctan2(sin_arg_per,cos_arg_per)
+            else:
+                # in case longitude of ascenfing node is 0, omega=arctan2(e_y,e_x)
+                arg_per_mat = numpy.arctan2(e_vecs[1].value_in(units.none), \
+                                            e_vecs[0].value_in(units.none))
+                filter_negative_zmom = (~filter_non0_e_cross_an & (mom[2]<0.|(units.m*units.kms)))
+                if filter_negative_zmom: 
+                    arg_per_mat = 2.*numpy.pi - arg_per_mat
+    else:
+        e_vecs_unit[filter_non0_ecc] = normalize_vector(e_vecs[filter_non0_ecc],
+                                                        e_vecs[filter_non0_ecc].lengths(),
+                                                        units.none,
+                                                        one_dim=one_particle)
+        cos_arg_per = numpy.einsum('ij,ji->i', e_vecs_unit[filter_non0_ecc], asc_node_matrix_unit[filter_non0_ecc].T)
+        e_cross_an = numpy.zeros_like(e_vecs_unit)
+        e_cross_an[filter_non0_ecc] = (e_vecs_unit[filter_non0_ecc]|units.none).cross(asc_node_matrix_unit[filter_non0_ecc]|units.none)
+        filter_non0_e_cross_an = ((e_cross_an|units.none).lengths() != 0.)
+        ss = -numpy.sign(numpy.einsum('ij,ji->i',mom_unit_vecs[filter_non0_e_cross_an], e_cross_an[filter_non0_e_cross_an].T))
+        sin_arg_per = ss*(e_cross_an[filter_non0_e_cross_an]|units.none).lengths()
+        arg_per_mat[filter_non0_e_cross_an] = numpy.arctan2(sin_arg_per,cos_arg_per)
+        
+        # in case longitude of ascenfing node is 0, omega=arctan2(e_y,e_x)
+        arg_per_mat[~filter_non0_e_cross_an & filter_non0_ecc] = \
+            numpy.arctan2(e_vecs[~filter_non0_e_cross_an & filter_non0_ecc,1].value_in(units.none), \
+                          e_vecs[~filter_non0_e_cross_an & filter_non0_ecc,0].value_in(units.none))
+        filter_negative_zmom = (~filter_non0_e_cross_an & filter_non0_ecc & (mom[:,2]<0.|(units.m*units.kms)))
+        arg_per_mat[filter_negative_zmom] = 2.*numpy.pi - arg_per_mat[filter_negative_zmom]
+    
+    return semimajor_axis, eccentricity, period, inc, long_asc_node, arg_per_mat
+    
+def normalize_vector(vecs, norm, vecs_unit, one_dim = False):
+    """
+    normalize array of vector quantities
+    """
+    if one_dim:
+        vecs_norm = numpy.zeros_like(numpy.array(vecs.value_in(vecs_unit)))
+        vecs_norm[0] = vecs[0]/norm
+        vecs_norm[1] = vecs[1]/norm
+        vecs_norm[2] = vecs[2]/norm
+    else:
+        vecs_norm = numpy.zeros_like(numpy.array(vecs.value_in(vecs_unit)))
+        vecs_norm[:,0] = vecs[:,0]/norm
+        vecs_norm[:,1] = vecs[:,1]/norm
+        vecs_norm[:,2] = vecs[:,2]/norm
+    return vecs_norm
+    
+    
+    
+

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -169,3 +169,122 @@ class KeplerTests(amusetest.TestCase):
           arg_=orbital_elements_from_binary(new_binary_from_orbital_elements(*arg,G=constants.G),G=constants.G)
           for i,(copy,org) in enumerate(zip(arg_,arg)):
             self.assertAlmostEquals(copy,org)
+    
+    def test6(self):
+        """
+        testing orbital_elements_for_rel_posvel_arrays forN particles with 
+        random orbital elements
+        """
+        numpy.random.seed(666)
+        N = 100
+        
+        mass_sun = 1. | units.MSun
+        mass1 = numpy.ones(N) * mass_sun
+        mass2 = numpy.zeros(N) | units.MSun
+        semi_major_axis=(-numpy.log(random.random(N))) | units.AU 
+        eccentricity = random.random(N)
+        true_anomaly = 360.*random.random(N)-180.
+        inclination = 180*random.random(N)
+        longitude_of_the_ascending_node = 360*random.random(N)-180
+        argument_of_periapsis = 360*random.random(N)-180       
+        
+        comets = datamodel.Particles(N)
+        for i,arg in enumerate(zip(mass1,mass2,semi_major_axis,eccentricity,true_anomaly,inclination, 
+                                   longitude_of_the_ascending_node,argument_of_periapsis)):
+            sun_and_comet = new_binary_from_orbital_elements(*arg,G=constants.G)
+            comets[i].mass = sun_and_comet[1].mass
+            comets[i].position = sun_and_comet[1].position
+            comets[i].velocity = sun_and_comet[1].velocity
+        
+        semi_major_axis_ext, eccentricity_ext, period_ext, inclination_ext, \
+        longitude_of_the_ascending_node_ext, argument_of_periapsis_ext = \
+        orbital_elements_for_rel_posvel_arrays(comets.position,
+                                               comets.velocity,
+                                               comets.mass + mass_sun,
+                                               G=constants.G)        
+        rad_to_deg = 180./numpy.pi
+        for i in range(N):
+            self.assertAlmostEqual(semi_major_axis[i].value_in(units.AU),semi_major_axis_ext[i].value_in(units.AU))
+            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
+            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
+            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
+            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
+
+    def test7(self):
+        """
+        testing orbital_elements_for_rel_posvel_arrays for the case of one particle
+        """
+        numpy.random.seed(999)
+        
+        mass1 = 0.5 | units.MSun
+        mass2 = 0.8 | units.MSun
+        sem = 12. | units.AU
+        ecc = 0.05
+        inc = 20.
+        lon = 10.
+        arg = 0.4
+        
+        binary = new_binary_from_orbital_elements(mass1, 
+                                                  mass2,
+                                                  sem,
+                                                  ecc,
+                                                  360.*random.random()-180.,
+                                                  inc,
+                                                  lon,
+                                                  arg,
+                                                  G=constants.G)
+
+        rel_pos = binary[1].position - binary[0].position
+        rel_vel = binary[1].velocity - binary[0].velocity
+        mass_12 = binary[1].mass + binary[0].mass
+        sem_ext, ecc_ext, per_ext, inc_ext, lon_ext, arg_ext = \
+        orbital_elements_for_rel_posvel_arrays(rel_pos, rel_vel, mass_12, G=constants.G)
+        
+        rad_to_deg = 180./numpy.pi
+        self.assertAlmostEqual(sem.value_in(units.AU), sem_ext.value_in(units.AU))
+        self.assertAlmostEqual(ecc, ecc_ext)
+        self.assertAlmostEqual(inc, rad_to_deg*inc_ext)
+        self.assertAlmostEqual(lon, rad_to_deg*lon_ext)
+        self.assertAlmostEqual(arg, rad_to_deg*arg_ext)
+    
+    def test8(self):
+        """
+        testing orbital_elements_for_rel_posvel_arrays for extreme cases
+        """
+        N = 3
+        mass1 = (1.2*numpy.ones(N)) | units.MSun
+        mass2 = (0.1, 0.05, 0.003) | units.MSun
+        semi_major_axis = (1., 2., 3.) | units.AU
+        eccentricity = (0., 0.5, 0.6)
+        true_anomaly = 360.*random.random(N)-180.
+        inclination = (12., 0., 180.)
+        longitude_of_the_ascending_node = (0., 0., 0.,)
+        argument_of_periapsis = (0., 23., 90.)
+        mass12 = []
+        rel_position = []
+        rel_velocity = []
+        for i,arg in enumerate(zip(mass1,mass2,semi_major_axis,eccentricity,true_anomaly,inclination, 
+                                   longitude_of_the_ascending_node,argument_of_periapsis)):
+            sun_and_comet = new_binary_from_orbital_elements(*arg,G=constants.G)
+            mass12.append(sun_and_comet[0].mass + sun_and_comet[1].mass)
+            rel_position.append(sun_and_comet[1].position - sun_and_comet[0].position)
+            rel_velocity.append(sun_and_comet[1].velocity - sun_and_comet[0].velocity)
+            
+        # to convert lists to vector quantities
+        rel_pos = numpy.array([vec_i.value_in(units.AU) for vec_i in rel_position]) | units.AU
+        rel_vel = numpy.array([vec_i.value_in(units.kms) for vec_i in rel_velocity]) | units.kms
+        mass_12 = numpy.array([m_i.value_in(units.MSun) for m_i in mass12]) | units.MSun
+        
+        semi_major_axis_ext, eccentricity_ext, period_ext, inclination_ext, \
+        longitude_of_the_ascending_node_ext, argument_of_periapsis_ext = \
+        orbital_elements_for_rel_posvel_arrays(rel_pos,
+                                               rel_vel,
+                                               mass_12,
+                                               G=constants.G)        
+        rad_to_deg = 180./numpy.pi
+        for i in range(N):
+            self.assertAlmostEqual(semi_major_axis[i].value_in(units.AU),semi_major_axis_ext[i].value_in(units.AU))
+            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
+            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
+            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
+            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -5,7 +5,7 @@ import numpy
 from amuse.test import amusetest
 
 
-from amuse.ext.orbital_elements import new_binary_from_orbital_elements,orbital_elements_from_binary
+from amuse.ext.orbital_elements import new_binary_from_orbital_elements,orbital_elements_from_binary, orbital_elements_for_rel_posvel_arrays
 
 from amuse.units import units
 from amuse.units import constants
@@ -172,8 +172,8 @@ class KeplerTests(amusetest.TestCase):
     
     def test6(self):
         """
-        testing orbital_elements_for_rel_posvel_arrays forN particles with 
-        random orbital elements
+        testing orbital_elements_for_rel_posvel_arrays for N particles 
+        with random orbital elements
         """
         numpy.random.seed(666)
         N = 100


### PR DESCRIPTION
Adding routine (and tests) to calculate orbital elements for number of two-body problems. This can be useful for number of orbiters of the same central body. Arguments are arrays of relative position and velocity vectors, and vector of total masses of the individual two-body problems. The routine should be reasonably fast even for a large numbers of systems (10^6). 