### PR TITLE
Update lab.py to also import Rebound interface

### DIFF
--- a/src/amuse/lab.py
+++ b/src/amuse/lab.py
@@ -52,6 +52,7 @@ from amuse.community.mercury.interface import Mercury, MercuryInterface
 from amuse.community.mi6.interface import MI6, MI6Interface
 from amuse.community.mikkola.interface import Mikkola, MikkolaInterface
 from amuse.community.smalln.interface import SmallN, SmallNInterface
+from amuse.community.rebound.interface import Rebound, ReboundInterface
 
 
 from amuse.community.fi.interface import Fi, FiInterface


### PR DESCRIPTION
I think Rebound is by now tested well enough to be included as a default interface.