### PR TITLE
Patch rebound delete

### DIFF
--- a/src/amuse/community/rebound/interface.cc
+++ b/src/amuse/community/rebound/interface.cc
@@ -467,17 +467,13 @@ int get_index_of_next_particle(int index_of_the_particle,
     return 0;
 }
 
-int delete_particle(int index_of_the_particle){
-    particle_location loc = get_index_from_identity(index_of_the_particle);
-    if(loc.index < 0) {return -1;}
-    
-    indexMap.erase(index_of_the_particle);
-    for( ReboundSimulationVector::iterator i = codes.begin(); i != codes.end(); i++) {
-        code_state cs = *i;
-        if(cs.code == loc.code){
-            cs.has_removal = true;
-        }
-        *i = cs;
+int _delete_particle(int index_of_the_particle, int code_index){
+
+    if(code_index < 0 || code_index >= (signed) codes.size()){
+        return -10;
+    }
+    int keepSorted = 1;
+    reb_remove_by_hash(codes[code_index].code, index_of_the_particle, keepSorted);
     }
     return 0;
 }

--- a/src/amuse/community/rebound/interface.cc
+++ b/src/amuse/community/rebound/interface.cc
@@ -468,7 +468,6 @@ int get_index_of_next_particle(int index_of_the_particle,
 }
 
 int _delete_particle(int index_of_the_particle, int code_index){
-
     if(code_index < 0 || code_index >= (signed) codes.size()){
         return -10;
     }
@@ -581,7 +580,13 @@ int get_kinetic_energy(int code_index, double * kinetic_energy){
 }
 
 int get_number_of_particles(int * number_of_particles){
-    *number_of_particles = indexMap.size();
+    int N = 0;
+    for( ReboundSimulationVector::iterator i = codes.begin(); i != codes.end(); i++) {
+        code_state cs = *i;
+        N += cs.code->N;
+    }
+
+    *number_of_particles = N;
     return 0;
 }
 

--- a/src/amuse/community/rebound/interface.cc
+++ b/src/amuse/community/rebound/interface.cc
@@ -474,7 +474,6 @@ int _delete_particle(int index_of_the_particle, int code_index){
     }
     int keepSorted = 1;
     reb_remove_by_hash(codes[code_index].code, index_of_the_particle, keepSorted);
-    }
     return 0;
 }
 

--- a/src/amuse/community/rebound/interface.py
+++ b/src/amuse/community/rebound/interface.py
@@ -57,7 +57,24 @@ class ReboundInterface(CodeInterface,
             particle could not be created"""
         return function
         
-        
+    def delete_particle(self, index_of_the_particle, code_index=0):
+        return self._delete_particle(index_of_the_particle, code_index)
+
+    @legacy_function
+    def _delete_particle():
+        """
+        Delete a particle.
+        """
+        function = LegacyFunctionSpecification()
+        function.can_handle_array = True
+        function.addParameter('index_of_the_particle', dtype='int32', direction=function.IN, description ="Index of the particle")
+        function.addParameter('code_index', dtype='int32', direction=function.IN, description = "Index of the code in rebound", default = 0)
+        function.result_type = 'int32'
+        function.result_doc = """ 0 - OK
+            particle was deleted
+        -1 - ERROR
+            particle not deleted"""
+        return function
 
     @legacy_function
     def _set_integrator():


### PR DESCRIPTION
Fixes for bug #105. Only still fails on the final part of test3, can't figure that out yet (help would be appreciated). But deleting particles this way seems to work correctly, and much faster than previous method.