### PR TITLE
This fix allows the usage of Bonsai on machines running CUDA8

### DIFF
--- a/src/amuse/community/bonsai/src/include/my_cuda.h
+++ b/src/amuse/community/bonsai/src/include/my_cuda.h
@@ -1262,7 +1262,10 @@ namespace my_dev {
           jitOptVals[jitOptionCount] = (void *)jitRegCount;        
           jitOptionCount++;        
         }
-        
+       
+#if 0
+       CUDA8 fix, do not check for Fermi anymore, it is no longer supported
+
         //Fermi requires at least compute mode 2, so if device is compute mode 2
         //but the given option is not compute mode 2 (eg constant <= 3) we change 
         //it to compute mode 2.0
@@ -1273,8 +1276,8 @@ namespace my_dev {
         if(computeMode < architecture)
           maxArchitecture = computeMode;
   
-  	maxArchitecture = computeMode;	
-            
+        maxArchitecture = computeMode;
+
        //Check for double precision, only use it if device supports it
         //Set the architecture
         {                
@@ -1284,7 +1287,7 @@ namespace my_dev {
           jitOptVals[jitOptionCount] = (void *)arch;        
           jitOptionCount++;  
         }     
-        
+#endif        
         
         // set up size of compilation log buffer                                                                                                    
         jitOptions[jitOptionCount] = CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES;                                                                                          
@@ -1298,18 +1301,12 @@ namespace my_dev {
         char *jitLogBuffer = new char[jitLogBufferSize];                                                                                            
         jitOptVals[jitOptionCount] = jitLogBuffer;                                                                                                               
         jitOptionCount++;
-                                                          
+
         
         string ptxSource;
         load_source(hKernelFilename, ptxSource);
         
-  //       hier gebleven bij jit moeten we source code inladen
-  //       sterker nog dat willen we altijd, dus altijd code inladen! Woo!
-        
-  //         CU_SAFE_CALL(cuModuleLoad(&cuModule, hKernelFilename));
-    
-  //         jitOptionCount = 0;
-          CU_SAFE_CALL(cuModuleLoadDataEx(&cuModule, ptxSource.c_str(), jitOptionCount, jitOptions, (void **)jitOptVals));
+        CU_SAFE_CALL(cuModuleLoadDataEx(&cuModule, ptxSource.c_str(), jitOptionCount, jitOptions, (void **)jitOptVals));
           
           // printf("> PTX JIT log:\n%s\n", jitLogBuffer);        
           


### PR DESCRIPTION
During kernel compilation new devices were not properly identified which caused a default value to be set for the compute mode. This default value has recently been deprecated, causing launch errors.
