### PR TITLE
Update Rebound to version 3.3 (fixes building problem on MacOS)

### DIFF
--- a/src/amuse/community/rebound/Makefile
+++ b/src/amuse/community/rebound/Makefile
@@ -24,7 +24,7 @@ LIB_OBJ = $(CODEDIR)/src/rebound.o $(CODEDIR)/src/tree.o $(CODEDIR)/src/particle
           $(CODEDIR)/src/integrator_hermes.o $(CODEDIR)/src/boundary.o \
           $(CODEDIR)/src/collision.o $(CODEDIR)/src/tools.o \
           $(CODEDIR)/src/communication_mpi.o $(CODEDIR)/src/display.o $(CODEDIR)/src/derivatives.o \
-          $(CODEDIR)/src/glad.o $(CODEDIR)/src/transformations.o \
+          $(CODEDIR)/src/glad.o $(CODEDIR)/src/integrator_janus.o $(CODEDIR)/src/transformations.o \
           $(CODEDIR)/src/simulationarchive.o $(CODEDIR)/src/output.o \
           $(CODEDIR)/src/input.o \
 

--- a/src/amuse/community/rebound/download_http.py
+++ b/src/amuse/community/rebound/download_http.py
@@ -128,7 +128,7 @@ class GetCodeFromHttp(object):
         print "downloading finished"
         self.unpack_downloaded_file(filename)
     
-def main(must_download_from_svn = False, version = '289b66b457210a8b99e9dac4bb13ed6ff47270e7'):
+def main(must_download_from_svn = False, version = ''):
     instance = GetCodeFromHttp()
     instance.version = version
     instance.start()
@@ -140,7 +140,7 @@ def new_option_parser():
     
     result.add_option(
         "--version", 
-        default = '289b66b457210a8b99e9dac4bb13ed6ff47270e7',
+        default = '912ede04438c0b54ea8d4b144e2a414d493e0821',
         dest="version",
         help="git revision to download from github",
         type="string"


### PR DESCRIPTION
Also, only list explicit version in one place in download_http.py to avoid confusion.