### PR TITLE
Add units to angles and vectorise 'orbital_elements.py'

### DIFF
--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy
 
 import warnings
@@ -11,7 +13,7 @@ from amuse.units.quantities import to_quantity, VectorQuantity
 
 def newton(f, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50):
     if fprime is None:
-        print "provide fprime"
+        print("provide fprime")
         return x0
     i = 0
     x = x0
@@ -50,10 +52,10 @@ def equal_length_array_or_scalar(
             if mode == "warn":
                 warnings.warn("Length of array is not equal to %i. Using only\
                         the first value." % length)
+                return array[0:1]
             elif mode == "exception":
                 raise Exception("Length of array is not equal to %i. This is\
                 not supported." % length)
-            return array[0]
     except:
         if mode == "warn":
             warnings.warn("Not an array, continuing with scalar.")
@@ -173,24 +175,24 @@ def generate_binaries_from_orbital_elements(
     beta = numpy.array([betax, betay, betaz])
 
     # Relative position and velocity
-    separation = (
+    separation = (  # Compute the relative separation
             semi_major_axis*(1.0 - eccentricity**2)
             / (1.0 + eccentricity*cos_true_anomaly)
-            )  # Compute the relative separation
+            )
     position_vector = (
             separation*cos_true_anomaly*alpha
             + separation*sin_true_anomaly*beta
-            )
+            ).T
     velocity_tilde = (
             (
                 G*(primary_mass + secondary_mass)
                 / (semi_major_axis*(1.0 - eccentricity**2))
                 )**0.5
-            ).reshape((number_of_primaries, 1))  # Common factor
+            )  # Common factor
     velocity_vector = (
             -1.0 * velocity_tilde * sin_true_anomaly * alpha
             + velocity_tilde*(eccentricity + cos_true_anomaly)*beta
-            )
+            ).T
 
     primaries = Particles(number_of_primaries)
     secondaries = Particles(number_of_secondaries)
@@ -378,20 +380,25 @@ def orbital_elements_from_binaries(primaries, secondaries, G=nbody_system.G):
         true_anomaly = 0.
     else:
         e_vector_unit = e_vector/e_vector.lengths()
+        print(e_vector_unit, ascending_node_vector_unit)
 
-        cos_arg_per = numpy.dot(e_vector_unit, ascending_node_vector_unit)
+        cos_arg_per = numpy.dot(e_vector_unit, ascending_node_vector_unit.T)
         # cos_arg_per = e_vector_unit.dot(ascending_node_vector_unit)
         e_cross_an = numpy.cross(e_vector_unit, ascending_node_vector_unit)
-        print specific_angular_momentum_unit, e_cross_an
-        ss = -numpy.sign(numpy.dot(specific_angular_momentum_unit, e_cross_an))
+        # print(specific_angular_momentum_unit, e_cross_an)
+        ss = -numpy.sign(
+                numpy.dot(specific_angular_momentum_unit, e_cross_an.T)
+                )
         # ss=-numpy.sign(specific_angular_momentum_unit.dot(e_cross_an))
         sin_arg_per = ss*(e_cross_an**2).sum()**0.5
         arg_per = arctan2(sin_arg_per, cos_arg_per)
 
-        cos_true_anomaly = numpy.dot(e_vector_unit, position_unit)
+        cos_true_anomaly = numpy.dot(e_vector_unit, position_unit.T)
         # cos_true_anomaly = e_vector_unit.dot(position_unit)
         e_cross_pos = numpy.cross(e_vector_unit, position_unit)
-        ss = numpy.sign(numpy.dot(specific_angular_momentum_unit, e_cross_pos))
+        ss = numpy.sign(
+                numpy.dot(specific_angular_momentum_unit, e_cross_pos.T)
+                )
         # ss=numpy.sign(specific_angular_momentum_unit.dot(e_cross_pos))
         sin_true_anomaly = ss * (e_cross_pos**2).sum()**0.5
         true_anomaly = arctan2(sin_true_anomaly, cos_true_anomaly)

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -148,14 +148,10 @@ def rel_posvel_arrays_from_orbital_elements(
     Returns relative positions/velocities for secondaries orbiting primaries.
     If primary_mass is a scalar, assumes the same primary for all secondaries.
     """
-    # mass_unit = primary_mass.unit
     try:
         number_of_secondaries = len(secondary_mass)
     except:
         number_of_secondaries = 1
-        # secondary_mass = numpy.array(
-        #         [secondary_mass.value_in(mass_unit)]
-        #         ) | mass_unit
 
     # arrays need to be equal to number of secondaries, or have just one value
     primary_mass = equal_length_array_or_scalar(
@@ -542,8 +538,6 @@ def orbital_elements_from_arrays(
             e_vecs[filter_non0_ecc],
             e_vecs_norm[filter_non0_ecc]
             )
-    # cos_arg_per = numpy.einsum('ij,ji->i', e_vecs_unit[filter_non0_ecc],
-    #         asc_node_matrix_unit[filter_non0_ecc].T)
     cos_arg_per = (
             e_vecs_unit[filter_non0_ecc]
             * asc_node_matrix_unit[filter_non0_ecc]
@@ -555,13 +549,6 @@ def orbital_elements_from_arrays(
             )
     e_cross_an_norm = (e_cross_an**2).sum(axis=1)**0.5
     filter_non0_e_cross_an = (e_cross_an_norm != 0.)
-    # ss = -numpy.sign(
-    #         numpy.einsum(
-    #             'ij,ji->i',
-    #             mom_unit_vecs[filter_non0_e_cross_an],
-    #             e_cross_an[filter_non0_e_cross_an].T
-    #             )
-    #         )
     ss = -numpy.sign(
             (
                 mom_unit_vecs[filter_non0_e_cross_an]

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -3,7 +3,7 @@ orbital element conversion and utility functions
 
 this module provides:
 
-generate_binaries_from_orbital_elements
+generate_binaries
 get_orbital_elements_from_binary
 orbital_elements_from_binaries
 orbital_elements_from_arrays
@@ -27,6 +27,7 @@ from amuse.units.trigo import cos, sin, arccos, arctan2
 from amuse.datamodel import Particles, Particle
 
 from amuse.units.quantities import to_quantity, VectorQuantity
+
 
 def newton(f, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50):
     if fprime is None:
@@ -232,7 +233,7 @@ def rel_posvel_arrays_from_orbital_elements(
     return position_vector, velocity_vector
 
 
-def generate_binaries_from_orbital_elements(
+def generate_binaries(
         primary_mass,
         secondary_mass,
         semi_major_axis,
@@ -314,7 +315,7 @@ def new_binary_from_orbital_elements(
     and velocities computed from the input orbital elements.
     inclination is given between 0 and 180 deg.
     angles are assumed to be in deg if no unit is given.
-    """    
+    """
     def angle_with_unit(angle, default_unit=units.deg):
         try:
             default_unit = angle.unit
@@ -333,7 +334,7 @@ def new_binary_from_orbital_elements(
             longitude_of_the_ascending_node,
             default_unit=units.deg
             )
-    primary, secondary = generate_binaries_from_orbital_elements(
+    primary, secondary = generate_binaries(
             mass1, mass2, semimajor_axis,
             eccentricity=eccentricity,
             true_anomaly=true_anomaly,
@@ -386,15 +387,18 @@ def get_orbital_elements_from_binary(binary, G=nbody_system.G):
             mass1[0], mass2[0], semimajor_axis[0], eccentricity[0],
             true_anomaly[0], inclination[0], long_asc_node[0], arg_per[0])
 
+
 def orbital_elements_from_binary(binary, G=nbody_system.G):
     (
             mass1, mass2, semimajor_axis, eccentricity, true_anomaly,
             inclination, long_asc_node, arg_per
-            ) = get_orbital_elements_from_binary(primaries, secondaries, G=G)
+            ) = get_orbital_elements_from_binary(binary, G=G)
     return (
             mass1[0], mass2[0], semimajor_axis[0], eccentricity[0],
-            true_anomaly[0].value_in(units.deg), inclination[0].value_in(units.deg), 
-            long_asc_node[0].value_in(units.deg), arg_per[0].value_in(units.deg))
+            true_anomaly[0].value_in(units.deg),
+            inclination[0].value_in(units.deg),
+            long_asc_node[0].value_in(units.deg),
+            arg_per[0].value_in(units.deg))
 
 
 def orbital_elements_from_binaries(primaries, secondaries, G=nbody_system.G):
@@ -596,22 +600,24 @@ def orbital_elements_from_arrays(
             inc, long_asc_node, arg_per_mat
             )
 
+
 def orbital_elements_for_rel_posvel_arrays(
         rel_position_raw, rel_velocity_raw,
         total_masses, G=nbody_system.G):
-    ( semimajor_axis, eccentricity, true_anomaly,
-      inc, long_asc_node, arg_per_mat ) = orbital_elements_from_arrays(
-       rel_position_raw, rel_velocity_raw,total_masses, G)
-       
-    true_anomaly=true_anomaly.value_in(units.deg)
-    inc=inc.value_in(units.deg)
-    long_asc_node=long_asc_node.value_in(units.deg)
-    arg_per_mat=arg_per_mat.value_in(units.deg)
-    
+    (semimajor_axis, eccentricity, true_anomaly, inc, long_asc_node,
+        arg_per_mat) = orbital_elements_from_arrays(
+                rel_position_raw, rel_velocity_raw, total_masses, G)
+
+    true_anomaly = true_anomaly.value_in(units.deg)
+    inc = inc.value_in(units.deg)
+    long_asc_node = long_asc_node.value_in(units.deg)
+    arg_per_mat = arg_per_mat.value_in(units.deg)
+
     return (
             semimajor_axis, eccentricity, true_anomaly,
             inc, long_asc_node, arg_per_mat
             )
+
 
 def normalize_vector(vecs, norm, one_dim=False):
     """

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -38,11 +38,11 @@ def equal_length_array_or_scalar(
         array, length=1, mode="continue"
         ):
     """
-    Returns 'array' if its length is equal to 'length'.  If this is not the
-    case, returns 'array' anyway if it is a scalar, or the first value of the
-    array if its length is different from 'length'.  If mode is "warn", issues
-    a warning if this happens; if mode is "exception" raises an exception in
-    this case.
+    Returns 'array' if its length is equal to 'length'. If this is not the
+    case, returns an array of length 'length' with values equal to the first
+    value of the array (or if 'array' is a scalar, that value. If mode is
+    "warn", issues a warning if this happens; if mode is "exception" raises an
+    exception in this case.
     """
     try:
         array_length = len(array)
@@ -52,15 +52,33 @@ def equal_length_array_or_scalar(
             if mode == "warn":
                 warnings.warn("Length of array is not equal to %i. Using only\
                         the first value." % length)
-                return array[0:1]
+                try:
+                    unit = array.unit
+                    value = array[0].value_in(unit)
+                except:
+                    unit = units.none
+                    value = array[0]
+                array = VectorQuantity(
+                        array=numpy.ones(length) * value,
+                        unit=unit,
+                        )
+                return array
             elif mode == "exception":
                 raise Exception("Length of array is not equal to %i. This is\
                 not supported." % length)
     except:
+        try:
+            unit = array.unit
+            value = array.value_in(unit)
+        except:
+            unit = units.none
+            value = array
+        array = VectorQuantity(
+                array=numpy.ones(length) * value,
+                unit=unit,
+                )
         if mode == "warn":
-            warnings.warn("Not an array, continuing with scalar.")
-        elif mode == "exception":
-            raise Exception("Not an array, this is not supported.")
+            warnings.warn("Using single value for all cases.")
         return array
 
 

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -2,55 +2,45 @@ import numpy
 
 import warnings
 
-from amuse.units import units, nbody_system, constants
+from amuse.units import units, nbody_system
 from amuse.units.trigo import cos, sin, arccos, arctan2
-from amuse.datamodel import Particles, rotation
+from amuse.datamodel import Particles, Particle
 
-from amuse.units.quantities import to_quantity
+from amuse.units.quantities import to_quantity, VectorQuantity
 
-def newton(f,x0,fprime=None,args=(),tol=1.48e-8,maxiter=50):
+
+def newton(f, x0, fprime=None, args=(), tol=1.48e-8, maxiter=50):
     if fprime is None:
         print "provide fprime"
         return x0
-    i=0
-    x=x0
-    while (i<maxiter):
-        fv=f(x,*args)
-        dfv=fprime(x,*args)
-        if(dfv==0):
-            return x0,-2
-        delta=-fv/dfv
-        if(abs(delta)<tol):
-            return x+delta,0
-        x=x+delta
-        i=i+1
-    return x,-1    
+    i = 0
+    x = x0
+    while (i < maxiter):
+        fv = f(x, *args)
+        dfv = fprime(x, *args)
+        if(dfv == 0):
+            return x0, -2
+        delta = -fv/dfv
+        if(abs(delta) < tol):
+            return x+delta, 0
+        x = x+delta
+        i = i+1
+    return x, -1
 
 
-def true_anomaly_from_eccentric_anomaly(E,e):
-    return 2*arctan2((1+e)**0.5*sin(E/2),(1-e)**0.5*cos(E/2))
-
-# E from M,e
-# newton solver for M=E-e sin E
-
-
-def angle_with_unit(angle, default_unit=units.deg):
-    try:
-        unit = angle.unit
-    except:
-        angle = angle | default_unit
-    return angle
+def true_anomaly_from_eccentric_anomaly(E, e):
+    return 2*arctan2((1+e)**0.5*sin(E/2), (1-e)**0.5*cos(E/2))
 
 
 def equal_length_array_or_scalar(
         array, length=1, mode="continue"
         ):
     """
-    Returns 'array' if its length is equal to 'length'.
-    If this is not the case, returns 'array' anyway if it is a scalar,
-    or the first value of the array if its length is different from 'length'.
-    If mode is "warn", issues a warning if this happens; if mode is "exception"
-    raises an exception in this case.
+    Returns 'array' if its length is equal to 'length'.  If this is not the
+    case, returns 'array' anyway if it is a scalar, or the first value of the
+    array if its length is different from 'length'.  If mode is "warn", issues
+    a warning if this happens; if mode is "exception" raises an exception in
+    this case.
     """
     try:
         array_length = len(array)
@@ -111,8 +101,21 @@ def generate_binaries_from_orbital_elements(
     returns two particlesets, which contain the primaries and the secondaries
     in binary pairs.
     """
-    number_of_primaries = len(primary_mass)
-    number_of_secondaries = len(secondary_mass)
+    mass_unit = primary_mass.unit
+    try:
+        number_of_primaries = len(primary_mass)
+    except:
+        number_of_primaries = 1
+        primary_mass = numpy.array(
+                [primary_mass.value_in(mass_unit)]
+                ) | mass_unit
+    try:
+        number_of_secondaries = len(secondary_mass)
+    except:
+        number_of_secondaries = 1
+        secondary_mass = numpy.array(
+                [secondary_mass.value_in(mass_unit)]
+                ) | mass_unit
 
     # mass arrays need to be the same length
     if number_of_secondaries != number_of_primaries:
@@ -179,11 +182,13 @@ def generate_binaries_from_orbital_elements(
             + separation*sin_true_anomaly*beta
             )
     velocity_tilde = (
-            G*(primary_mass + secondary_mass)
-            / (semi_major_axis*(1.0 - eccentricity**2))
-            )**0.5  # Common factor
+            (
+                G*(primary_mass + secondary_mass)
+                / (semi_major_axis*(1.0 - eccentricity**2))
+                )**0.5
+            ).reshape((number_of_primaries, 1))  # Common factor
     velocity_vector = (
-            -1.0*velocity_tilde*sin_true_anomaly*alpha
+            -1.0 * velocity_tilde * sin_true_anomaly * alpha
             + velocity_tilde*(eccentricity + cos_true_anomaly)*beta
             )
 
@@ -196,10 +201,11 @@ def generate_binaries_from_orbital_elements(
             position_vector, primary_mass, secondary_mass)
     centers_of_mass_velocity = center_of_mass_array(
             velocity_vector, primary_mass, secondary_mass)
-    primaries.position = -centers_of_mass
-    secondaries.position = centers_of_mass
-    primaries.velocity = -centers_of_mass_velocity
-    secondaries.velocity = centers_of_mass_velocity
+
+    primaries.position = - centers_of_mass
+    secondaries.position = position_vector - centers_of_mass
+    primaries.velocity = - centers_of_mass_velocity
+    secondaries.velocity = velocity_vector - centers_of_mass_velocity
     return primaries, secondaries
 
 
@@ -220,9 +226,15 @@ def new_binary_from_orbital_elements(
     inclination is given between 0 and 180 deg.
     angles are assumed to be in deg if no unit is given.
     """
+    def angle_with_unit(angle, default_unit=units.deg):
+        try:
+            default_unit = angle.unit
+        except:
+            angle = angle | default_unit
+        return angle
 
     # If no unit is given for angles, assume they are in degrees
-    true_anomaly = angle_with_unit(inclination, default_unit=units.deg)
+    true_anomaly = angle_with_unit(true_anomaly, default_unit=units.deg)
     inclination = angle_with_unit(inclination, default_unit=units.deg)
     argument_of_periapsis = angle_with_unit(
             argument_of_periapsis,
@@ -233,7 +245,7 @@ def new_binary_from_orbital_elements(
             default_unit=units.deg
             )
     primary, secondary = generate_binaries_from_orbital_elements(
-            [mass1], [mass2], semimajor_axis,
+            mass1, mass2, semimajor_axis,
             eccentricity=eccentricity,
             true_anomaly=true_anomaly,
             inclination=inclination,
@@ -242,41 +254,71 @@ def new_binary_from_orbital_elements(
             G=G
             )
 
-    result = Particles(2)
+    result = Particles()
     result.add_particle(primary[0])
     result.add_particle(secondary[0])
     return result
 
 
 def orbital_elements_from_binary(binary, G=nbody_system.G):
-    """ 
-    Function that computes orbital elements from given two-particle set. 
-    Elements are computed for the second particle in this set and the 
-    return values are: mass1, mass2, semimajor axis, eccentricity, 
-    cosine of true anomaly, cosine of inclination, cosine of the 
-    longitude of the ascending node and the cosine of the argument of 
-    pericenter. In case of a perfectly circular orbit the true anomaly 
-    and argument of pericenter cannot be determined; in this case the 
-    return values are 1.0 for both cosines. 
     """
-    if len(binary)>2:
+    Function that computes orbital elements from given two-particle set.
+    Elements are computed for the second particle in this set and the
+    return values are: mass1, mass2, semimajor axis, eccentricity,
+    cosine of true anomaly, cosine of inclination, cosine of the
+    longitude of the ascending node and the cosine of the argument of
+    pericenter. In case of a perfectly circular orbit the true anomaly
+    and argument of pericenter cannot be determined; in this case the
+    return values are 1.0 for both cosines.
+    """
+    primaries = Particles()
+    secondaries = Particles()
+    if len(binary) > 2:
         raise Exception("expects binary or single part")
-
-    if len(binary)==2:
-        mass1=binary[0].mass
-        mass2=binary[1].mass
-        position = binary[1].position-binary[0].position
-        velocity = binary[1].velocity-binary[0].velocity
-        total_mass = mass1 + mass2
+    elif len(binary) == 2:
+        primaries.add_particle(binary[0])
+        secondaries.add_particle(binary[1])
     else:
-        mass1=binary.mass
-        mass2=0.*mass1
-        position = binary.position
-        velocity = binary.velocity
-        total_mass = mass1
-      
+        # FIXME: in case of one particle, what do we calculate the orbit of?
+        # The method below is what was default before.
+        primaries.add_particle(binary[0])
+        primaries[0].position *= 0
+        primaries[0].velocity *= 0
+        secondaries.add_particle(Particle())
+        secondaries[0].mass = 0 * primaries[0].mass
+        secondaries[0].position = binary.position
+        secondaries[0].velocity = binary.velocity
+
+    (
+            mass1, mass2, semimajor_axis, eccentricity, true_anomaly,
+            inclination, long_asc_node, arg_per
+            ) = orbital_elements_from_binaries(primaries, secondaries, G=G)
+    return (
+            mass1[0], mass2[0], semimajor_axis[0], eccentricity[0],
+            true_anomaly[0], inclination[0], long_asc_node[0], arg_per[0])
+
+
+def orbital_elements_from_binaries(primaries, secondaries, G=nbody_system.G):
+    """
+    Function that computes orbital elements from given primaries and
+    secondaries.
+    Elements are computed for the second particle in this set and the
+    return values are: mass1, mass2, semimajor axis, eccentricity,
+    cosine of true anomaly, cosine of inclination, cosine of the
+    longitude of the ascending node and the cosine of the argument of
+    pericenter. In case of a perfectly circular orbit the true anomaly
+    and argument of pericenter cannot be determined; in this case the
+    return values are 1.0 for both cosines.
+    """
+
+    position = secondaries.position - primaries.position
+    velocity = secondaries.velocity - primaries.velocity
+    mass1 = primaries.mass
+    mass2 = secondaries.mass
+    total_mass = mass1 + mass2
+
     specific_energy = (
-            (1.0/2.0)*velocity.lengths_squared() 
+            (1.0/2.0)*velocity.lengths_squared()
             - G*total_mass/position.lengths()
             )
     specific_angular_momentum = position.cross(velocity)
@@ -298,84 +340,88 @@ def orbital_elements_from_binary(binary, G=nbody_system.G):
     else:
         eccentricity = numpy.sqrt(1.0 + eccentricity_argument)
 
-    ### Orbital inclination ###
+    # Orbital inclination
     inclination = arccos(
             specific_angular_momentum.z
             / specific_angular_momentum_norm
             )
 
-    ### Longitude of ascending nodes, with reference direction along x-axis ###
-    z_vector = [0.,0.,1.] | units.none
+    # Longitude of ascending nodes, with reference direction along x-axis
+    z_vector = [0., 0., 1.] | units.none
     ascending_node_vector = z_vector.cross(specific_angular_momentum)
-    if ascending_node_vector.lengths().number==0:
-        ascending_node_vector_unit= numpy.array([1.,0.,0.]) 
+    if ascending_node_vector.lengths().number == 0:
+        ascending_node_vector_unit = numpy.array([1., 0., 0.])
     else:
         ascending_node_vector_unit = (
                 ascending_node_vector
                 / ascending_node_vector.lengths()
                 )
     long_asc_node = arctan2(
-            ascending_node_vector_unit[1],
-            ascending_node_vector_unit[0]
+            ascending_node_vector_unit[:, 1],
+            ascending_node_vector_unit[:, 0]
             )
 
-    ### Argument of periapsis and true anomaly, using eccentricity a.k.a. Laplace-Runge-Lenz vector ###
-    mu = G*total_mass  ### Argument of pericenter ###
+    # Argument of periapsis and true anomaly, using eccentricity a.k.a.
+    # Laplace-Runge-Lenz vector
+    mu = G*total_mass  # Argument of pericenter
     position_unit = position/position.lengths()
     e_vector = (
             (1.0/mu)*velocity.cross(specific_angular_momentum)
             - position_unit
             ) | units.none
-    if (e_vector.lengths() == 0.0): ### Argument of pericenter and true anomaly cannot be determined for e = 0, in this case return 1.0 for the cosines ###
+    if (e_vector.lengths() == 0.0):
+        # Argument of pericenter and true anomaly cannot be determined for e =
+        # 0, in this case return 1.0 for the cosines
         cos_arg_per = 1.0
-        arg_per=0.
+        arg_per = 0.
         cos_true_anomaly = 1.0
-        true_anomaly=0.
+        true_anomaly = 0.
     else:
         e_vector_unit = e_vector/e_vector.lengths()
-        
+
         cos_arg_per = numpy.dot(e_vector_unit, ascending_node_vector_unit)
         # cos_arg_per = e_vector_unit.dot(ascending_node_vector_unit)
         e_cross_an = numpy.cross(e_vector_unit, ascending_node_vector_unit)
+        print specific_angular_momentum_unit, e_cross_an
         ss = -numpy.sign(numpy.dot(specific_angular_momentum_unit, e_cross_an))
         # ss=-numpy.sign(specific_angular_momentum_unit.dot(e_cross_an))
         sin_arg_per = ss*(e_cross_an**2).sum()**0.5
         arg_per = arctan2(sin_arg_per, cos_arg_per)
 
+        cos_true_anomaly = numpy.dot(e_vector_unit, position_unit)
+        # cos_true_anomaly = e_vector_unit.dot(position_unit)
+        e_cross_pos = numpy.cross(e_vector_unit, position_unit)
+        ss = numpy.sign(numpy.dot(specific_angular_momentum_unit, e_cross_pos))
+        # ss=numpy.sign(specific_angular_momentum_unit.dot(e_cross_pos))
+        sin_true_anomaly = ss * (e_cross_pos**2).sum()**0.5
+        true_anomaly = arctan2(sin_true_anomaly, cos_true_anomaly)
 
-        cos_true_anomaly = numpy.dot(e_vector_unit,position_unit)
-        #cos_true_anomaly = e_vector_unit.dot(position_unit)
-        e_cross_pos=numpy.cross(e_vector_unit,position_unit)
-        ss=numpy.sign(numpy.dot(specific_angular_momentum_unit,e_cross_pos))
-        #ss=numpy.sign(specific_angular_momentum_unit.dot(e_cross_pos))
-        sin_true_anomaly = ss*(e_cross_pos**2).sum()**0.5
-        true_anomaly=arctan2(sin_true_anomaly,cos_true_anomaly)
-
-        
     return (
             mass1, mass2, semimajor_axis, eccentricity, true_anomaly,
             inclination, long_asc_node, arg_per)
 
 
 def orbital_elements_for_rel_posvel_arrays(
-        rel_position_raw, rel_velocity_raw, 
+        rel_position_raw, rel_velocity_raw,
         total_masses, G=nbody_system.G):
     """
     Orbital elements from array of relative positions and velocities vectors,
-    based on orbital_elements_from_binary and adapted to work for arrays (each line
-    characterises a two body problem).
-    
+    based on orbital_elements_from_binary and adapted to work for arrays (each
+    line characterises a two body problem).
+
     For circular orbits (eccentricity=0): returns argument of pericenter = 0.,
         true anomaly = 0.
-    
+
     For equatorial orbits (inclination=0): longitude of ascending node = 0,
         argument of pericenter = arctan2(e_y,e_x).
-    
-    :argument rel_position: array of vectors of relative positions of the two-body systems
-    :argument rel_velocity: array of vectors of relative velocities of the two-body systems
+
+    :argument rel_position: array of vectors of relative positions of the
+    two-body systems
+    :argument rel_velocity: array of vectors of relative velocities of the
+    two-body systems
     :argument total_masses: array of total masses for two-body systems
     :argument G: gravitational constant
-    
+
     :output semimajor_axis: array of semi-major axes
     :output eccentricity: array of eccentricities
     :output period: array of orbital periods
@@ -384,29 +430,29 @@ def orbital_elements_for_rel_posvel_arrays(
     :output arg_per_mat: array of argument of pericenters [radians]
     :output true_anomaly: array of true anomalies [radians]
     """
-    if len(numpy.shape(rel_position_raw))==1:
-        rel_position = numpy.zeros([1,3]) * rel_position_raw[0]
-        rel_position[0,0] = rel_position_raw[0]
-        rel_position[0,1] = rel_position_raw[1]
-        rel_position[0,2] = rel_position_raw[2]
-        rel_velocity = numpy.zeros([1,3]) * rel_velocity_raw[0]
-        rel_velocity[0,0] = rel_velocity_raw[0]
-        rel_velocity[0,1] = rel_velocity_raw[1]
-        rel_velocity[0,2] = rel_velocity_raw[2]
+    if len(numpy.shape(rel_position_raw)) == 1:
+        rel_position = numpy.zeros([1, 3]) * rel_position_raw[0]
+        rel_position[0, 0] = rel_position_raw[0]
+        rel_position[0, 1] = rel_position_raw[1]
+        rel_position[0, 2] = rel_position_raw[2]
+        rel_velocity = numpy.zeros([1, 3]) * rel_velocity_raw[0]
+        rel_velocity[0, 0] = rel_velocity_raw[0]
+        rel_velocity[0, 1] = rel_velocity_raw[1]
+        rel_velocity[0, 2] = rel_velocity_raw[2]
     else:
         rel_position = rel_position_raw
         rel_velocity = rel_velocity_raw
-    
-    separation = (rel_position**2).sum(axis=1)**0.5    
+
+    separation = (rel_position**2).sum(axis=1)**0.5
     n_vec = len(rel_position)
-    
+
     speed_squared = (rel_velocity**2).sum(axis=1)
-    
+
     semimajor_axis = (
             G * total_masses * separation
             / (2. * G * total_masses - separation * speed_squared)
             )
-    
+
     neg_ecc_arg = (
             (
                 to_quantity(rel_position).cross(rel_velocity)**2
@@ -415,31 +461,33 @@ def orbital_elements_for_rel_posvel_arrays(
             )
     filter_ecc0 = (1. <= neg_ecc_arg)
     eccentricity = numpy.zeros(separation.shape)
-    eccentricity[~filter_ecc0] = numpy.sqrt( 1.0 - neg_ecc_arg[~filter_ecc0])
+    eccentricity[~filter_ecc0] = numpy.sqrt(1.0 - neg_ecc_arg[~filter_ecc0])
     eccentricity[filter_ecc0] = 0.
-            
+
     # angular momentum
-    mom = to_quantity(rel_position).cross(rel_velocity)        
-    
+    mom = to_quantity(rel_position).cross(rel_velocity)
+
     # inclination
-    inc = arccos(mom[:,2]/to_quantity(mom).lengths())
-    
+    inc = arccos(mom[:, 2]/to_quantity(mom).lengths())
+
     # Longitude of ascending nodes, with reference direction along x-axis
     asc_node_matrix_unit = numpy.zeros(rel_position.shape)
-    z_vectors = numpy.zeros([n_vec,3])
-    z_vectors[:,2] = 1.
+    z_vectors = numpy.zeros([n_vec, 3])
+    z_vectors[:, 2] = 1.
     z_vectors = z_vectors | units.none
     ascending_node_vectors = z_vectors.cross(mom)
     filter_non0_incl = (
             to_quantity(ascending_node_vectors).lengths().number > 0.)
-    asc_node_matrix_unit[~filter_non0_incl] = numpy.array([1.,0.,0.])
+    asc_node_matrix_unit[~filter_non0_incl] = numpy.array([1., 0., 0.])
     an_vectors_len = to_quantity(
             ascending_node_vectors[filter_non0_incl]).lengths()
     asc_node_matrix_unit[filter_non0_incl] = normalize_vector(
             ascending_node_vectors[filter_non0_incl],
             an_vectors_len)
-    long_asc_node = arctan2(asc_node_matrix_unit[:,1], asc_node_matrix_unit[:,0])
-    
+    long_asc_node = arctan2(
+            asc_node_matrix_unit[:, 1],
+            asc_node_matrix_unit[:, 0])
+
     # Argument of periapsis using eccentricity a.k.a. Laplace-Runge-Lenz vector
     mu = G*total_masses
     pos_unit_vecs = normalize_vector(rel_position, separation)
@@ -447,25 +495,28 @@ def orbital_elements_for_rel_posvel_arrays(
     mom_unit_vecs = normalize_vector(mom, mom_len)
     e_vecs = (
             normalize_vector(
-                to_quantity(rel_velocity).cross(mom), mu) 
+                to_quantity(rel_velocity).cross(mom), mu)
             - pos_unit_vecs
             )
-    
+
     # Argument of pericenter cannot be determined for e = 0,
     # in this case return 0.0 and 1.0 for the cosines
     e_vecs_norm = (e_vecs**2).sum(axis=1)**0.5
     filter_non0_ecc = (e_vecs_norm > 1.e-15)
-    arg_per_mat = numpy.zeros(long_asc_node.shape)
+    arg_per_mat = VectorQuantity(
+            array=numpy.zeros(long_asc_node.shape),
+            unit=units.rad)
     cos_arg_per = numpy.zeros(long_asc_node.shape)
-    arg_per_mat[~filter_non0_ecc] = 0.
+    arg_per_mat[~filter_non0_ecc] = 0. | units.rad
     cos_arg_per[~filter_non0_ecc] = 1.
-    
+
     e_vecs_unit = numpy.zeros(rel_position.shape)
     e_vecs_unit[filter_non0_ecc] = normalize_vector(
             e_vecs[filter_non0_ecc],
             e_vecs_norm[filter_non0_ecc]
             )
-    #~ cos_arg_per = numpy.einsum('ij,ji->i', e_vecs_unit[filter_non0_ecc], asc_node_matrix_unit[filter_non0_ecc].T)
+    # cos_arg_per = numpy.einsum('ij,ji->i', e_vecs_unit[filter_non0_ecc],
+    #         asc_node_matrix_unit[filter_non0_ecc].T)
     cos_arg_per = (
             e_vecs_unit[filter_non0_ecc]
             * asc_node_matrix_unit[filter_non0_ecc]
@@ -477,7 +528,13 @@ def orbital_elements_for_rel_posvel_arrays(
             )
     e_cross_an_norm = (e_cross_an**2).sum(axis=1)**0.5
     filter_non0_e_cross_an = (e_cross_an_norm != 0.)
-    #~ ss = -numpy.sign(numpy.einsum('ij,ji->i',mom_unit_vecs[filter_non0_e_cross_an], e_cross_an[filter_non0_e_cross_an].T))
+    # ss = -numpy.sign(
+    #         numpy.einsum(
+    #             'ij,ji->i',
+    #             mom_unit_vecs[filter_non0_e_cross_an],
+    #             e_cross_an[filter_non0_e_cross_an].T
+    #             )
+    #         )
     ss = -numpy.sign(
             (
                 mom_unit_vecs[filter_non0_e_cross_an]
@@ -485,8 +542,8 @@ def orbital_elements_for_rel_posvel_arrays(
                 ).sum(axis=-1)
             )
     sin_arg_per = ss*e_cross_an_norm[filter_non0_e_cross_an]
-    arg_per_mat[filter_non0_e_cross_an] = arctan2(sin_arg_per,cos_arg_per)
-    
+    arg_per_mat[filter_non0_e_cross_an] = arctan2(sin_arg_per, cos_arg_per)
+
     # in case longitude of ascending node is 0, omega=arctan2(e_y,e_x)
     arg_per_mat[~filter_non0_e_cross_an & filter_non0_ecc] = (
             arctan2(
@@ -497,27 +554,27 @@ def orbital_elements_for_rel_posvel_arrays(
     filter_negative_zmom = (
             ~filter_non0_e_cross_an
             & filter_non0_ecc
-            & (mom[:,2] < 0.*mom[0,0])
+            & (mom[:, 2] < 0.*mom[0, 0])
             )
     arg_per_mat[filter_negative_zmom] = (
             2. * numpy.pi
             - arg_per_mat[filter_negative_zmom]
             )
-    
+
     # true anomaly
     cos_true_anomaly = (e_vecs_unit*pos_unit_vecs).sum(axis=-1)
-    e_cross_pos = numpy.cross(e_vecs_unit,pos_unit_vecs)
+    e_cross_pos = numpy.cross(e_vecs_unit, pos_unit_vecs)
     ss2 = numpy.sign((mom_unit_vecs*e_cross_pos).sum(axis=-1))
     sin_true_anomaly = ss2*(e_cross_pos**2).sum(axis=1)**0.5
-    true_anomaly = arctan2(sin_true_anomaly,cos_true_anomaly)
-    
+    true_anomaly = arctan2(sin_true_anomaly, cos_true_anomaly)
+
     return (
             semimajor_axis, eccentricity, true_anomaly,
             inc, long_asc_node, arg_per_mat
             )
 
 
-def normalize_vector(vecs, norm, one_dim = False):
+def normalize_vector(vecs, norm, one_dim=False):
     """
     normalize array of vector quantities
     """
@@ -528,7 +585,7 @@ def normalize_vector(vecs, norm, one_dim = False):
         vecs_norm[2] = vecs[2]/norm
     else:
         vecs_norm = numpy.zeros(vecs.shape)
-        vecs_norm[:,0] = vecs[:,0]/norm
-        vecs_norm[:,1] = vecs[:,1]/norm
-        vecs_norm[:,2] = vecs[:,2]/norm
+        vecs_norm[:, 0] = vecs[:, 0]/norm
+        vecs_norm[:, 1] = vecs[:, 1]/norm
+        vecs_norm[:, 2] = vecs[:, 2]/norm
     return vecs_norm

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -4,10 +4,10 @@ orbital element conversion and utility functions
 this module provides:
 
 generate_binaries
+orbital_elements
 get_orbital_elements_from_binary
-orbital_elements_from_binaries
-orbital_elements_from_arrays
-
+get_orbital_elements_from_binaries
+get_orbital_elements_from_arrays
 
 and the following deprecated functions (assume input
 or output angle floats to be degrees):
@@ -378,7 +378,7 @@ def get_orbital_elements_from_binary(binary, G=nbody_system.G):
     (
             mass1, mass2, semimajor_axis, eccentricity, true_anomaly,
             inclination, long_asc_node, arg_per
-            ) = orbital_elements_from_binaries(primaries, secondaries, G=G)
+            ) = get_orbital_elements_from_binaries(primaries, secondaries, G=G)
     return (
             mass1[0], mass2[0], semimajor_axis[0], eccentricity[0],
             true_anomaly[0], inclination[0], long_asc_node[0], arg_per[0])
@@ -397,7 +397,7 @@ def orbital_elements_from_binary(binary, G=nbody_system.G):
             arg_per[0].value_in(units.deg))
 
 
-def orbital_elements_from_binaries(primaries, secondaries, G=nbody_system.G):
+def get_orbital_elements_from_binaries(primaries, secondaries, G=nbody_system.G):
     """
     Function that computes orbital elements from given primaries and
     secondaries.
@@ -416,7 +416,7 @@ def orbital_elements_from_binaries(primaries, secondaries, G=nbody_system.G):
     mass2 = secondaries.mass
     total_mass = mass1 + mass2
     semimajor_axis, eccentricity, true_anomaly, inclination, long_asc_node, \
-        arg_per = orbital_elements_from_arrays(
+        arg_per = get_orbital_elements_from_arrays(
             position, velocity, total_mass, G=G)
 
     return (
@@ -424,7 +424,7 @@ def orbital_elements_from_binaries(primaries, secondaries, G=nbody_system.G):
             inclination, long_asc_node, arg_per)
 
 
-def orbital_elements_from_arrays(
+def get_orbital_elements_from_arrays(
         rel_position_raw, rel_velocity_raw,
         total_masses, G=nbody_system.G):
     """
@@ -587,12 +587,29 @@ def orbital_elements_from_arrays(
             inc, long_asc_node, arg_per_mat
             )
 
+def orbital_elements(*args, **kwargs):#G=nbody_system.G):
+    try:
+        if len(args)==1:
+          return get_orbital_elements_from_binary(*args,**kwargs)
+        elif len(args)==2:
+          return get_orbital_elements_from_binaries(*args,**kwargs)
+        elif len(args)==3:
+          return get_orbital_elements_from_arrays(*args,**kwargs)
+        else:
+          raise Exception
+    except:
+      raise Exception("""
+  orbital elements takes as input either: 
+  - single two particle set,
+  - two sets of primaries and secondaries                    
+  - arrays of rel. position, rel. velocity and masses 
+  """)
 
 def orbital_elements_for_rel_posvel_arrays(
         rel_position_raw, rel_velocity_raw,
         total_masses, G=nbody_system.G):
     (semimajor_axis, eccentricity, true_anomaly, inc, long_asc_node,
-        arg_per_mat) = orbital_elements_from_arrays(
+        arg_per_mat) = get_orbital_elements_from_arrays(
                 rel_position_raw, rel_velocity_raw, total_masses, G)
 
     true_anomaly = true_anomaly.value_in(units.deg)

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -1,5 +1,7 @@
 import numpy
 
+import warnings
+
 from amuse.units import units, nbody_system, constants
 from amuse.units.trigo import cos, sin, arccos, arctan2
 from amuse.datamodel import Particles, rotation
@@ -40,42 +42,101 @@ def angle_with_unit(angle, default_unit=units.deg):
     return angle
 
 
-def new_binary_from_orbital_elements(
-        mass1,
-        mass2,
-        semimajor_axis, 
-        eccentricity = 0,
-        true_anomaly = 0, 
-        inclination = 0,
-        longitude_of_the_ascending_node = 0,
-        argument_of_periapsis = 0,
-        G=nbody_system.G
-    ):
-    """ 
-
-    Function that returns two-particle Particle set, with the second 
-    particle position and velocities computed from the input orbital 
-    elements. inclination between 0 and 180
-
+def equal_length_array_or_scalar(
+        array, length=1, mode="continue"
+        ):
     """
-    
-    # If no unit is given for angles, assume they are in degrees
-    true_anomaly = angle_with_unit(inclination, default_unit=units.deg)
-    inclination = angle_with_unit(inclination, default_unit=units.deg)
-    argument_of_periapsis = angle_with_unit(
-            argument_of_periapsis, 
-            default_unit=units.deg
+    Returns 'array' if its length is equal to 'length'.
+    If this is not the case, returns 'array' anyway if it is a scalar,
+    or the first value of the array if its length is different from 'length'.
+    If mode is "warn", issues a warning if this happens; if mode is "exception"
+    raises an exception in this case.
+    """
+    try:
+        array_length = len(array)
+        if array_length == length:
+            return array
+        else:
+            if mode == "warn":
+                warnings.warn("Length of array is not equal to %i. Using only\
+                        the first value." % length)
+            elif mode == "exception":
+                raise Exception("Length of array is not equal to %i. This is\
+                not supported." % length)
+            return array[0]
+    except:
+        if mode == "warn":
+            warnings.warn("Not an array, continuing with scalar.")
+        elif mode == "exception":
+            raise Exception("Not an array, this is not supported.")
+        return array
+
+
+def center_of_mass_array(
+        vectors,
+        primary_mass,
+        secondary_mass,
+        ):
+    """
+    Returns array of center_of_mass vectors, where primaries are considered to
+    be at (0,0,0) and secondaries at 'vectors'.
+    """
+    total_mass = (primary_mass + secondary_mass).reshape(
+            (len(primary_mass), 1)
             )
-    longitude_of_the_ascending_node = angle_with_unit(
-            longitude_of_the_ascending_node, 
-            default_unit=units.deg
+    center_of_mass_array = (
+            (
+                vectors
+                * secondary_mass.reshape(
+                    (len(secondary_mass), 1)
+                    )
+                )
+            / total_mass
             )
+    return center_of_mass_array
+
+
+def generate_binaries_from_orbital_elements(
+        primary_mass,
+        secondary_mass,
+        semi_major_axis,
+        eccentricity=0 | units.rad,
+        true_anomaly=0 | units.rad,
+        inclination=0 | units.rad,
+        longitude_of_the_ascending_node=0 | units.rad,
+        argument_of_periapsis=0 | units.rad,
+        G=nbody_system.G
+        ):
+    """
+    returns two particlesets, which contain the primaries and the secondaries
+    in binary pairs.
+    """
+    number_of_primaries = len(primary_mass)
+    number_of_secondaries = len(secondary_mass)
+
+    # mass arrays need to be the same length
+    if number_of_secondaries != number_of_primaries:
+        raise Exception("The number of primaries is not the same as the number\
+                of secondaries, this is not supported.")
+    # other arrays need to be the same length as well, or have just one value
+    semi_major_axis = equal_length_array_or_scalar(
+            semi_major_axis, length=number_of_primaries)
+    eccentricity = equal_length_array_or_scalar(
+            eccentricity, length=number_of_primaries)
+    true_anomaly = equal_length_array_or_scalar(
+            true_anomaly, length=number_of_primaries)
+    inclination = equal_length_array_or_scalar(
+            inclination, length=number_of_primaries)
+    longitude_of_the_ascending_node = equal_length_array_or_scalar(
+            longitude_of_the_ascending_node, length=number_of_primaries)
+    argument_of_periapsis = equal_length_array_or_scalar(
+            argument_of_periapsis, length=number_of_primaries)
 
     cos_true_anomaly = cos(true_anomaly)
     sin_true_anomaly = sin(true_anomaly)
 
     cos_inclination = cos(inclination)
-    sin_inclination = sin(inclination)    
+    sin_inclination = sin(inclination)
 
     cos_arg_per = cos(argument_of_periapsis)
     sin_arg_per = sin(argument_of_periapsis)
@@ -83,7 +144,7 @@ def new_binary_from_orbital_elements(
     cos_long_asc_nodes = cos(longitude_of_the_ascending_node)
     sin_long_asc_nodes = sin(longitude_of_the_ascending_node)
 
-    ### alpha is a unit vector directed along the line of node ###
+    # alpha is a unit vector directed along the line of node
     alphax = (
             cos_long_asc_nodes*cos_arg_per
             - sin_long_asc_nodes*sin_arg_per*cos_inclination
@@ -93,9 +154,10 @@ def new_binary_from_orbital_elements(
             + cos_long_asc_nodes*sin_arg_per*cos_inclination
             )
     alphaz = sin_arg_per*sin_inclination
-    alpha = numpy.array([alphax,alphay,alphaz])
+    alpha = numpy.array([alphax, alphay, alphaz])
 
-    ### beta is a unit vector perpendicular to alpha and the orbital angular momentum vector ###
+    # beta is a unit vector perpendicular to alpha and the orbital angular
+    # momentum vector
     betax = (
             - cos_long_asc_nodes*sin_arg_per
             - sin_long_asc_nodes*cos_arg_per*cos_inclination
@@ -105,14 +167,11 @@ def new_binary_from_orbital_elements(
             + cos_long_asc_nodes*cos_arg_per*cos_inclination
             )
     betaz = cos_arg_per*sin_inclination
-    beta = numpy.array([betax,betay,betaz])
+    beta = numpy.array([betax, betay, betaz])
 
-#    print 'alpha',alphax**2+alphay**2+alphaz**2 # For debugging; should be 1
-#    print 'beta',betax**2+betay**2+betaz**2 # For debugging; should be 1
-
-    ### Relative position and velocity ###
+    # Relative position and velocity
     separation = (
-            semimajor_axis*(1.0 - eccentricity**2)
+            semi_major_axis*(1.0 - eccentricity**2)
             / (1.0 + eccentricity*cos_true_anomaly)
             )  # Compute the relative separation
     position_vector = (
@@ -120,26 +179,76 @@ def new_binary_from_orbital_elements(
             + separation*sin_true_anomaly*beta
             )
     velocity_tilde = (
-            G*(mass1 + mass2)
-            / (semimajor_axis*(1.0 - eccentricity**2))
+            G*(primary_mass + secondary_mass)
+            / (semi_major_axis*(1.0 - eccentricity**2))
             )**0.5  # Common factor
     velocity_vector = (
             -1.0*velocity_tilde*sin_true_anomaly*alpha
             + velocity_tilde*(eccentricity + cos_true_anomaly)*beta
             )
 
-    result = Particles(2)
-    result[0].mass = mass1
-    result[1].mass = mass2
-    
-    result[1].position = position_vector
-    result[1].velocity = velocity_vector
+    primaries = Particles(number_of_primaries)
+    secondaries = Particles(number_of_secondaries)
+    primaries.mass = primary_mass
+    secondaries.mass = secondary_mass
 
-    result.move_to_center()
+    centers_of_mass = center_of_mass_array(
+            position_vector, primary_mass, secondary_mass)
+    centers_of_mass_velocity = center_of_mass_array(
+            velocity_vector, primary_mass, secondary_mass)
+    primaries.position = -centers_of_mass
+    secondaries.position = centers_of_mass
+    primaries.velocity = -centers_of_mass_velocity
+    secondaries.velocity = centers_of_mass_velocity
+    return primaries, secondaries
+
+
+def new_binary_from_orbital_elements(
+        mass1,
+        mass2,
+        semimajor_axis,
+        eccentricity=0 | units.deg,
+        true_anomaly=0 | units.deg,
+        inclination=0 | units.deg,
+        longitude_of_the_ascending_node=0 | units.deg,
+        argument_of_periapsis=0 | units.deg,
+        G=nbody_system.G
+        ):
+    """
+    returns a two-particle Particle set, with the second particle's position
+    and velocities computed from the input orbital elements.
+    inclination is given between 0 and 180 deg.
+    angles are assumed to be in deg if no unit is given.
+    """
+
+    # If no unit is given for angles, assume they are in degrees
+    true_anomaly = angle_with_unit(inclination, default_unit=units.deg)
+    inclination = angle_with_unit(inclination, default_unit=units.deg)
+    argument_of_periapsis = angle_with_unit(
+            argument_of_periapsis,
+            default_unit=units.deg
+            )
+    longitude_of_the_ascending_node = angle_with_unit(
+            longitude_of_the_ascending_node,
+            default_unit=units.deg
+            )
+    primary, secondary = generate_binaries_from_orbital_elements(
+            [mass1], [mass2], semimajor_axis,
+            eccentricity=eccentricity,
+            true_anomaly=true_anomaly,
+            inclination=inclination,
+            longitude_of_the_ascending_node=longitude_of_the_ascending_node,
+            argument_of_periapsis=argument_of_periapsis,
+            G=G
+            )
+
+    result = Particles(2)
+    result.add_particle(primary[0])
+    result.add_particle(secondary[0])
     return result
 
 
-def orbital_elements_from_binary( binary, G=nbody_system.G):
+def orbital_elements_from_binary(binary, G=nbody_system.G):
     """ 
     Function that computes orbital elements from given two-particle set. 
     Elements are computed for the second particle in this set and the 

--- a/src/amuse/ext/orbital_elements.py
+++ b/src/amuse/ext/orbital_elements.py
@@ -31,6 +31,15 @@ def true_anomaly_from_eccentric_anomaly(E,e):
 # E from M,e
 # newton solver for M=E-e sin E
 
+
+def angle_with_unit(angle, default_unit=units.deg):
+    try:
+        unit = angle.unit
+    except:
+        angle = angle | default_unit
+    return angle
+
+
 def new_binary_from_orbital_elements(
         mass1,
         mass2,
@@ -49,6 +58,18 @@ def new_binary_from_orbital_elements(
     elements. inclination between 0 and 180
 
     """
+    
+    # If no unit is given for angles, assume they are in degrees
+    true_anomaly = angle_with_unit(inclination, default_unit=units.deg)
+    inclination = angle_with_unit(inclination, default_unit=units.deg)
+    argument_of_periapsis = angle_with_unit(
+            argument_of_periapsis, 
+            default_unit=units.deg
+            )
+    longitude_of_the_ascending_node = angle_with_unit(
+            longitude_of_the_ascending_node, 
+            default_unit=units.deg
+            )
 
     cos_true_anomaly = cos(true_anomaly)
     sin_true_anomaly = sin(true_anomaly)

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -219,14 +219,13 @@ class KeplerTests(amusetest.TestCase):
                                                comets.velocity,
                                                comets.mass + mass_sun,
                                                G=constants.G)        
-        rad_to_deg = 180./numpy.pi
-        for i in range(N):
-            self.assertAlmostEqual(semi_major_axis[i].value_in(units.AU),semi_major_axis_ext[i].value_in(units.AU))
-            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
-            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
-            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
-            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
-            self.assertAlmostEqual(true_anomaly[i],rad_to_deg*ta_ext[i])
+
+        self.assertAlmostEqual(semi_major_axis,semi_major_axis_ext)
+        self.assertAlmostEqual(eccentricity,eccentricity_ext)
+        self.assertAlmostEqual(inclination | units.deg,inclination_ext)
+        self.assertAlmostEqual(longitude_of_the_ascending_node | units.deg,longitude_of_the_ascending_node_ext)
+        self.assertAlmostEqual(argument_of_periapsis | units.deg,argument_of_periapsis_ext)
+        self.assertAlmostEqual(true_anomaly | units.deg,ta_ext)
 
     def test7(self):
         """

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -134,41 +134,51 @@ class KeplerTests(amusetest.TestCase):
     
     def test4(self):
         numpy.random.seed(3456789)
-        N=100
-        
-        mass1=random.random(N) | nbody_system.mass 
-        mass2=random.random(N) | nbody_system.mass
-        semi_major_axis=(-numpy.log(random.random(N))) | nbody_system.length 
-        eccentricity = random.random(N)
-        true_anomaly = 360.*random.random(N)-180.
-        inclination = 180*random.random(N)
-        longitude_of_the_ascending_node = 360*random.random(N)-180
-        argument_of_periapsis = 360*random.random(N)-180       
+        N = 100
 
-        for arg in zip(mass1,mass2,semi_major_axis,eccentricity,true_anomaly,inclination, 
-                                  longitude_of_the_ascending_node,argument_of_periapsis):
-          arg_=orbital_elements_from_binary(new_binary_from_orbital_elements(*arg))
-          for i,(copy,org) in enumerate(zip(arg_,arg)):
-            self.assertAlmostEquals(copy,org)
+        mass1 = random.random(N) | nbody_system.mass
+        mass2 = random.random(N) | nbody_system.mass
+        semi_major_axis = (-numpy.log(random.random(N))) | nbody_system.length
+        eccentricity = random.random(N)
+        true_anomaly = (360.*random.random(N)-180.) | units.deg
+        inclination = (180*random.random(N)) | units.deg
+        longitude_of_the_ascending_node = (
+                360*random.random(N)-180) | units.deg
+        argument_of_periapsis = (360*random.random(N)-180) | units.deg
+
+        for arg in zip(
+                mass1, mass2, semi_major_axis, eccentricity, true_anomaly,
+                inclination, longitude_of_the_ascending_node,
+                argument_of_periapsis):
+            arg_ = orbital_elements_from_binary(
+                    new_binary_from_orbital_elements(*arg))
+            for i, (copy, org) in enumerate(zip(arg_, arg)):
+                self.assertAlmostEquals(copy, org)
 
     def test5(self):
         numpy.random.seed(4567893)
-        N=100
-        
-        mass1=random.random(N) | units.MSun 
-        mass2=random.random(N) | units.MSun
-        semi_major_axis=(-numpy.log(random.random(N))) | units.AU 
-        eccentricity = random.random(N)
-        true_anomaly = 360.*random.random(N)-180.
-        inclination = 180*random.random(N)
-        longitude_of_the_ascending_node = 360*random.random(N)-180
-        argument_of_periapsis = 360*random.random(N)-180       
+        N = 100
 
-        for arg in zip(mass1,mass2,semi_major_axis,eccentricity,true_anomaly,inclination, 
-                                  longitude_of_the_ascending_node,argument_of_periapsis):
-          arg_=orbital_elements_from_binary(new_binary_from_orbital_elements(*arg,G=constants.G),G=constants.G)
-          for i,(copy,org) in enumerate(zip(arg_,arg)):
-            self.assertAlmostEquals(copy,org)
+        mass1 = random.random(N) | units.MSun
+        mass2 = random.random(N) | units.MSun
+        semi_major_axis = (-numpy.log(random.random(N))) | units.AU
+        eccentricity = random.random(N)
+        true_anomaly = (360.*random.random(N)-180.) | units.deg
+        inclination = (180*random.random(N)) | units.deg
+        longitude_of_the_ascending_node = (
+                360*random.random(N)-180
+                ) | units.deg
+        argument_of_periapsis = (360*random.random(N)-180) | units.deg
+
+        for arg in zip(
+                mass1, mass2, semi_major_axis, eccentricity, true_anomaly,
+                inclination, longitude_of_the_ascending_node,
+                argument_of_periapsis):
+            arg_ = orbital_elements_from_binary(
+                new_binary_from_orbital_elements(*arg, G=constants.G),
+                G=constants.G)
+            for i, (copy, org) in enumerate(zip(arg_, arg)):
+                self.assertAlmostEquals(copy, org)
     
     def test6(self):
         """

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -10,6 +10,7 @@ from amuse.ext.orbital_elements import (
         orbital_elements_from_binary,
         orbital_elements_for_rel_posvel_arrays,
         rel_posvel_arrays_from_orbital_elements,
+        orbital_elements_from_binaries
         )
 
 from amuse.units import units
@@ -585,3 +586,46 @@ class KeplerTests(amusetest.TestCase):
         self.assertAlmostEqual(lon, lon_ext)
         self.assertAlmostEqual(arg, arg_ext)
         self.assertAlmostEqual(ta, ta_ext)
+
+    def test15(self):
+        """
+        testing orbital_elements_for_rel_posvel_arrays for N particles 
+        with random orbital elements
+        """
+        numpy.random.seed(666)
+        N = 100
+        
+        mass_sun = 1. | units.MSun
+        mass1 = numpy.ones(N) * mass_sun
+        mass2 = numpy.zeros(N) | units.MSun
+        semi_major_axis=(-numpy.log(random.random(N))) | units.AU 
+        eccentricity = random.random(N)
+        true_anomaly = 360.*random.random(N)-180.
+        inclination = 180*random.random(N)
+        longitude_of_the_ascending_node = 360*random.random(N)-180
+        argument_of_periapsis = 360*random.random(N)-180       
+        
+        comets = datamodel.Particles(N)
+        suns = datamodel.Particles(N)
+        for i,arg in enumerate(zip(mass1,mass2,semi_major_axis,eccentricity,true_anomaly,inclination, 
+                                   longitude_of_the_ascending_node,argument_of_periapsis)):
+            sun_and_comet = new_binary_from_orbital_elements(*arg,G=constants.G)
+            comets[i].mass = sun_and_comet[1].mass
+            comets[i].position = sun_and_comet[1].position
+            comets[i].velocity = sun_and_comet[1].velocity
+        
+        suns.mass=mass1
+        suns.position=comets.position
+        suns.velocity=0*comets.velocity
+        
+        semi_major_axis_ext, eccentricity_ext, ta_ext, inclination_ext, \
+        longitude_of_the_ascending_node_ext, argument_of_periapsis_ext = \
+        orbital_elements_from_binaries(suns, comets,G=constants.G)
+        rad_to_deg = 180./numpy.pi
+        for i in range(N):
+            self.assertAlmostEqual(semi_major_axis[i].value_in(units.AU),semi_major_axis_ext[i].value_in(units.AU))
+            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
+            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
+            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
+            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
+            self.assertAlmostEqual(true_anomaly[i],rad_to_deg*ta_ext[i])

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -5,7 +5,12 @@ import numpy
 from amuse.test import amusetest
 
 
-from amuse.ext.orbital_elements import new_binary_from_orbital_elements,orbital_elements_from_binary, orbital_elements_for_rel_posvel_arrays
+from amuse.ext.orbital_elements import (
+        new_binary_from_orbital_elements,
+        orbital_elements_from_binary,
+        orbital_elements_for_rel_posvel_arrays,
+        rel_posvel_arrays_from_orbital_elements,
+        )
 
 from amuse.units import units
 from amuse.units import constants
@@ -13,6 +18,7 @@ from amuse.units import nbody_system
 from amuse import datamodel
 
 from numpy import random
+
 
 class KeplerTests(amusetest.TestCase):
 
@@ -461,3 +467,42 @@ class KeplerTests(amusetest.TestCase):
             self.assertAlmostEqual(longitude_of_the_ascending_node[i],longitude_of_the_ascending_node_ext[i])
             self.assertAlmostEqual(argument_of_periapsis[i],argument_of_periapsis_ext[i])
             self.assertAlmostEqual(true_anomaly[i],ta_ext[i])
+
+    def test12(self):
+        """
+        tests generating cartesian coordinates from orbital elements
+        """
+        numpy.random.seed(1701)
+
+        mass1 = 1.0 | units.MSun
+        mass2 = 0.1 | units.MEarth
+        sem = 2. | units.AU
+        ecc = 0.15
+        inc = 11. | units.deg
+        lon = 30. | units.deg
+        arg = 0.3 | units.deg
+        ta = (360.*random.random()-180.) | units.deg
+
+        rel_pos, rel_vel = rel_posvel_arrays_from_orbital_elements(
+                mass1,
+                mass2,
+                sem,
+                ecc,
+                ta,
+                inc,
+                lon,
+                arg,
+                G=constants.G)
+
+        mass_12 = mass1 + mass2
+        sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
+            orbital_elements_for_rel_posvel_arrays(
+                    rel_pos, rel_vel, mass_12, G=constants.G)
+
+        self.assertAlmostEqual(
+                sem.value_in(units.AU), sem_ext.value_in(units.AU))
+        self.assertAlmostEqual(ecc, ecc_ext)
+        self.assertAlmostEqual(inc, inc_ext)
+        self.assertAlmostEqual(lon, lon_ext)
+        self.assertAlmostEqual(arg, arg_ext)
+        self.assertAlmostEqual(ta, ta_ext)

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -588,43 +588,54 @@ class KeplerTests(amusetest.TestCase):
 
     def test15(self):
         """
-        testing orbital_elements_for_rel_posvel_arrays for N particles 
+        testing orbital_elements_for_rel_posvel_arrays for N particles
         with random orbital elements
         """
         numpy.random.seed(666)
         N = 100
-        
+
         mass_sun = 1. | units.MSun
         mass1 = numpy.ones(N) * mass_sun
         mass2 = numpy.zeros(N) | units.MSun
-        semi_major_axis=(-numpy.log(random.random(N))) | units.AU 
+        semi_major_axis = (-numpy.log(random.random(N))) | units.AU
         eccentricity = random.random(N)
         true_anomaly = 360.*random.random(N)-180.
         inclination = 180*random.random(N)
         longitude_of_the_ascending_node = 360*random.random(N)-180
-        argument_of_periapsis = 360*random.random(N)-180       
-        
+        argument_of_periapsis = 360*random.random(N)-180
+
         comets = datamodel.Particles(N)
         suns = datamodel.Particles(N)
-        for i,arg in enumerate(zip(mass1,mass2,semi_major_axis,eccentricity,true_anomaly,inclination, 
-                                   longitude_of_the_ascending_node,argument_of_periapsis)):
-            sun_and_comet = new_binary_from_orbital_elements(*arg,G=constants.G)
+        for i, arg in enumerate(
+                zip(mass1, mass2, semi_major_axis, eccentricity, true_anomaly,
+                    inclination, longitude_of_the_ascending_node,
+                    argument_of_periapsis)):
+            sun_and_comet = new_binary_from_orbital_elements(
+                    *arg, G=constants.G)
             comets[i].mass = sun_and_comet[1].mass
             comets[i].position = sun_and_comet[1].position
             comets[i].velocity = sun_and_comet[1].velocity
-        
-        suns.mass=mass1
-        suns.position=comets.position
-        suns.velocity=0*comets.velocity
-        
-        semi_major_axis_ext, eccentricity_ext, ta_ext, inclination_ext, \
-        longitude_of_the_ascending_node_ext, argument_of_periapsis_ext = \
-        orbital_elements_from_binaries(suns, comets,G=constants.G)
+
+        suns.mass = mass1
+        suns.position = 0*comets.position
+        suns.velocity = 0*comets.velocity
+
+        mass1_ext, mass2_ext, semi_major_axis_ext, eccentricity_ext, ta_ext,\
+            inclination_ext, longitude_of_the_ascending_node_ext,\
+            argument_of_periapsis_ext = orbital_elements_from_binaries(
+                    suns, comets, G=constants.G)
         rad_to_deg = 180./numpy.pi
         for i in range(N):
-            self.assertAlmostEqual(semi_major_axis[i].value_in(units.AU),semi_major_axis_ext[i].value_in(units.AU))
-            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
-            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
-            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
-            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
-            self.assertAlmostEqual(true_anomaly[i],rad_to_deg*ta_ext[i])
+            self.assertAlmostEqual(
+                    semi_major_axis[i].value_in(units.AU),
+                    semi_major_axis_ext[i].value_in(units.AU))
+            self.assertAlmostEqual(eccentricity[i], eccentricity_ext[i])
+            self.assertAlmostEqual(
+                    inclination[i], rad_to_deg*inclination_ext[i])
+            self.assertAlmostEqual(
+                    longitude_of_the_ascending_node[i],
+                    rad_to_deg*longitude_of_the_ascending_node_ext[i])
+            self.assertAlmostEqual(
+                    argument_of_periapsis[i],
+                    rad_to_deg*argument_of_periapsis_ext[i])
+            self.assertAlmostEqual(true_anomaly[i], rad_to_deg*ta_ext[i])

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -7,8 +7,10 @@ from amuse.test import amusetest
 
 from amuse.ext.orbital_elements import (
         new_binary_from_orbital_elements,
-        orbital_elements_from_binary,
+        #~ orbital_elements_from_binary,
+        get_orbital_elements_from_binary,
         orbital_elements_for_rel_posvel_arrays,
+        orbital_elements_from_arrays,
         rel_posvel_arrays_from_orbital_elements,
         orbital_elements_from_binaries
         )
@@ -122,22 +124,22 @@ class KeplerTests(amusetest.TestCase):
         self.assertAlmostRelativeEquals(binary[1].velocity, [-1,1,0] | nbody_system.speed)
 
 
-    def xtest3(self):
-        mass1 = 1 | nbody_system.mass 
-        mass2 = 1 | nbody_system.mass
+    def test3(self):
+        mass1 = 1. | nbody_system.mass 
+        mass2 = 1. | nbody_system.mass
         
         binary = new_binary_from_orbital_elements(
             mass1,
             mass2,
-            1 | nbody_system.length,
-            eccentricity = 0.5
+            1. | nbody_system.length,
+            eccentricity = 0.
         )
         
         self.assertEquals(len(binary), 2)
-        self.assertAlmostRelativeEquals(binary[0].position, [0,0,0] | nbody_system.length)
-        self.assertAlmostRelativeEquals(binary[1].position, [0,0,0] | nbody_system.length)
-        self.assertAlmostRelativeEquals(binary[0].velocity, [0,0,0] | nbody_system.speed)
-        self.assertAlmostRelativeEquals(binary[1].velocity, [0,numpy.sqrt(2),0] | nbody_system.speed)
+        self.assertAlmostRelativeEquals(binary[0].position, [-0.5,0,0] | nbody_system.length)
+        self.assertAlmostRelativeEquals(binary[1].position, [0.5,0,0] | nbody_system.length)
+        self.assertAlmostRelativeEquals(binary[0].velocity, [0,-1/numpy.sqrt(2),0] | nbody_system.speed)
+        self.assertAlmostRelativeEquals(binary[1].velocity, [0,1/numpy.sqrt(2),0] | nbody_system.speed)
     
     def test4(self):
         numpy.random.seed(3456789)
@@ -157,7 +159,7 @@ class KeplerTests(amusetest.TestCase):
                 mass1, mass2, semi_major_axis, eccentricity, true_anomaly,
                 inclination, longitude_of_the_ascending_node,
                 argument_of_periapsis):
-            arg_ = orbital_elements_from_binary(
+            arg_ = get_orbital_elements_from_binary(
                     new_binary_from_orbital_elements(*arg))
             for i, (copy, org) in enumerate(zip(arg_, arg)):
                 self.assertAlmostEquals(copy, org)
@@ -181,7 +183,7 @@ class KeplerTests(amusetest.TestCase):
                 mass1, mass2, semi_major_axis, eccentricity, true_anomaly,
                 inclination, longitude_of_the_ascending_node,
                 argument_of_periapsis):
-            arg_ = orbital_elements_from_binary(
+            arg_ = get_orbital_elements_from_binary(
                 new_binary_from_orbital_elements(*arg, G=constants.G),
                 G=constants.G)
             for i, (copy, org) in enumerate(zip(arg_, arg)):
@@ -222,10 +224,10 @@ class KeplerTests(amusetest.TestCase):
 
         self.assertAlmostEqual(semi_major_axis,semi_major_axis_ext)
         self.assertAlmostEqual(eccentricity,eccentricity_ext)
-        self.assertAlmostEqual(inclination | units.deg,inclination_ext)
-        self.assertAlmostEqual(longitude_of_the_ascending_node | units.deg,longitude_of_the_ascending_node_ext)
-        self.assertAlmostEqual(argument_of_periapsis | units.deg,argument_of_periapsis_ext)
-        self.assertAlmostEqual(true_anomaly | units.deg,ta_ext)
+        self.assertAlmostEqual(inclination ,inclination_ext)
+        self.assertAlmostEqual(longitude_of_the_ascending_node ,longitude_of_the_ascending_node_ext)
+        self.assertAlmostEqual(argument_of_periapsis ,argument_of_periapsis_ext)
+        self.assertAlmostEqual(true_anomaly,ta_ext)
 
     def test7(self):
         """
@@ -258,13 +260,12 @@ class KeplerTests(amusetest.TestCase):
         sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
         orbital_elements_for_rel_posvel_arrays(rel_pos, rel_vel, mass_12, G=constants.G)
         
-        rad_to_deg = 180./numpy.pi
-        self.assertAlmostEqual(sem.value_in(units.AU), sem_ext.value_in(units.AU))
+        self.assertAlmostEqual(sem, sem_ext)
         self.assertAlmostEqual(ecc, ecc_ext)
-        self.assertAlmostEqual(inc, rad_to_deg*inc_ext)
-        self.assertAlmostEqual(lon, rad_to_deg*lon_ext)
-        self.assertAlmostEqual(arg, rad_to_deg*arg_ext)
-        self.assertAlmostEqual(ta,rad_to_deg*ta_ext)
+        self.assertAlmostEqual(inc, inc_ext)
+        self.assertAlmostEqual(lon, lon_ext)
+        self.assertAlmostEqual(arg, arg_ext)
+        self.assertAlmostEqual(ta,ta_ext)
     
     def test8(self):
         """
@@ -300,14 +301,13 @@ class KeplerTests(amusetest.TestCase):
                                                rel_vel,
                                                mass_12,
                                                G=constants.G)        
-        rad_to_deg = 180./numpy.pi
-        for i in range(N):
-            self.assertAlmostEqual(semi_major_axis[i].value_in(units.AU),semi_major_axis_ext[i].value_in(units.AU))
-            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
-            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
-            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
-            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
-            self.assertAlmostEqual(true_anomaly[i],rad_to_deg*ta_ext[i])
+
+        self.assertAlmostEqual(semi_major_axis,semi_major_axis_ext)
+        self.assertAlmostEqual(eccentricity,eccentricity_ext)
+        self.assertAlmostEqual(inclination,inclination_ext)
+        self.assertAlmostEqual(longitude_of_the_ascending_node,longitude_of_the_ascending_node_ext)
+        self.assertAlmostEqual(argument_of_periapsis,argument_of_periapsis_ext)
+        self.assertAlmostEqual(true_anomaly,ta_ext)
 
     def test9(self):
         """
@@ -340,15 +340,13 @@ class KeplerTests(amusetest.TestCase):
         orbital_elements_for_rel_posvel_arrays(comets.position,
                                                comets.velocity,
                                                comets.mass + mass_sun,
-                                               G=nbody_system.G)        
-        rad_to_deg = 180./numpy.pi
-        for i in range(N):
-            self.assertAlmostEqual(semi_major_axis[i],semi_major_axis_ext[i])
-            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
-            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
-            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
-            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
-            self.assertAlmostEqual(true_anomaly[i],rad_to_deg*ta_ext[i])
+                                               G=nbody_system.G)
+        self.assertAlmostEqual(semi_major_axis,semi_major_axis_ext)
+        self.assertAlmostEqual(eccentricity,eccentricity_ext)
+        self.assertAlmostEqual(inclination,inclination_ext)
+        self.assertAlmostEqual(longitude_of_the_ascending_node,longitude_of_the_ascending_node_ext)
+        self.assertAlmostEqual(argument_of_periapsis,argument_of_periapsis_ext)
+        self.assertAlmostEqual(true_anomaly,ta_ext)
 
     def xtest10(self):
         """
@@ -381,15 +379,14 @@ class KeplerTests(amusetest.TestCase):
         orbital_elements_for_rel_posvel_arrays(comets.position,
                                                comets.velocity,
                                                comets.mass + mass_sun,
-                                               G=1)        
-        rad_to_deg = 180./numpy.pi
-        for i in range(N):
-            self.assertAlmostEqual(semi_major_axis[i],semi_major_axis_ext[i])
-            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
-            self.assertAlmostEqual(inclination[i],rad_to_deg*inclination_ext[i])
-            self.assertAlmostEqual(longitude_of_the_ascending_node[i],rad_to_deg*longitude_of_the_ascending_node_ext[i])
-            self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
-            self.assertAlmostEqual(true_anomaly[i],rad_to_deg*ta_ext[i])
+                                               G=1)
+
+        self.assertAlmostEqual(semi_major_axis,semi_major_axis_ext)
+        self.assertAlmostEqual(eccentricity,eccentricity_ext)
+        self.assertAlmostEqual(inclination,inclination_ext)
+        self.assertAlmostEqual(longitude_of_the_ascending_node,longitude_of_the_ascending_node_ext)
+        self.assertAlmostEqual(argument_of_periapsis,argument_of_periapsis_ext)
+        self.assertAlmostEqual(true_anomaly,ta_ext)
             
             
     def test11(self):
@@ -455,18 +452,17 @@ class KeplerTests(amusetest.TestCase):
         
         semi_major_axis_ext, eccentricity_ext, ta_ext, inclination_ext, \
         longitude_of_the_ascending_node_ext, argument_of_periapsis_ext = \
-        orbital_elements_for_rel_posvel_arrays(comets.position,
+        orbital_elements_from_arrays(comets.position,
                                                comets.velocity,
                                                comets.mass + mass_sun,
                                                G=constants.G)
         
-        for i in range(N):
-            self.assertAlmostEqual(semi_major_axis[i].value_in(units.AU),semi_major_axis_ext[i].value_in(units.AU))
-            self.assertAlmostEqual(eccentricity[i],eccentricity_ext[i])
-            self.assertAlmostEqual(inclination[i],inclination_ext[i])
-            self.assertAlmostEqual(longitude_of_the_ascending_node[i],longitude_of_the_ascending_node_ext[i])
-            self.assertAlmostEqual(argument_of_periapsis[i],argument_of_periapsis_ext[i])
-            self.assertAlmostEqual(true_anomaly[i],ta_ext[i])
+        self.assertAlmostEqual(semi_major_axis,semi_major_axis_ext.in_(units.AU))
+        self.assertAlmostEqual(eccentricity,eccentricity_ext)
+        self.assertAlmostEqual(inclination,inclination_ext)
+        self.assertAlmostEqual(longitude_of_the_ascending_node,longitude_of_the_ascending_node_ext)
+        self.assertAlmostEqual(argument_of_periapsis,argument_of_periapsis_ext)
+        self.assertAlmostEqual(true_anomaly,ta_ext)
 
     def test12(self):
         """
@@ -496,11 +492,10 @@ class KeplerTests(amusetest.TestCase):
 
         mass_12 = mass1 + mass2
         sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
-            orbital_elements_for_rel_posvel_arrays(
+            orbital_elements_from_arrays(
                     rel_pos, rel_vel, mass_12, G=constants.G)
 
-        self.assertAlmostEqual(
-                sem.value_in(units.AU), sem_ext.value_in(units.AU))
+        self.assertAlmostEqual(sem, sem_ext)
         self.assertAlmostEqual(ecc, ecc_ext)
         self.assertAlmostEqual(inc, inc_ext)
         self.assertAlmostEqual(lon, lon_ext)
@@ -536,11 +531,11 @@ class KeplerTests(amusetest.TestCase):
 
         mass_12 = mass1 + mass2
         sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
-            orbital_elements_for_rel_posvel_arrays(
+            orbital_elements_from_arrays(
                     rel_pos, rel_vel, mass_12, G=constants.G)
 
         self.assertAlmostEqual(
-                sem.value_in(units.AU), sem_ext.value_in(units.AU))
+                sem, sem_ext)
         self.assertAlmostEqual(ecc, ecc_ext)
         self.assertAlmostEqual(inc, inc_ext)
         self.assertAlmostEqual(lon, lon_ext)
@@ -576,7 +571,7 @@ class KeplerTests(amusetest.TestCase):
 
         mass_12 = mass1 + mass2
         sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
-            orbital_elements_for_rel_posvel_arrays(
+            orbital_elements_from_arrays(
                     rel_pos, rel_vel, mass_12, G=constants.G)
         self.assertAlmostEqual(
                 sem.value_in(units.AU), sem_ext.value_in(units.AU))

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -506,3 +506,82 @@ class KeplerTests(amusetest.TestCase):
         self.assertAlmostEqual(lon, lon_ext)
         self.assertAlmostEqual(arg, arg_ext)
         self.assertAlmostEqual(ta, ta_ext)
+
+    def test13(self):
+        """
+        tests generating cartesian coordinates from orbital elements
+        """
+        numpy.random.seed(17014)
+        N = 5
+
+        mass1 = 1.0 | units.MSun
+        mass2 = numpy.ones(N) * 0.01 | units.MEarth
+        sem = 2. | units.AU
+        ecc = 0.15
+        inc = 11. | units.deg
+        lon = 30. | units.deg
+        arg = 0.3 | units.deg
+        ta = (360.*random.random()-180.) | units.deg
+
+        rel_pos, rel_vel = rel_posvel_arrays_from_orbital_elements(
+                mass1,
+                mass2,
+                sem,
+                ecc,
+                ta,
+                inc,
+                lon,
+                arg,
+                G=constants.G)
+
+        mass_12 = mass1 + mass2
+        sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
+            orbital_elements_for_rel_posvel_arrays(
+                    rel_pos, rel_vel, mass_12, G=constants.G)
+
+        self.assertAlmostEqual(
+                sem.value_in(units.AU), sem_ext.value_in(units.AU))
+        self.assertAlmostEqual(ecc, ecc_ext)
+        self.assertAlmostEqual(inc, inc_ext)
+        self.assertAlmostEqual(lon, lon_ext)
+        self.assertAlmostEqual(arg, arg_ext)
+        self.assertAlmostEqual(ta, ta_ext)
+
+    def test14(self):
+        """
+        tests generating cartesian coordinates from orbital elements
+        """
+        numpy.random.seed(17018)
+        N = 5
+
+        mass1 = numpy.ones(N) * 1.0 | units.MSun
+        mass2 = random.random(N) | units.MEarth
+        sem = numpy.array([2., 1.0, 1.1, 1.2, 4.0]) | units.AU
+        ecc = numpy.array([0.15, 0.01, 0.5, 0.9, 0.99])
+        inc = numpy.array([11., 0.1, 20, 90, 180.]) | units.deg
+        lon = numpy.array([31., 32., 33., 45., 30.]) | units.deg
+        arg = numpy.array([0.3, 11., 15., 30., 95.]) | units.deg
+        ta = (360.*random.random(N)-180.) | units.deg
+
+        rel_pos, rel_vel = rel_posvel_arrays_from_orbital_elements(
+                mass1,
+                mass2,
+                sem,
+                ecc,
+                ta,
+                inc,
+                lon,
+                arg,
+                G=constants.G)
+
+        mass_12 = mass1 + mass2
+        sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
+            orbital_elements_for_rel_posvel_arrays(
+                    rel_pos, rel_vel, mass_12, G=constants.G)
+        self.assertAlmostEqual(
+                sem.value_in(units.AU), sem_ext.value_in(units.AU))
+        self.assertAlmostEqual(ecc, ecc_ext)
+        self.assertAlmostEqual(inc, inc_ext)
+        self.assertAlmostEqual(lon, lon_ext)
+        self.assertAlmostEqual(arg, arg_ext)
+        self.assertAlmostEqual(ta, ta_ext)

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -7,12 +7,10 @@ from amuse.test import amusetest
 
 from amuse.ext.orbital_elements import (
         new_binary_from_orbital_elements,
-        #~ orbital_elements_from_binary,
         get_orbital_elements_from_binary,
         orbital_elements_for_rel_posvel_arrays,
-        orbital_elements_from_arrays,
+        orbital_elements,
         rel_posvel_arrays_from_orbital_elements,
-        orbital_elements_from_binaries
         )
 
 from amuse.units import units
@@ -159,7 +157,7 @@ class KeplerTests(amusetest.TestCase):
                 mass1, mass2, semi_major_axis, eccentricity, true_anomaly,
                 inclination, longitude_of_the_ascending_node,
                 argument_of_periapsis):
-            arg_ = get_orbital_elements_from_binary(
+            arg_ = orbital_elements(
                     new_binary_from_orbital_elements(*arg))
             for i, (copy, org) in enumerate(zip(arg_, arg)):
                 self.assertAlmostEquals(copy, org)
@@ -183,7 +181,7 @@ class KeplerTests(amusetest.TestCase):
                 mass1, mass2, semi_major_axis, eccentricity, true_anomaly,
                 inclination, longitude_of_the_ascending_node,
                 argument_of_periapsis):
-            arg_ = get_orbital_elements_from_binary(
+            arg_ = orbital_elements(
                 new_binary_from_orbital_elements(*arg, G=constants.G),
                 G=constants.G)
             for i, (copy, org) in enumerate(zip(arg_, arg)):
@@ -452,7 +450,7 @@ class KeplerTests(amusetest.TestCase):
         
         semi_major_axis_ext, eccentricity_ext, ta_ext, inclination_ext, \
         longitude_of_the_ascending_node_ext, argument_of_periapsis_ext = \
-        orbital_elements_from_arrays(comets.position,
+        orbital_elements(comets.position,
                                                comets.velocity,
                                                comets.mass + mass_sun,
                                                G=constants.G)
@@ -492,7 +490,7 @@ class KeplerTests(amusetest.TestCase):
 
         mass_12 = mass1 + mass2
         sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
-            orbital_elements_from_arrays(
+            orbital_elements(
                     rel_pos, rel_vel, mass_12, G=constants.G)
 
         self.assertAlmostEqual(sem, sem_ext)
@@ -531,7 +529,7 @@ class KeplerTests(amusetest.TestCase):
 
         mass_12 = mass1 + mass2
         sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
-            orbital_elements_from_arrays(
+            orbital_elements(
                     rel_pos, rel_vel, mass_12, G=constants.G)
 
         self.assertAlmostEqual(
@@ -571,7 +569,7 @@ class KeplerTests(amusetest.TestCase):
 
         mass_12 = mass1 + mass2
         sem_ext, ecc_ext, ta_ext, inc_ext, lon_ext, arg_ext = \
-            orbital_elements_from_arrays(
+            orbital_elements(
                     rel_pos, rel_vel, mass_12, G=constants.G)
         self.assertAlmostEqual(
                 sem.value_in(units.AU), sem_ext.value_in(units.AU))
@@ -617,7 +615,7 @@ class KeplerTests(amusetest.TestCase):
 
         mass1_ext, mass2_ext, semi_major_axis_ext, eccentricity_ext, ta_ext,\
             inclination_ext, longitude_of_the_ascending_node_ext,\
-            argument_of_periapsis_ext = orbital_elements_from_binaries(
+            argument_of_periapsis_ext = orbital_elements(
                     suns, comets, G=constants.G)
         rad_to_deg = 180./numpy.pi
         for i in range(N):

--- a/test/ext_tests/test_orbital_elements.py
+++ b/test/ext_tests/test_orbital_elements.py
@@ -344,7 +344,7 @@ class KeplerTests(amusetest.TestCase):
             self.assertAlmostEqual(argument_of_periapsis[i],rad_to_deg*argument_of_periapsis_ext[i])
             self.assertAlmostEqual(true_anomaly[i],rad_to_deg*ta_ext[i])
 
-    def test10(self):
+    def xtest10(self):
         """
         testing orbital_elements_for_rel_posvel_arrays for N particles 
         with random orbital elements, unitless


### PR DESCRIPTION
- Fix old to-do: angles now use AMUSE units
- Use trigo functions from Amuse to make angles unit-aware

Possible danger: previous default for angles was in degrees. However, unitless angles will now be seen as radians.
Possible workaround: detect unitless angles somehow, and assign units.deg to those? Is this possible/desired?

Also, some code cleanup (indents to multiples of 4, get rid of too long lines) for improved readability