### PR TITLE
add option to ignore whether worker is present

### DIFF
--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -1061,10 +1061,12 @@ class AbstractMessageChannel(OptionalAttributes):
     def custom_args(self):
         return '--hold -e gdb --args'
     
-    
-        
     @option(type='boolean', sections=("channel",))
     def must_check_if_worker_is_up_to_date(self):
+        return True
+
+    @option(type='boolean', sections=("channel",))
+    def try_to_locate_worker(self):
         return True
     
     @option(type="int", sections=("channel",))
@@ -1122,6 +1124,8 @@ Please do a 'make clean; make' in the root directory.
         if len(self.worker_code_directory) > 0 and os.path.exists(self.worker_code_directory):
             full_name_of_the_worker = os.path.join(self.worker_code_directory, exe_name)
             full_name_of_the_worker = os.path.normpath(os.path.abspath(full_name_of_the_worker))
+            if not self.try_to_locate_worker:
+                return full_name_of_the_worker
             found = os.path.exists(full_name_of_the_worker)
             if not found:
                 tried_workers.append(full_name_of_the_worker)
@@ -1131,6 +1135,8 @@ Please do a 'make clean; make' in the root directory.
             directory_of_this_module = os.path.dirname(inspect.getfile(current_type))
             full_name_of_the_worker = os.path.join(directory_of_this_module, exe_name)
             full_name_of_the_worker = os.path.normpath(os.path.abspath(full_name_of_the_worker))
+            if not self.try_to_locate_worker:
+                return full_name_of_the_worker
             found = os.path.exists(full_name_of_the_worker)
             if not found:
                 tried_workers.append(full_name_of_the_worker)
@@ -1145,6 +1151,8 @@ Please do a 'make clean; make' in the root directory.
             full_name_of_the_worker = os.path.join(directory_of_this_module, '_workers', exe_name)
             full_name_of_the_worker = os.path.normpath(os.path.abspath(full_name_of_the_worker))
             
+            if not self.try_to_locate_worker:
+                return full_name_of_the_worker
             found = os.path.exists(full_name_of_the_worker)
             if not found:
                 raise exceptions.CodeException("The worker application does not exist, it should be at: \n{0}".format('\n'.join(tried_workers)))

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -1108,7 +1108,7 @@ Please do a 'make clean; make' in the root directory.
 """.format(type(object).__name__))
 
     def get_full_name_of_the_worker(self, type):
-        
+
         if os.path.isabs(self.name_of_the_worker):
             if os.path.exists(self.name_of_the_worker):
                 if not os.access(self.name_of_the_worker, os.X_OK):
@@ -1120,8 +1120,8 @@ Please do a 'make clean; make' in the root directory.
         
         tried_workers = []
         found = False
-        
-        if len(self.worker_code_directory) > 0 and os.path.exists(self.worker_code_directory):
+                
+        if len(self.worker_code_directory) > 0:
             full_name_of_the_worker = os.path.join(self.worker_code_directory, exe_name)
             full_name_of_the_worker = os.path.normpath(os.path.abspath(full_name_of_the_worker))
             if not self.try_to_locate_worker:

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -1115,11 +1115,13 @@ Please do a 'make clean; make' in the root directory.
             if not self.check_worker_location:
                 return full_name_of_the_worker
             
-            if os.path.exists(full_name_of_the_worker):
-                if not os.access(self.full_name_of_the_worker, os.X_OK):
-                    raise exceptions.CodeException("The worker application exists, but it is not executable.\n{0}".format(self.name_of_the_worker))
+            if not os.path.exists(full_name_of_the_worker):
+                raise exceptions.CodeException("The worker path has been specified, but it is not found: \n{0}".format(full_name_of_the_worker))
+
+            if not os.access(full_name_of_the_worker, os.X_OK):
+                raise exceptions.CodeException("The worker application exists, but it is not executable.\n{0}".format(full_name_of_the_worker))
        
-                return self.name_of_the_worker
+            return full_name_of_the_worker
         
         exe_name = self.worker_code_prefix + self.name_of_the_worker + self.worker_code_suffix
 


### PR DESCRIPTION
this is a harmless hack to allow the startup of a code from a containerized AMUSE install (from outside this container), for example :
```
s=SSE(channel_type="sockets",debugger="custom",
      custom_exe="singularity", 
      custom_args="exec ./ipelupessy-amuse-singularity-master-42.3.simg",
      worker_code_directory="/usr/lib/python2.7/site-packages/amuse/_workers/",
      must_check_if_worker_is_up_to_date=False,
      try_to_locate_worker=False )
```
the worker_code_directory specifies the location within the container, the two other options are necessary to skip check, since we do not look inside of the container atm
(such checks could also be added ofcourse) 