### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Logs**
+If applicable, add logfiles to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS and version: [e.g. macOS High Sierra; Ubuntu Linux 17.10]
+ - Compiler: [e.g. gcc6]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a feature or improvement for AMUSE
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or logfiles about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-issue.md
@@ -1,0 +1,7 @@
+---
+name: Other issue
+about: Report an issue that is not a feature request or bug report
+
+---
+
+


### PR DESCRIPTION
Adds templates for creating issues (per the github recommended community standards):
- bug report
- feature request
- other

This may help create clearer issues, which could reduce the time needed to close them.