### PR TITLE
Use explicit integer division

### DIFF
--- a/src/amuse/io/base.py
+++ b/src/amuse/io/base.py
@@ -493,7 +493,7 @@ class FortranFileFormatProcessor(BinaryFileFormatProcessor):
         
     def read_fortran_block_float_vectors(self, file, size = 3):
         result = self.read_fortran_block_floats(file)
-        return result.reshape(len(result)/size,size)
+        return result.reshape(len(result)//size,size)
         
     def write_fortran_block(self, file, input):
         format = self.endianness+'I'


### PR DESCRIPTION
Recent versions of NumPy don't accept a floating point number as input
to reshape (and will thus not automatically truncate and convert a
float to an integer). Using an explicit integer division avoids errors
with this.

Fixes issue #259.