### PR TITLE
fixes for VectorQuantity and as_vector_quantity

### DIFF
--- a/src/amuse/datamodel/memory_storage.py
+++ b/src/amuse/datamodel/memory_storage.py
@@ -126,6 +126,7 @@ class InMemoryAttributeStorage(AttributeStorage):
             try:
                 storage.set_values(indices, values_to_set)
             except ValueError as ex:
+                raise Exception("unexpectedly not dead code path....")
                 # hack to set values between 
                 # with quanities with units.none
                 # and when values are stored without units

--- a/src/amuse/units/quantities.py
+++ b/src/amuse/units/quantities.py
@@ -625,6 +625,7 @@ class VectorQuantity(Quantity):
         >>> print vector
         [0.0, 3.5, 2.0] kg
         """
+        quantity = as_vector_quantity(quantity)
         if self.unit.is_zero():
             self.unit = quantity.unit
         self._number[index] = quantity.value_in(self.unit)
@@ -1239,15 +1240,16 @@ def is_unit(input):
         return False
 
 def as_vector_quantity(value):
-    if not is_quantity(value):
-        if hasattr(value, "__iter__"):
+    if is_quantity(value): 
+        return value
+    else:
+        if isinstance(value, __array_like):
             result = AdaptingVectorQuantity()
             for subvalue in value:
                 result.append(as_vector_quantity(subvalue))
             return result
         else:
-            raise Exception("Cannot convert '{0!r}' to a vector quantity".format(value))
-    return value
+            return new_quantity(value, none)
 
 def to_quantity(input):
     if is_quantity(input):


### PR DESCRIPTION
tricky fix because changes some behaviour in setting attributes also

this fixes #290 and #291 (ie makes this questionable behaviour somewhat well behaved), but has side effects, for example: p.mass =1 results in mass becoming 1 | units.none (ie automatically units attached)
this comes from the check_attributes method..needs to be investigated further...