### PR TITLE
print (read only) behind read only parameters

### DIFF
--- a/src/amuse/datamodel/parameters.py
+++ b/src/amuse/datamodel/parameters.py
@@ -75,7 +75,10 @@ class Parameters(object):
 
         for name in sorted(self.names()):
             output += name + ": "
-            output += str(getattr(self, name))+"\n"
+            output += str(getattr(self, name))
+            if self.get_parameter(name).is_readonly():
+                output += "  (read only)"
+            output += "\n"
 
         return output
 


### PR DESCRIPTION
this proposed change to the parameter print functionality prints out some more information (the read only status) for a parameter

not sure if there is anything that depends on the exact output string format that might make this a bad idea
(maybe some test need to be changed)