### PR TITLE
Multiple parameter sets

### DIFF
--- a/src/amuse/support/interface.py
+++ b/src/amuse/support/interface.py
@@ -860,7 +860,7 @@ class HandleParameters(HandleCodeInterfaceAttributeAccess):
     def __init__(self, interface):
         self.property_definitions = {}
         self.interface = interface
-        self.definitions = defaultdict(list,parameters=[])
+        self.definitions = defaultdict(list)
         self.parameters = {}
 
     def supports(self, name, was_found):
@@ -868,8 +868,8 @@ class HandleParameters(HandleCodeInterfaceAttributeAccess):
 
     def get_attribute(self, name, value):
         if not self.parameters:
-            for n,d in self.definitions.iteritems():
-                self.parameters[n] =  parameters.new_parameters_instance_with_docs(d, self.interface)
+            for n in self.definitions or ['parameters']:
+                self.parameters[n] =  parameters.new_parameters_instance_with_docs(self.definitions[n], self.interface)
        
         return self.parameters[name or 'parameters']
 


### PR DESCRIPTION
this patchset allows the definition of multiple parameter sets on a code as a means to organize large parameter sets.

The rationale is that this is simialr for compound codes when e.g.
code.gas_parameters -> referal to code.gas_code.parameters
code.grav_parameters -> etc

defines parameter_set_names() function 

I am not sure yet if this is worth the complication