### PR TITLE
added citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -53,7 +53,15 @@
         }, 
         {
             "affiliation": "Leiden University", 
+            "name": "van der Helm, Edwin"
+        }, 
+        {
+            "affiliation": "Leiden University", 
             "name": "Beedorf, Jeroen"
+        }, 
+        {
+            "affiliation": "Netherlands eScience Center", 
+            "name": "Bos, Patrick"
         }, 
         {
             "affiliation": "Leiden University", 
@@ -61,11 +69,47 @@
         }, 
         {
             "affiliation": "Netherlands eScience Center", 
-            "name": "Bos, Patrick"
+            "name": "van Werkhoven, Ben"
         }, 
         {
-            "affiliation": "Netherlands eScience Center", 
-            "name": "van Werkhoven, Ben"
+            "affiliation": "Leiden University", 
+            "name": "Wijnen, Thomas"
+        }, 
+        {
+            "affiliation": "Institute for Advanced Study", 
+            "name": "Hamers, Adrian"
+        }, 
+        {
+            "affiliation": "Booking.com", 
+            "name": "Caputo, Daniel"
+        }, 
+        {
+            "affiliation": "Leiden University", 
+            "name": "Ferrari, Guilherme"
+        }, 
+        {
+            "affiliation": "University of Amsterdam", 
+            "name": "Toonen, Silvia"
+        }, 
+        {
+            "affiliation": "Nvidia", 
+            "name": "Gaburov, Evghenii"
+        }, 
+        {
+            "affiliation": "TNO", 
+            "name": "Paardekooper, Jan-Pieter"
+        }, 
+        {
+            "affiliation": "University of Cambridge", 
+            "name": "Janes, Jurgen"
+        }, 
+        {
+            "affiliation": "Quintel Intellegence", 
+            "name": "Kruip, Chael"
+        }, 
+        {
+            "affiliation": "Georgia Institute of Technology", 
+            "name": "Altay, Gabriel"
         }
     ], 
     "description": "\"<p>\nAstrophysical Multipurpose Software Environment\n</p>\n<p>\nCombine existing numerical codes in an easy to use Python framework. With AMUSE you can simulate objects such as star clusters, proto-planetary disks and galaxies.\n</p>\n<p>\nWhat AMUSE can do for you:\n</p>\n<ul>\n<li>provides a homogeneous environment to design astrophysical simulations used by students and researchers</li>\n<li>couples different simulation codes in a Python environment to be run locally or distributed</li>\n<li>provides a very easy way to solve astronomical problems that involve complicated physical interactions</li>\n<li>used for more than 40 scientific papers and PhD theses</li>\n</ul>\"\n", 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -18,6 +18,7 @@
             "orcid": "0000-0001-5839-0302"
         },
         {
+            "affiliation": "University of Exeter",
             "name": "Rieder, Steven",
             "orcid": "0000-0003-3688-5798"
         },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,46 +1,85 @@
 {
     "creators": [
         {
-            "affiliation": "Netherlands eScience Center",
-            "name": "Pelupessy, Inti"
-        },
-        {
-            "affiliation": "Leiden University",
-            "name": "van Elteren, Arjen"
-        },
-        {
-            "affiliation": "Drexel University",
-            "name": "McMillan, Steve"
-        },
-        {
-            "affiliation": "Leiden University",
-            "name": "Portegies Zwart, Simon",
+            "affiliation": "Leiden University", 
+            "name": "Portegies Zwart, Simon", 
             "orcid": "0000-0001-5839-0302"
-        },
+        }, 
         {
-            "affiliation": "University of Exeter",
-            "name": "Rieder, Steven",
+            "affiliation": "Leiden University", 
+            "name": "van Elteren, Arjen"
+        }, 
+        {
+            "affiliation": "Netherlands eScience Center", 
+            "name": "Pelupessy, Inti"
+        }, 
+        {
+            "affiliation": "Drexel University", 
+            "name": "McMillan, Steve"
+        }, 
+        {
+            "affiliation": "University of Exeter", 
+            "name": "Rieder, Steven", 
             "orcid": "0000-0003-3688-5798"
-        },
+        }, 
         {
-            "affiliation": "Netherlands eScience Center",
-            "name": "Bos, Patrick"
-        },
+            "affiliation": "Leiden University", 
+            "name": "de Vries, Nathan"
+        }, 
         {
-            "affiliation": "Netherlands eScience Center",
-            "name": "Drost, Niels",
+            "affiliation": "Leiden University", 
+            "name": "Marosvolgyi, Marcell"
+        }, 
+        {
+            "affiliation": "Drexel University", 
+            "name": "Whitehead, Alfred"
+        }, 
+        {
+            "affiliation": "Drexel University", 
+            "name": "Wall, Joshua"
+        }, 
+        {
+            "affiliation": "Netherlands eScience Center", 
+            "name": "Drost, Niels", 
             "orcid": "0000-0001-9795-7981"
+        }, 
+        {
+            "affiliation": "Leiden University", 
+            "name": "Jilkova, Lucie"
+        }, 
+        {
+            "affiliation": "Leiden University", 
+            "name": "Martinez Barbosa, Carmen"
+        }, 
+        {
+            "affiliation": "Leiden University", 
+            "name": "Beedorf, Jeroen"
+        }, 
+        {
+            "affiliation": "Leiden University", 
+            "name": "Boekholt, Tjarda"
+        }, 
+        {
+            "affiliation": "Netherlands eScience Center", 
+            "name": "Bos, Patrick"
+        }, 
+        {
+            "affiliation": "Netherlands eScience Center", 
+            "name": "van Werkhoven, Ben"
         }
-    ],
-    "description": "<p>Astrophysical Multipurpose Software Environment</p><p>Combine existing numerical codes in an easy to use Python framework. With AMUSE you can simulate objects such as star clusters, proto-planetary disks and galaxies.</p><p>What AMUSE can do for you:</p><ul><li>provides a homogeneous environment to design astrophysical simulations used by students and researchers</li><li>couples different simulation codes in a Python environment to be run locally or distributed</li><li>provides a very easy way to solve astronomical problems that involve complicated physical interactions</li><li>used for more than 40 scientific papers and PhD theses</li></ul>",
+    ], 
+    "description": "\"<p>\nAstrophysical Multipurpose Software Environment\n</p>\n<p>\nCombine existing numerical codes in an easy to use Python framework. With AMUSE you can simulate objects such as star clusters, proto-planetary disks and galaxies.\n</p>\n<p>\nWhat AMUSE can do for you:\n</p>\n<ul>\n<li>provides a homogeneous environment to design astrophysical simulations used by students and researchers</li>\n<li>couples different simulation codes in a Python environment to be run locally or distributed</li>\n<li>provides a very easy way to solve astronomical problems that involve complicated physical interactions</li>\n<li>used for more than 40 scientific papers and PhD theses</li>\n</ul>\"\n", 
+    "doi": "10.5281/zenodo.1435860", 
     "keywords": [
-        "astronomy",
-        "multi-model simulation",
-        "model coupling",
+        "astronomy", 
+        "multi-model simulation", 
+        "model coupling", 
         "physics"
-    ],
+    ], 
     "license": {
         "id": "Apache-2.0"
-    },
-    "title": "AMUSE"
+    }, 
+    "publication_date": "2018-09-27", 
+    "title": "AMUSE", 
+    "version": "11.3"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -104,6 +104,10 @@
             "name": "Janes, Jurgen"
         }, 
         {
+            "affiliation": "University of Groningen", 
+            "name": "Punzo, Davide"
+        }, 
+        {
             "affiliation": "Quintel Intellegence", 
             "name": "Kruip, Chael"
         }, 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,37 +18,76 @@ abstract: |
     </ul>"
 authors: 
   -
-    affiliation: "Netherlands eScience Center"
-    family-names: Pelupessy
-    given-names: Inti
+    affiliation: "Leiden University"
+    family-names: "Portegies Zwart"
+    given-names: Simon
+    orcid: "https://orcid.org/0000-0001-5839-0302"
   -
     affiliation: "Leiden University"
     family-names: Elteren
     given-names: Arjen
     name-particle: van
   -
+    affiliation: "Netherlands eScience Center"
+    family-names: Pelupessy
+    given-names: Inti
+  -
     affiliation: "Drexel University"
     family-names: McMillan
     given-names: Steve
-  -
-    affiliation: "Leiden University"
-    family-names: "Portegies Zwart"
-    given-names: Simon
-    orcid: "https://orcid.org/0000-0001-5839-0302"
   -
     affiliation: "University of Exeter"
     family-names: Rieder
     given-names: Steven
     orcid: "https://orcid.org/0000-0003-3688-5798"
   -
-    affiliation: "Netherlands eScience Center"
-    family-names: Bos
-    given-names: Patrick
+    affiliation: "Leiden University"
+    family-names: de Vries
+    given-names: Nathan
+  -
+    affiliation: "Leiden University"
+    family-names: Marosvolgyi
+    given-names: Marcell
+  -
+    affiliation: "Drexel University"
+    family-names: Whitehead
+    given-names: Alfred
+  -
+    affiliation: "Drexel University"
+    family-names: Wall
+    given-names: Joshua
   -
     affiliation: "Netherlands eScience Center"
     family-names: Drost
     given-names: Niels
     orcid: "https://orcid.org/0000-0001-9795-7981"
+  -
+    affiliation: "Leiden University"
+    family-names: Jilkova
+    given-names: Lucie
+  -
+    affiliation: "Leiden University"
+    family-names: Martinez Barbosa
+    given-names: Barbosa
+  -
+    affiliation: "Leiden University"
+    family-names: Beedorf
+    given-names: Jeroen
+  -
+    affiliation: "Leiden University"
+    family-names: Boekholt
+    given-names: Tjarda
+  -
+    affiliation: "Netherlands eScience Center"
+    family-names: Bos
+    given-names: Patrick
+  -
+    affiliation: "Netherlands eScience Center"
+    family-names: Werkhoven
+    given-names: Ben
+    name-particle: van
+
+
 cff-version: "1.0.3"
 date-released: 2018-09-27
 doi: "10.5281/zenodo.1435860"
@@ -58,7 +97,8 @@ keywords:
   - "model coupling"
   - physics
 license: "Apache-2.0"
-message: "If you use this software, please cite it using these metadata."
+message: "This is the software citation for the framework code. If you publish work
+with AMUSE please cite also the code papers of the components used."
 repository-code: "https://github.com/amusecode/amuse"
 title: AMUSE
 version: "11.3"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -71,21 +71,65 @@ authors:
     given-names: Carmen
   -
     affiliation: "Leiden University"
+    family-names: van der Helm
+    given-names: Edwin
+  -
+    affiliation: "Leiden University"
     family-names: Beedorf
     given-names: Jeroen
+  -
+    affiliation: "Netherlands eScience Center"
+    family-names: Bos
+    given-names: Patrick
   -
     affiliation: "Leiden University"
     family-names: Boekholt
     given-names: Tjarda
   -
     affiliation: "Netherlands eScience Center"
-    family-names: Bos
-    given-names: Patrick
-  -
-    affiliation: "Netherlands eScience Center"
     family-names: Werkhoven
     given-names: Ben
     name-particle: van
+  -
+    affiliation: "Leiden University"
+    family-names: Wijnen
+    given-names: Thomas
+  -
+    affiliation: "Institute for Advanced Study"
+    family-names: Hamers
+    given-names: Adrian
+  -
+    affiliation: "Booking.com"
+    family-names: Caputo
+    given-names: Daniel
+  -
+    affiliation: "Leiden University"
+    family-names: Ferrari
+    given-names: Guilherme
+  -
+    affiliation: "University of Amsterdam"
+    family-names: Toonen
+    given-names: Silvia
+  -
+    affiliation: "Nvidia"
+    family-names: Gaburov
+    given-names: Evghenii
+  -
+    affiliation: "TNO"
+    family-names: Paardekooper
+    given-names: Jan-Pieter
+  -
+    affiliation: "University of Cambridge"
+    family-names: Janes
+    given-names: Jurgen
+  -
+    affiliation: "Quintel Intellegence"
+    family-names: Kruip
+    given-names: Chael
+  -
+    affiliation: "Georgia Institute of Technology"
+    family-names: Altay
+    given-names: Gabriel
 
 
 cff-version: "1.0.3"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -36,6 +36,7 @@ authors:
     given-names: Simon
     orcid: "https://orcid.org/0000-0001-5839-0302"
   -
+    affiliation: "University of Exeter"
     family-names: Rieder
     given-names: Steven
     orcid: "https://orcid.org/0000-0003-3688-5798"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -123,6 +123,10 @@ authors:
     family-names: Janes
     given-names: Jurgen
   -
+    affiliation: "University of Groningen"
+    family-names: Punzo
+    given-names: Davide
+  -
     affiliation: "Quintel Intellegence"
     family-names: Kruip
     given-names: Chael

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -68,7 +68,7 @@ authors:
   -
     affiliation: "Leiden University"
     family-names: Martinez Barbosa
-    given-names: Barbosa
+    given-names: Carmen
   -
     affiliation: "Leiden University"
     family-names: Beedorf


### PR DESCRIPTION
Hi @ipelupessy,

this PR adds a CITATION.cff metadata file for citation. I then used ``cffconvert`` from PyPI to generate a ``.zenodo.json`` from it, such that we can tell Zenodo about the metadata we want to associate with each release.

The set of authors in CITATION.cff needs checking, in order to determine we included the correct people. I don't know if you want to include all commiters as well, although I feel including them is a token of appreciation for their work. BTW I used the order given here https://github.com/amusecode/amuse/graphs/contributors to determine the order the authors should be in.

Also, please check the orcids and affiliations (i just did a superficial search which hopefully led me to the right people, but it's worth checking.)

Finally, the metadata assumes that there will be another (pre)release ...today. I've labeled it ``11.3`` to be consistent with your naming scheme.

Let me know if I can help with anything,
-Jurriaan