### PR TITLE
Make examples/simple scripts more compliant with the AMUSE code style guide

### DIFF
--- a/examples/simple/agb.py
+++ b/examples/simple/agb.py
@@ -8,7 +8,7 @@ from matplotlib import pyplot
 
 from amuse.community.sse.interface import SSE
 from amuse.units import units
-from amuse.ext import solarsystem
+# from amuse.ext import solarsystem
 
 from amuse import datamodel
 

--- a/examples/simple/agb.py
+++ b/examples/simple/agb.py
@@ -12,37 +12,41 @@ from amuse.ext import solarsystem
 
 from amuse import datamodel
 
+
 def plottillagb():
     sun = datamodel.Particle(
-        mass = 1 | units.MSun,
-        radius = 1 | units.RSun
+        mass=1 | units.MSun,
+        radius=1 | units.RSun
     )
-    
+
     sse = SSE()
     sse.particles.add_particle(sun)
-    
+
     channel_from_se_to_memory = sse.particles.new_channel_to(sun.as_set())
     channel_from_se_to_memory.copy()
-    
-    masses = []|units.MSun
 
-    timerange = numpy.arange(11500, 13500,10) | units.Myr
+    masses = [] | units.MSun
+
+    timerange = numpy.arange(11500, 13500, 10) | units.Myr
     for time in timerange:
         sse.evolve_model(time)
         channel_from_se_to_memory.copy()
         masses.append(sun.mass)
-        print(time.as_quantity_in(units.Myr), sun.mass.as_quantity_in(units.MSun))
-        
+        print(time.as_quantity_in(units.Myr),
+              sun.mass.as_quantity_in(units.MSun))
+
     sse.stop()
-    
-    figure = pyplot.figure(figsize= (6,6))
-    
+
+    figure = pyplot.figure(figsize=(6, 6))
+
     subplot = figure.add_subplot(1, 1, 1)
-    subplot.plot(timerange.value_in(units.Gyr), masses.value_in(units.MSun),'.')
+    subplot.plot(timerange.value_in(units.Gyr),
+                 masses.value_in(units.MSun), '.')
     subplot.set_xlabel('t (Gyr)')
     subplot.set_ylabel('mass (MSun)')
-    
+
     pyplot.show()
+
 
 if __name__ == '__main__':
     plottillagb()

--- a/examples/simple/binary_population_synthesis.py
+++ b/examples/simple/binary_population_synthesis.py
@@ -17,6 +17,7 @@ import time
 
 USE_VECTOR_OPERATIONS = True
 
+
 def multidimensional_meshgrid(*arrays):
     """
     Utitility function to create a multidimensional grid based
@@ -30,8 +31,8 @@ def multidimensional_meshgrid(*arrays):
     size = 1
     for length in lengths:
         size *= length
-        
-    result = []    
+
+    result = []
     for i, quantity in enumerate(reversed_quantities):
         shape = numpy.ones(dim, dtype=numpy.int)
         shape[i] = lengths[i]
@@ -42,15 +43,15 @@ def multidimensional_meshgrid(*arrays):
         array = array.reshape(shape)
         for j, length in enumerate(lengths):
             if j != i:
-                array = array.repeat(length, axis=j) 
-        
-        
+                array = array.repeat(length, axis=j)
+
         if quantities.is_quantity(quantity):
             result.append(quantity.unit.new_quantity(array))
         else:
             result.append(array)
 
     return tuple(result[::-1])
+
 
 def create_binary(stars, binaries, primary_mass, mass_ratio, separation, eccentricity):
     """
@@ -60,30 +61,30 @@ def create_binary(stars, binaries, primary_mass, mass_ratio, separation, eccentr
     """
     primary_star = datamodel.Particle()
     primary_star.mass = primary_mass
-    
+
     # we add the particle to the stars set
     # and we get a reference to the particle in the stars set
     # back
     # we want to use that star in constructing the
-    # binary, so that the binaries all refer to 
+    # binary, so that the binaries all refer to
     # the stars in the "stars set"
     primary_star = stars.add_particle(primary_star)
-    
+
     secondary_star = datamodel.Particle()
     secondary_star.mass = primary_mass * mass_ratio
     secondary_star = stars.add_particle(secondary_star)
-    
+
     binary = datamodel.Particle()
     binary.eccentricity = eccentricity
     binary.semi_major_axis = separation
     binary.child1 = primary_star
     binary.child2 = secondary_star
-    
+
     binaries.add_particle(binary)
-    
-    
+
+
 def generate_initial_population_grid(
-    min_mass, max_mass, number_of_mass_bins, 
+    min_mass, max_mass, number_of_mass_bins,
     min_ratio, max_ratio, number_of_ratio_bins,
     min_separation, max_separation, number_of_separation_bins,
     min_eccentricity, max_eccentricity, number_of_eccentricity_bins
@@ -94,36 +95,42 @@ def generate_initial_population_grid(
     ratio and separation), the total number of binaries will
     be the product of all bins.
     """
-    
-    # quantities.linspace takes care of the units, 
+
+    # quantities.linspace takes care of the units,
     # but is otherwhise equal to numpy.arange
-    primary_masses  = quantities.linspace(min_mass, max_mass, number_of_mass_bins)
-    mass_ratios = quantities.linspace(min_ratio, max_ratio, number_of_ratio_bins)
-    separations = quantities.linspace(min_separation, max_separation, number_of_separation_bins)
-    eccentricities = quantities.linspace(min_eccentricity, max_eccentricity, number_of_eccentricity_bins)
-    
+    primary_masses = quantities.linspace(
+        min_mass, max_mass, number_of_mass_bins)
+    mass_ratios = quantities.linspace(
+        min_ratio, max_ratio, number_of_ratio_bins)
+    separations = quantities.linspace(
+        min_separation, max_separation, number_of_separation_bins)
+    eccentricities = quantities.linspace(
+        min_eccentricity, max_eccentricity, number_of_eccentricity_bins)
+
     # We can create the binaries individualy (with nested for loops to
     # go through each dimension) or at once with vector operations.
     # As vector operations are handled by numpy (in C) these are
     # much faster (default in this script).
     if USE_VECTOR_OPERATIONS is True:
-        grid = multidimensional_meshgrid(primary_masses, mass_ratios, separations, eccentricities)
-        
+        grid = multidimensional_meshgrid(
+            primary_masses, mass_ratios, separations, eccentricities)
+
         all_primary_masses = grid[0].flatten()
-        all_mass_ratios    = grid[1].flatten()
-        all_separations    = grid[2].flatten()
+        all_mass_ratios = grid[1].flatten()
+        all_separations = grid[2].flatten()
         all_eccentricities = grid[3].flatten()
-        
-        primary_stars   = datamodel.Particles(mass=all_primary_masses)
-        secondary_stars = datamodel.Particles(mass=all_primary_masses * all_mass_ratios)
-        
+
+        primary_stars = datamodel.Particles(mass=all_primary_masses)
+        secondary_stars = datamodel.Particles(
+            mass=all_primary_masses * all_mass_ratios)
+
         stars = datamodel.Particles()
-        primary_stars   = stars.add_particles(primary_stars)
+        primary_stars = stars.add_particles(primary_stars)
         secondary_stars = stars.add_particles(secondary_stars)
-        
+
         binaries = datamodel.Particles(
-            semi_major_axis = all_separations,
-            eccentricity    = all_eccentricities
+            semi_major_axis=all_separations,
+            eccentricity=all_eccentricities
         )
         binaries.child1 = list(primary_stars)
         binaries.child2 = list(secondary_stars)
@@ -131,71 +138,72 @@ def generate_initial_population_grid(
         for primary_mass in primary_masses:
             for mass_ratio in mass_ratios:
                 for separation in separations:
-                    for eccentricity in eccentricities :
+                    for eccentricity in eccentricities:
                         create_binary(
-                            stars, 
-                            binaries, 
-                            primary_mass, 
-                            mass_ratio, 
-                            separation, 
+                            stars,
+                            binaries,
+                            primary_mass,
+                            mass_ratio,
+                            separation,
                             eccentricity
                         )
-                
+
     return binaries, stars
+
 
 def evolve_population(binaries, stars, end_time, time_step):
     code = SeBa()
-    
+
     # add the stars first, as the binaries will
     # refer to them
     code.particles.add_particles(stars)
     code.binaries.add_particles(binaries)
-    
-    
-    channel_from_code_to_model_for_binaries = code.binaries.new_channel_to(binaries)
+
+    channel_from_code_to_model_for_binaries = code.binaries.new_channel_to(
+        binaries)
     channel_from_code_to_model_for_stars = code.particles.new_channel_to(stars)
-    
-    #we evolve in steps of timestep, just to get some feedback
+
+    # we evolve in steps of timestep, just to get some feedback
     print("start evolving...")
     time = 0.0 * end_time
     while time < end_time:
         time += time_step
         code.evolve_model(time)
         print("evolved to time: ", time.as_quantity_in(units.Myr))
-        
+
     channel_from_code_to_model_for_stars.copy()
     channel_from_code_to_model_for_binaries.copy()
-    
+
+
 def make_hr_diagram(binaries):
-    pyplot.figure(figsize = (8,8))
+    pyplot.figure(figsize=(8, 8))
     pyplot.title('Binary population', fontsize=12)
     separation = binaries.semi_major_axis.value_in(units.RSun)
     eccentricity = binaries.eccentricity
     pyplot.hexbin(
         separation,
         eccentricity,
-        gridsize = 40,
-        bins = 'log',
-        extent = (0, 100, 0.0, 0.9)
+        gridsize=40,
+        bins='log',
+        extent=(0, 100, 0.0, 0.9)
     )
     pyplot.xlabel('semi major axis (AU)')
     pyplot.ylabel('eccentricity')
     pyplot.show()
-    
+
 
 if __name__ == "__main__":
     print("generating a binary population...")
-    
+
     binaries, stars = generate_initial_population_grid(
-        0.5 | units.MSun, 1.5 | units.MSun, 3, #mass range
-        0.9, 0.9, 1,                           #mass ratios range
-        10 | units.RSun, 100 | units.RSun, 120,    #semi major axis range
-        0.0 , 1.0, 120                          #eccentricity range
+        0.5 | units.MSun, 1.5 | units.MSun, 3,  # mass range
+        0.9, 0.9, 1,  # mass ratios range
+        10 | units.RSun, 100 | units.RSun, 120,  # semi major axis range
+        0.0, 1.0, 120  # eccentricity range
     )
-    
+
     print("generated a population of", len(binaries), "binaries")
-    
+
     evolve_population(binaries, stars,  1 | units.Gyr, 250 | units.Myr)
-    
+
     make_hr_diagram(binaries)
-    

--- a/examples/simple/binary_population_synthesis.py
+++ b/examples/simple/binary_population_synthesis.py
@@ -8,12 +8,12 @@ from amuse.units import units
 from amuse.units import quantities
 from amuse import datamodel
 from amuse.community.seba.interface import SeBa
-from amuse.community.bse.interface import BSE
+# from amuse.community.bse.interface import BSE
 
 from matplotlib import pyplot
 
 import numpy
-import time
+# import time
 
 USE_VECTOR_OPERATIONS = True
 
@@ -21,7 +21,7 @@ USE_VECTOR_OPERATIONS = True
 def multidimensional_meshgrid(*arrays):
     """
     Utitility function to create a multidimensional grid based
-    on a list of arrays. Each array defines a 
+    on a list of arrays. Each array defines a
     range in one dimension.
     """
     reversed_quantities = tuple(reversed(arrays))
@@ -53,7 +53,8 @@ def multidimensional_meshgrid(*arrays):
     return tuple(result[::-1])
 
 
-def create_binary(stars, binaries, primary_mass, mass_ratio, separation, eccentricity):
+def create_binary(
+        stars, binaries, primary_mass, mass_ratio, separation, eccentricity):
     """
     creates a single binary, the constituent stars will be accumulated
     in the stars partice set, the binary will be added to the binaries

--- a/examples/simple/boss_bodenheimer_test.py
+++ b/examples/simple/boss_bodenheimer_test.py
@@ -36,128 +36,134 @@ from amuse.ext.evrard_test import body_centered_grid_unit_cube
 
 from amuse.community.fi.interface import Fi
 
-rc('font',**{'family':'sans-serif','sans-serif':['Helvetica']})
+rc('font', **{'family': 'sans-serif', 'sans-serif': ['Helvetica']})
 rc('text', usetex=True)
 
-def get_grid_posvel(N=100, grid_size= 1 | units.parsec):
-  """ 
-  gives x,y(,z,vx,vy,vz) Cartesian coordinate grid (where z=0, vx=vy=vz=0)
-  -- for plotting SPH quantities in the xy plane
-  -- N points on each axis; size of the grid 'grid_size' for x and y 
-  """
-  
-  cell_center_positions_1d = numpy.linspace(-0.5, 0.5, N)
-  x,y = numpy.meshgrid(cell_center_positions_1d, cell_center_positions_1d)
-  x = x.flatten()
-  y = y.flatten()
-    
-  x *= grid_size
-  y *= grid_size
-  z = x * 0.0
-    
-  vx=0.0 * x / (1.0 | units.s)
-  vy=0.0 * x / (1.0 | units.s)
-  vz=0.0 * x / (1.0 | units.s)
-  
-  return x,y,z,vx,vy,vz
 
-def plot_sph_rho(sph, N=100, grid_size= 1 | units.parsec, 
-                 plot_name = "cloud_plot_rho.png", plot_title = "SPH density"):
-  """
-  plots the log10(SPH density) in the xy plane 
-  input: sph -- set of sph particles 
-    N -- number of grid points (in x and y)
-    grid_size -- size of the grid (x and y)
-    plot_name -- name for the output figure
-    plot_title -- title of the plot
-  """
-  # getting the grid
-  x,y,z,vx,vy,vz = get_grid_posvel(N, grid_size)
-  
-  # getting density from the SPH data
-  rho,rhovx,rhovy,rhovz,rhoe=sph.get_hydro_state_at_point(x,y,z,vx,vy,vz)
-  rho=rho.reshape((N,N))
-  
-  # plotting
-  extent = (grid_size * (-0.5, 0.5, -0.5, 0.5)).value_in(units.parsec)
-  pyplot.figure(figsize=(5,5.2))
-  pyplot.imshow(numpy.log10(rho.value_in(units.amu/units.cm**3)),
-                extent = extent)
-  pyplot.title(plot_title)
-  #pyplot.xlabel('x [pc]')
-  #pyplot.ylabel('y [pc]')
-  frame = pyplot.gca()
-  frame.axes.get_xaxis().set_visible(False)
-  frame.axes.get_yaxis().set_visible(False)
-  cbar = pyplot.colorbar()
-  cbar.set_label(r'$\log (\rho [\mathrm{amu}/\mathrm{cm}^3])$')
-  pyplot.tight_layout()
-  
-  pyplot.savefig(plot_name)
-  #pyplot.show()
+def get_grid_posvel(N=100, grid_size=1 | units.parsec):
+    """ 
+    gives x,y(,z,vx,vy,vz) Cartesian coordinate grid (where z=0, vx=vy=vz=0)
+    -- for plotting SPH quantities in the xy plane
+    -- N points on each axis; size of the grid 'grid_size' for x and y 
+    """
+
+    cell_center_positions_1d = numpy.linspace(-0.5, 0.5, N)
+    x, y = numpy.meshgrid(cell_center_positions_1d, cell_center_positions_1d)
+    x = x.flatten()
+    y = y.flatten()
+
+    x *= grid_size
+    y *= grid_size
+    z = x * 0.0
+
+    vx = 0.0 * x / (1.0 | units.s)
+    vy = 0.0 * x / (1.0 | units.s)
+    vz = 0.0 * x / (1.0 | units.s)
+
+    return x, y, z, vx, vy, vz
+
+
+def plot_sph_rho(sph, N=100, grid_size=1 | units.parsec,
+                 plot_name="cloud_plot_rho.png", plot_title="SPH density"):
+    """
+    plots the log10(SPH density) in the xy plane 
+    input: sph -- set of sph particles 
+      N -- number of grid points (in x and y)
+      grid_size -- size of the grid (x and y)
+      plot_name -- name for the output figure
+      plot_title -- title of the plot
+    """
+    # getting the grid
+    x, y, z, vx, vy, vz = get_grid_posvel(N, grid_size)
+
+    # getting density from the SPH data
+    rho, rhovx, rhovy, rhovz, rhoe = sph.get_hydro_state_at_point(
+        x, y, z, vx, vy, vz)
+    rho = rho.reshape((N, N))
+
+    # plotting
+    extent = (grid_size * (-0.5, 0.5, -0.5, 0.5)).value_in(units.parsec)
+    pyplot.figure(figsize=(5, 5.2))
+    pyplot.imshow(numpy.log10(rho.value_in(units.amu/units.cm**3)),
+                  extent=extent)
+    pyplot.title(plot_title)
+    #pyplot.xlabel('x [pc]')
+    #pyplot.ylabel('y [pc]')
+    frame = pyplot.gca()
+    frame.axes.get_xaxis().set_visible(False)
+    frame.axes.get_yaxis().set_visible(False)
+    cbar = pyplot.colorbar()
+    cbar.set_label(r'$\log (\rho [\mathrm{amu}/\mathrm{cm}^3])$')
+    pyplot.tight_layout()
+
+    pyplot.savefig(plot_name)
+    # pyplot.show()
+
 
 def bb79_cloud_evolve(N=50000,
-                      Mcloud=1. | units.MSun, 
-                      Rcloud=3.2e16 | units.cm, 
+                      Mcloud=1. | units.MSun,
+                      Rcloud=3.2e16 | units.cm,
                       omega=1.56e-12 | units.rad/units.s,
                       density_perturb=0.5,
                       t_total=8.3e11 | units.s):
-  
-  # mean density of the cloud
-  rho_uni = Mcloud / (4./3.*numpy.pi*Rcloud**3)
-  print(" ** mean density = ", rho_uni.in_(units.g/units.cm**3))
-  # free fall time of the cloud
-  t_ff = numpy.sqrt(3.*numpy.pi / (32.*units.constants.G*rho_uni))
-  print(" ** free-fall time = ", t_ff.in_(units.yr))
-  
-  conv = nbody_system.nbody_to_si(Mcloud,Rcloud)
-  sph = Fi(conv)
-  
-  # the initial conditions of BB79 
-  parts_bb79 = bb79_cloud(targetN=N, omega=omega, rho_perturb=0.5, 
-                          ethep_ratio=0.25, convert_nbody=conv, 
-                          base_grid=body_centered_grid_unit_cube).result
-  
-  sph.gas_particles.add_particles(parts_bb79)
-  
-  sph.parameters.use_hydro_flag=True
-  sph.parameters.isothermal_flag=True
-  sph.parameters.integrate_entropy_flag=False
-  sph.parameters.gamma=1
-  sph.parameters.verbosity = 0
-  sph.parameters.timestep=0.1*t_ff
-  
-  print("**evolving to time: (end time = ~ {0:.3f} t_ff)".format(t_total/t_ff))
-  
-  # setting snapshots to be plotted
-  nplot = 10
-  if nplot > 1:
-    plot_timestep = t_total / (nplot - 1)
-  else:
-    plot_timestep = t_total
-  
-  # evolution of the cloud
-  for i in range(nplot):
-    ttarget=i*plot_timestep
-    t_tff = ttarget / t_ff
-    
-    sph.evolve_model(ttarget)
-    
-    plot_i = "bb79_rho_{0:03d}.png".format(i)
-    tt_tff = "{0:.3f}".format(t_tff)
-    title_i = "$%s\,t_{\mathrm{ff}}$" % (tt_tff)
-     
-    print("\t {0:.3f} t_ff -> {1}".format(t_tff,plot_i))
-  
-    plot_sph_rho(sph,N=300,grid_size= 0.025 | units.parsec, 
-                 plot_name = plot_i, plot_title = title_i)
-  
-  sph.stop()
-  
+
+    # mean density of the cloud
+    rho_uni = Mcloud / (4./3.*numpy.pi*Rcloud**3)
+    print(" ** mean density = ", rho_uni.in_(units.g/units.cm**3))
+    # free fall time of the cloud
+    t_ff = numpy.sqrt(3.*numpy.pi / (32.*units.constants.G*rho_uni))
+    print(" ** free-fall time = ", t_ff.in_(units.yr))
+
+    conv = nbody_system.nbody_to_si(Mcloud, Rcloud)
+    sph = Fi(conv)
+
+    # the initial conditions of BB79
+    parts_bb79 = bb79_cloud(targetN=N, omega=omega, rho_perturb=0.5,
+                            ethep_ratio=0.25, convert_nbody=conv,
+                            base_grid=body_centered_grid_unit_cube).result
+
+    sph.gas_particles.add_particles(parts_bb79)
+
+    sph.parameters.use_hydro_flag = True
+    sph.parameters.isothermal_flag = True
+    sph.parameters.integrate_entropy_flag = False
+    sph.parameters.gamma = 1
+    sph.parameters.verbosity = 0
+    sph.parameters.timestep = 0.1*t_ff
+
+    print(
+        "**evolving to time: (end time = ~ {0:.3f} t_ff)".format(t_total/t_ff))
+
+    # setting snapshots to be plotted
+    nplot = 10
+    if nplot > 1:
+        plot_timestep = t_total / (nplot - 1)
+    else:
+        plot_timestep = t_total
+
+    # evolution of the cloud
+    for i in range(nplot):
+        ttarget = i*plot_timestep
+        t_tff = ttarget / t_ff
+
+        sph.evolve_model(ttarget)
+
+        plot_i = "bb79_rho_{0:03d}.png".format(i)
+        tt_tff = "{0:.3f}".format(t_tff)
+        title_i = "$%s\,t_{\mathrm{ff}}$" % (tt_tff)
+
+        print("\t {0:.3f} t_ff -> {1}".format(t_tff, plot_i))
+
+        plot_sph_rho(sph, N=300, grid_size=0.025 | units.parsec,
+                     plot_name=plot_i, plot_title=title_i)
+
+    sph.stop()
+
+
 if __name__ == "__main__":
-  bb79_cloud_evolve(N=50000,
-                    Mcloud=1. | units.MSun, 
-                    Rcloud=3.2e16 | units.cm, 
-                    omega=1.56e-12 | units.rad/units.s,
-                    density_perturb=0.5,
-                    t_total=8.3e11 | units.s)  # ~1.5*t_ff
+    bb79_cloud_evolve(N=50000,
+                      Mcloud=1. | units.MSun,
+                      Rcloud=3.2e16 | units.cm,
+                      omega=1.56e-12 | units.rad/units.s,
+                      density_perturb=0.5,
+                      t_total=8.3e11 | units.s)  # ~1.5*t_ff

--- a/examples/simple/boss_bodenheimer_test.py
+++ b/examples/simple/boss_bodenheimer_test.py
@@ -14,16 +14,16 @@ Fragmentation in a rotating protostar -- Boss & Bodenheimer (1979, BB79,
     Rcloud -- radius of the cloud
     omega -- angular velocity of the cloud
     density_perturb -- amplitude of the density perturbation
-  
+
   Plot 10 snapshots of the simulations (bb79_rho_*.png)
        -- log10(rho [amu/cm**3]).
 """
 from __future__ import print_function
 
 import numpy
-import string
-import os
-import sys
+# import string
+# import os
+# import sys
 
 from matplotlib import pyplot
 from matplotlib import rc
@@ -41,10 +41,10 @@ rc('text', usetex=True)
 
 
 def get_grid_posvel(N=100, grid_size=1 | units.parsec):
-    """ 
+    """
     gives x,y(,z,vx,vy,vz) Cartesian coordinate grid (where z=0, vx=vy=vz=0)
     -- for plotting SPH quantities in the xy plane
-    -- N points on each axis; size of the grid 'grid_size' for x and y 
+    -- N points on each axis; size of the grid 'grid_size' for x and y
     """
 
     cell_center_positions_1d = numpy.linspace(-0.5, 0.5, N)
@@ -66,8 +66,8 @@ def get_grid_posvel(N=100, grid_size=1 | units.parsec):
 def plot_sph_rho(sph, N=100, grid_size=1 | units.parsec,
                  plot_name="cloud_plot_rho.png", plot_title="SPH density"):
     """
-    plots the log10(SPH density) in the xy plane 
-    input: sph -- set of sph particles 
+    plots the log10(SPH density) in the xy plane
+    input: sph -- set of sph particles
       N -- number of grid points (in x and y)
       grid_size -- size of the grid (x and y)
       plot_name -- name for the output figure
@@ -87,8 +87,8 @@ def plot_sph_rho(sph, N=100, grid_size=1 | units.parsec,
     pyplot.imshow(numpy.log10(rho.value_in(units.amu/units.cm**3)),
                   extent=extent)
     pyplot.title(plot_title)
-    #pyplot.xlabel('x [pc]')
-    #pyplot.ylabel('y [pc]')
+    # pyplot.xlabel('x [pc]')
+    # pyplot.ylabel('y [pc]')
     frame = pyplot.gca()
     frame.axes.get_xaxis().set_visible(False)
     frame.axes.get_yaxis().set_visible(False)

--- a/examples/simple/brunt.py
+++ b/examples/simple/brunt.py
@@ -1,4 +1,4 @@
-#-*-noplot-*-
+# -*-noplot-*-
 from __future__ import print_function
 from matplotlib import pyplot
 from amuse.plot import semilogy, xlabel, ylabel
@@ -6,6 +6,7 @@ from amuse.plot import semilogy, xlabel, ylabel
 from amuse.units import units
 from amuse.community.mesa.interface import MESA
 from amuse.datamodel import Particle
+
 
 def brunt_vaisala_frequency_squared_profile(mass, age):
     stellar_evolution = MESA()
@@ -16,18 +17,24 @@ def brunt_vaisala_frequency_squared_profile(mass, age):
     stellar_evolution.stop()
     return radius_profile.as_quantity_in(units.RSun), brunt_profile
 
+
 def make_plot(radius_profile, brunt_profile, mass, age):
     figure = pyplot.figure()
-    semilogy(radius_profile, -brunt_profile, 'g-', label = r'convective, $N^2$ < 0')
-    semilogy(radius_profile, brunt_profile, 'r-', label = r'radiative, $N^2$ > 0')
+    semilogy(radius_profile, -brunt_profile,
+             'g-', label=r'convective, $N^2$ < 0')
+    semilogy(radius_profile, brunt_profile,
+             'r-', label=r'radiative, $N^2$ > 0')
     xlabel('Radius')
     ylabel(r'$\|N^2\|$')
-    pyplot.title('Brunt-Vaisala frequency squared of a {0} star at {1}'.format(mass, age))
+    pyplot.title(
+        'Brunt-Vaisala frequency squared of a {0} star at {1}'.format(mass, age))
     pyplot.legend(loc=3)
-    pyplot.show()   
-    
+    pyplot.show()
+
+
 if __name__ == '__main__':
     mass = 1.0 | units.MSun
     age = 1.0 | units.Gyr
-    radius_profile, brunt_profile = brunt_vaisala_frequency_squared_profile(mass, age)
+    radius_profile, brunt_profile = brunt_vaisala_frequency_squared_profile(
+        mass, age)
     make_plot(radius_profile, brunt_profile, mass, age)

--- a/examples/simple/clump_finding.py
+++ b/examples/simple/clump_finding.py
@@ -4,7 +4,7 @@ in the particle set.
 """
 from __future__ import print_function
 
-import numpy 
+import numpy
 from numpy import random
 from matplotlib import pyplot
 
@@ -15,86 +15,88 @@ from amuse.community.hop.interface import Hop
 from amuse.datamodel.particles import Particles
 from amuse.ic.salpeter import new_salpeter_mass_distribution
 
-def new_cluster(number_of_stars = 1000):
+
+def new_cluster(number_of_stars=1000):
     masses = new_salpeter_mass_distribution(
-        number_of_stars, 
-        mass_min = 0.1 | units.MSun,
-        mass_max = 125.0 | units.MSun, 
-        alpha = -2.35
+        number_of_stars,
+        mass_min=0.1 | units.MSun,
+        mass_max=125.0 | units.MSun,
+        alpha=-2.35
     )
-    
+
     particles = Particles(number_of_stars)
     particles.mass = masses
     particles.x = units.parsec(random.gamma(2.0, 1.0, number_of_stars))
     particles.y = units.parsec(random.gamma(1.0, 1.0, number_of_stars))
     particles.z = units.parsec(random.random(number_of_stars))
-    
+
     return particles
 
 
 def find_clumps(particles, unit_converter):
-    
+
     hop = Hop(unit_converter)
     hop.particles.add_particles(particles)
     hop.calculate_densities()
     hop.do_hop()
-    
+
     result = [x.get_intersecting_subset_in(particles) for x in hop.groups()]
-    
+
     hop.stop()
-    
+
     return result
-    
+
+
 def plot_clumps(groups, total_mass):
     number_of_particles_in_group = []
-    fraction_of_mass_in_group =  []
+    fraction_of_mass_in_group = []
 
     for group in groups:
         number_of_particles_in_group.append(len(group))
         fraction = (group.mass.sum()/total_mass)
         fraction_of_mass_in_group.append(fraction)
-    
-    figure = pyplot.figure(figsize= (12,6))
-    
-    
+
+    figure = pyplot.figure(figsize=(12, 6))
+
     subplot = figure.add_subplot(1, 2, 1)
-    
+
     colormap = pyplot.cm.Paired
     for index, group in enumerate(groups):
         color = colormap(1.0 * index / len(groups))
         subplot.scatter(
             group.x.value_in(units.parsec),
             group.y.value_in(units.parsec),
-            s = group.mass.value_in(units.MSun),
-            edgecolors = color,
-            facecolors = color
+            s=group.mass.value_in(units.MSun),
+            edgecolors=color,
+            facecolors=color
         )
-    
-    subplot.set_xlim(0,1)
-    subplot.set_ylim(0,1)
+
+    subplot.set_xlim(0, 1)
+    subplot.set_ylim(0, 1)
     subplot.set_xlabel('x (parsec)')
     subplot.set_ylabel('y (parsec)')
-    
+
     subplot = figure.add_subplot(1, 2, 2)
-        
+
     subplot.plot(
         number_of_particles_in_group,
         fraction_of_mass_in_group,
     )
-    
+
     subplot.set_xscale('log')
     subplot.set_yscale('log')
     subplot.set_xlabel('N')
     subplot.set_ylabel('df/d(Log_10 N)')
-    
+
     figure.savefig('x.png')
     pyplot.show()
-    
+
+
 if __name__ == "__main__":
     number_of_stars = 10000
     stars = new_cluster(number_of_stars)
     total_mass = stars.mass.sum()
-    
+
     unit_converter = nbody_system.nbody_to_si(total_mass, 1 | units.parsec)
     groups = find_clumps(stars, unit_converter)
     plot_clumps(groups, total_mass)

--- a/examples/simple/clump_finding.py
+++ b/examples/simple/clump_finding.py
@@ -4,7 +4,7 @@ in the particle set.
 """
 from __future__ import print_function
 
-import numpy
+# import numpy
 from numpy import random
 from matplotlib import pyplot
 

--- a/examples/simple/cluster.py
+++ b/examples/simple/cluster.py
@@ -8,7 +8,7 @@ import numpy
 from matplotlib import pyplot
 from amuse.units import nbody_system
 from amuse.community.hermite0.interface import Hermite
-import logging
+# import logging
 
 from amuse.ic.plummer import new_plummer_model
 
@@ -22,15 +22,15 @@ def print_log(time, gravity, particles, total_energy_at_t0):
     potential_energy = gravity.potential_energy
     total_energy_at_this_time = kinetic_energy + potential_energy
     print("time                    : ", time)
-    print("energy error            : ", (total_energy_at_this_time -
-                                         total_energy_at_t0) / total_energy_at_t0)
+    print("energy error            : ", (
+        total_energy_at_this_time - total_energy_at_t0) / total_energy_at_t0)
 
 
 def simulate_small_cluster(
         number_of_stars=1000,
         end_time=40 | nbody_system.time,
         number_of_workers=1
-    ):
+        ):
     particles = new_plummer_model(number_of_stars)
     particles.scale_to_standard()
 

--- a/examples/simple/cluster.py
+++ b/examples/simple/cluster.py
@@ -12,7 +12,7 @@ import logging
 
 from amuse.ic.plummer import new_plummer_model
 
-#logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 smoothing_length = 0.0 | nbody_system.length ** 2
 
@@ -21,56 +21,57 @@ def print_log(time, gravity, particles, total_energy_at_t0):
     kinetic_energy = gravity.kinetic_energy
     potential_energy = gravity.potential_energy
     total_energy_at_this_time = kinetic_energy + potential_energy
-    print("time                    : " , time)
-    print("energy error            : " , (total_energy_at_this_time - total_energy_at_t0) / total_energy_at_t0)
+    print("time                    : ", time)
+    print("energy error            : ", (total_energy_at_this_time -
+                                         total_energy_at_t0) / total_energy_at_t0)
 
-    
+
 def simulate_small_cluster(
-        number_of_stars = 1000, 
-        end_time = 40 | nbody_system.time,
-        number_of_workers = 1
+        number_of_stars=1000,
+        end_time=40 | nbody_system.time,
+        number_of_workers=1
     ):
     particles = new_plummer_model(number_of_stars)
     particles.scale_to_standard()
-   
-    gravity = Hermite(number_of_workers = number_of_workers)
+
+    gravity = Hermite(number_of_workers=number_of_workers)
     gravity.parameters.epsilon_squared = 0.15 | nbody_system.length ** 2
-    
+
     gravity.particles.add_particles(particles)
-    
+
     from_gravity_to_model = gravity.particles.new_channel_to(particles)
-    
+
     time = 0.0 * end_time
     total_energy_at_t0 = gravity.kinetic_energy + gravity.potential_energy
-    
+
     positions_at_different_times = []
     positions_at_different_times.append(particles.position)
     times = []
     times.append(time)
-    
+
     print("evolving the model until t = " + str(end_time))
     while time < end_time:
-        time +=  end_time / 3.0
-        
+        time += end_time / 3.0
+
         gravity.evolve_model(time)
         from_gravity_to_model.copy()
-        
+
         positions_at_different_times.append(particles.position)
         times.append(time)
         print_log(time, gravity, particles, total_energy_at_t0)
-        
+
     gravity.stop()
-    
+
     return times, positions_at_different_times
 
 
-def adjust_spines(ax,spines, ticks):
+def adjust_spines(ax, spines, ticks):
     for loc, spine in ax.spines.iteritems():
         if loc in spines:
-            spine.set_position(('outward',10)) # outward by 10 points
+            spine.set_position(('outward', 10))  # outward by 10 points
             spine.set_smart_bounds(True)
         else:
-            spine.set_color('none') # don't draw spine
+            spine.set_color('none')  # don't draw spine
 
     if 'left' in spines:
         ax.yaxis.set_ticks_position('left')
@@ -88,45 +89,49 @@ def adjust_spines(ax,spines, ticks):
 
 def plot_positions(times, positions_at_different_times):
     figure = pyplot.figure()
-    plot_matrix_size = numpy.ceil(numpy.sqrt(len(positions_at_different_times))).astype(int)
+    plot_matrix_size = numpy.ceil(numpy.sqrt(
+        len(positions_at_different_times))).astype(int)
     number_of_rows = len(positions_at_different_times) / plot_matrix_size
-    figure.subplots_adjust(wspace = 0.15, hspace = 0.15)
-    
-    for index, (time, positions) in enumerate(zip(times, positions_at_different_times)):
-        subplot = figure.add_subplot(plot_matrix_size, plot_matrix_size, index + 1)
-        
+    figure.subplots_adjust(wspace=0.15, hspace=0.15)
+
+    for index, (time, positions) in enumerate(
+            zip(times, positions_at_different_times)
+            ):
+        subplot = figure.add_subplot(
+            plot_matrix_size, plot_matrix_size, index + 1)
+
         subplot.scatter(
-            positions[...,0].value_in(nbody_system.length),
-            positions[...,1].value_in(nbody_system.length),
-            s = 1,
-            edgecolors = 'red',
-            facecolors = 'red'
+            positions[..., 0].value_in(nbody_system.length),
+            positions[..., 1].value_in(nbody_system.length),
+            s=1,
+            edgecolors='red',
+            facecolors='red'
         )
-        
-        subplot.set_xlim(-4.0,4.0)
-        subplot.set_ylim(-4.0,4.0)
-        
+
+        subplot.set_xlim(-4.0, 4.0)
+        subplot.set_ylim(-4.0, 4.0)
+
         title = 'time = {0:.2f}'.format(time.value_in(nbody_system.time))
-        
-        subplot.set_title(title)#, fontsize=12)
+
+        subplot.set_title(title)  # , fontsize=12)
         spines = []
         if index % plot_matrix_size == 0:
             spines.append('left')
 
         if index >= ((number_of_rows - 1)*plot_matrix_size):
             spines.append('bottom')
-            
 
-        adjust_spines(subplot, spines,numpy.arange(-4.0,4.1, 1.0))
-        
+        adjust_spines(subplot, spines, numpy.arange(-4.0, 4.1, 1.0))
+
         if index % plot_matrix_size == 0:
             subplot.set_ylabel('y')
-            
+
         if index >= ((number_of_rows - 1)*plot_matrix_size):
             subplot.set_xlabel('x')
-            
+
     pyplot.show()
-    
+
+
 if __name__ == "__main__":
     times, positions_at_different_time = simulate_small_cluster(
         300,

--- a/examples/simple/collision.py
+++ b/examples/simple/collision.py
@@ -1,10 +1,11 @@
 """
-Evolves a cluster until a collision is detected between two stars in the cluster.
+Evolves a cluster until a collision is detected between two stars in the
+cluster.
 
 The stars in the cluster are distributed using a plummer sphere, the
 masses are set according to a Salpeter initial mass function.
 
-By default the radii of all stars are equal and very large. 
+By default the radii of all stars are equal and very large.
 
 All units are in nbody units.
 """
@@ -12,15 +13,18 @@ from __future__ import print_function
 
 import numpy
 from matplotlib import pyplot
-from amuse.lab import *
+from amuse.lab import (
+        nbody_system, new_plummer_model, new_salpeter_mass_distribution_nbody,
+        Hermite
+        )
 
 
 def new_cluster(number_of_stars=1000, radius=None):
     """
-    Return a new cluster of stars with the given radii and a salpeter 
-    mass distribution.
+    Return a new cluster of stars with the given radii and a salpeter mass
+    distribution.
     """
-    if radius == None:
+    if radius is None:
         radius = (0.5 / number_of_stars) | nbody_system.length
 
     particles = new_plummer_model(number_of_stars)
@@ -94,4 +98,5 @@ if __name__ == "__main__":
             "No stopping collision detected in the given timeframe.")
 
     plot_particles_and_highlight_collision(
-        particles, stopping_condition.particles(0), stopping_condition.particles(1))
+        particles, stopping_condition.particles(0),
+        stopping_condition.particles(1))

--- a/examples/simple/collision.py
+++ b/examples/simple/collision.py
@@ -10,23 +10,25 @@ All units are in nbody units.
 """
 from __future__ import print_function
 
-import numpy 
+import numpy
 from matplotlib import pyplot
 from amuse.lab import *
 
-def new_cluster(number_of_stars = 1000, radius = None):
+
+def new_cluster(number_of_stars=1000, radius=None):
     """
     Return a new cluster of stars with the given radii and a salpeter 
     mass distribution.
     """
     if radius == None:
         radius = (0.5 / number_of_stars) | nbody_system.length
-        
+
     particles = new_plummer_model(number_of_stars)
     particles.mass = new_salpeter_mass_distribution_nbody(number_of_stars)
     particles.radius = radius
     particles.move_to_center()
     return particles
+
 
 def plot_particles_and_highlight_collision(particles, particles1, particles2):
     """
@@ -35,56 +37,61 @@ def plot_particles_and_highlight_collision(particles, particles1, particles2):
     """
     figure = pyplot.figure()
     subplot = figure.add_subplot(1, 1, 1)
-      
+
     subplot.scatter(
         particles.x.value_in(nbody_system.length),
         particles.y.value_in(nbody_system.length),
-        s =  (2 * subplot.bbox.width  * particles.radius.value_in(nbody_system.length)) ** 2 ,
-        edgecolors = 'none',
-        facecolors = 'red',
-        marker = 'o',
+        s=(2 * subplot.bbox.width *
+           particles.radius.value_in(nbody_system.length)) ** 2,
+        edgecolors='none',
+        facecolors='red',
+        marker='o',
     )
-    
+
     subplot.scatter(
         particles1.x.value_in(nbody_system.length),
         particles1.y.value_in(nbody_system.length),
-        s = 2 * (2 * subplot.bbox.width  * particles1.radius.value_in(nbody_system.length)) ** 2,
-        edgecolors = 'none',
-        facecolors = 'black',
-        marker = 'o',
+        s=2 * (2 * subplot.bbox.width *
+               particles1.radius.value_in(nbody_system.length)) ** 2,
+        edgecolors='none',
+        facecolors='black',
+        marker='o',
     )
-    
+
     subplot.scatter(
         particles2.x.value_in(nbody_system.length),
         particles2.y.value_in(nbody_system.length),
-        s = 2 * (2 * subplot.bbox.width  *  particles2.radius.value_in(nbody_system.length)) ** 2,
-        edgecolors = 'none',
-        facecolors = 'black',
-        marker = 'o',
+        s=2 * (2 * subplot.bbox.width *
+               particles2.radius.value_in(nbody_system.length)) ** 2,
+        edgecolors='none',
+        facecolors='black',
+        marker='o',
     )
-    
-    subplot.set_xlim(-1,1)
-    subplot.set_ylim(-1,1)
+
+    subplot.set_xlim(-1, 1)
+    subplot.set_ylim(-1, 1)
     subplot.set_xlabel('x (nbody length)')
     subplot.set_ylabel('y (nbody length)')
-    
+
     pyplot.show()
-    
+
+
 if __name__ == "__main__":
     numpy.random.seed(1212)
-    
+
     particles = new_cluster(128)
-    
+
     code = Hermite()
     code.particles.add_particles(particles)
-    
+
     stopping_condition = code.stopping_conditions.collision_detection
     stopping_condition.enable()
-    
-    code.evolve_model(4 | nbody_system.time)
-    
-    if not stopping_condition.is_set():
-        raise Exception("No stopping collision detected in the given timeframe.")
-        
-    plot_particles_and_highlight_collision(particles, stopping_condition.particles(0), stopping_condition.particles(1) )
 
+    code.evolve_model(4 | nbody_system.time)
+
+    if not stopping_condition.is_set():
+        raise Exception(
+            "No stopping collision detected in the given timeframe.")
+
+    plot_particles_and_highlight_collision(
+        particles, stopping_condition.particles(0), stopping_condition.particles(1))

--- a/examples/simple/evolve_binary.py
+++ b/examples/simple/evolve_binary.py
@@ -1,11 +1,14 @@
 """
-Evolves a stellar binary and reports the mass of each star during the evolution.
+Evolves a stellar binary and reports the mass of each star during the
+evolution.
 
 Shows the type of each star as they change.
 """
 from __future__ import print_function
 
-from amuse.lab import *
+from amuse.lab import (
+        SeBa, Particles, constants, units
+        )
 import numpy
 from matplotlib import pyplot
 
@@ -45,7 +48,8 @@ def evolve_binary(mass_of_star1, mass_of_star2, orbital_period, eccentricity):
     current_time = 0 | units.Myr
     while current_time < (1000 | units.Myr):
         code.update_time_steps()
-        # The next line appears a bit weird, but saves time for this simple test.
+        # The next line appears a bit weird, but saves time for this simple
+        # test.
         deltat = max(1.0*code.binaries[0].time_step, 0.1 | units.Myr)
         current_time = current_time + deltat
         code.evolve_model(current_time)
@@ -60,8 +64,9 @@ def evolve_binary(mass_of_star1, mass_of_star2, orbital_period, eccentricity):
             print(binary.age, "Child 2, change of stellar type",
                   previous_type_child2, ' -> ', binary.child2.stellar_type)
             previous_type_child2 = binary.child2.stellar_type
-        results.append((binary.age, binary.child1.mass, binary.child1.stellar_type,
-                        binary.child2.mass, binary.child2.stellar_type))
+        results.append(
+                (binary.age, binary.child1.mass, binary.child1.stellar_type,
+                    binary.child2.mass, binary.child2.stellar_type))
 
     code.stop()
     return results

--- a/examples/simple/evolve_binary.py
+++ b/examples/simple/evolve_binary.py
@@ -9,39 +9,38 @@ from amuse.lab import *
 import numpy
 from matplotlib import pyplot
 
+
 def evolve_binary(mass_of_star1, mass_of_star2, orbital_period, eccentricity):
     code = SeBa()
-    
-    stars =  Particles(2)
+
+    stars = Particles(2)
     stars[0].mass = mass_of_star1
     stars[1].mass = mass_of_star2
-    
-    
+
     mu = stars.mass.sum() * constants.G
     semi_major_axis = (((orbital_period / (2.0 * numpy.pi))**2)*mu)**(1.0/3.0)
-    
-    
-    binaries =  Particles(1)
-    
+
+    binaries = Particles(1)
+
     binary = binaries[0]
     binary.semi_major_axis = semi_major_axis
     binary.eccentricity = eccentricity
     binary.child1 = stars[0]
     binary.child2 = stars[1]
-    
+
     # we add the single stars first, as the binaries will refer to these
     code.particles.add_particles(stars)
     code.binaries.add_particles(binaries)
-    
+
     from_seba_to_model = code.particles.new_channel_to(stars)
     from_seba_to_model.copy()
 
     from_seba_to_model_binaries = code.binaries.new_channel_to(binaries)
     from_seba_to_model_binaries.copy()
-    
+
     previous_type_child1 = binary.child1.stellar_type
     previous_type_child2 = binary.child2.stellar_type
-    
+
     results = []
     current_time = 0 | units.Myr
     while current_time < (1000 | units.Myr):
@@ -52,42 +51,43 @@ def evolve_binary(mass_of_star1, mass_of_star2, orbital_period, eccentricity):
         code.evolve_model(current_time)
         from_seba_to_model.copy()
         from_seba_to_model_binaries.copy()
-        
+
         if not binary.child1.stellar_type == previous_type_child1:
-            print(binary.age, "Child 1, change of stellar type", previous_type_child1, ' -> ',binary.child1.stellar_type)
+            print(binary.age, "Child 1, change of stellar type",
+                  previous_type_child1, ' -> ', binary.child1.stellar_type)
             previous_type_child1 = binary.child1.stellar_type
         if not binary.child2.stellar_type == previous_type_child2:
-            print(binary.age, "Child 2, change of stellar type", previous_type_child2, ' -> ',binary.child2.stellar_type)
+            print(binary.age, "Child 2, change of stellar type",
+                  previous_type_child2, ' -> ', binary.child2.stellar_type)
             previous_type_child2 = binary.child2.stellar_type
-        results.append((binary.age, binary.child1.mass, binary.child1.stellar_type, binary.child2.mass, binary.child2.stellar_type))
-        
-        
-    
-    code.stop() 
+        results.append((binary.age, binary.child1.mass, binary.child1.stellar_type,
+                        binary.child2.mass, binary.child2.stellar_type))
+
+    code.stop()
     return results
-    
+
 
 def plot_masses(table):
-    time = [] 
+    time = []
     mass_child1 = []
     mass_child2 = []
-    
+
     for age, mass1, type1, mass2, type2 in table:
         time.append(age.value_in(units.Myr))
         mass_child1.append(mass1.value_in(units.MSun))
         mass_child2.append(mass2.value_in(units.MSun))
-        
-    
-    figure = pyplot.figure(figsize = (8, 6))
-    plot = figure.add_subplot(1,1,1)
+
+    figure = pyplot.figure(figsize=(8, 6))
+    plot = figure.add_subplot(1, 1, 1)
     plot.plot(time, mass_child1)
     plot.plot(time, mass_child2)
     plot.set_xlabel('Time')
     plot.set_ylabel('Mass')
-   
+
     pyplot.show()
-    
-if __name__ == "__main__":     
+
+
+if __name__ == "__main__":
     table = evolve_binary(
         3.0 | units.MSun,
         0.3 | units.MSun,
@@ -95,4 +95,3 @@ if __name__ == "__main__":
         0.5
     )
     plot_masses(table)
-

--- a/examples/simple/evolve_orbit_in_potential.py
+++ b/examples/simple/evolve_orbit_in_potential.py
@@ -126,7 +126,8 @@ def setup_system():
 
 
 def setup_bridge(potential, cluster, current_age, timestep, orbit, code):
-    converter = nbody_system.nbody_to_si(current_age, cluster.position.length())
+    converter = nbody_system.nbody_to_si(
+        current_age, cluster.position.length())
     gravity = codelist[code](converter)
 
     cluster.mass = 0 | units.MSun

--- a/examples/simple/galactic_center.py
+++ b/examples/simple/galactic_center.py
@@ -2,7 +2,8 @@
 Evolves a cluster in the potention of the galactic center
   
 Uses the bridge integrator to couple different codes.
-In this example a cluster is evolved  circling the galactic center, represented by a static potential.
+In this example a cluster is evolved  circling the galactic center, represented
+by a static potential.
 """
 from __future__ import print_function
 
@@ -21,121 +22,130 @@ from matplotlib import pyplot
 
 from amuse.ic.kingmodel import new_king_model
 
+
 class GalacticCenterGravityCode(object):
     """
     Implements a code simulating the galactic center. As the center itself does
-    not evolve we only need to define the 'get_gravity_at_point'
-    and 'get_potential_at_point'. Note that both functions get arrays
-    of points.
+    not evolve we only need to define the 'get_gravity_at_point' and
+    'get_potential_at_point'. Note that both functions get arrays of points.
     """
-    def __init__(self,R=1000.| units.parsec, M=1.6e10 | units.MSun, alpha=1.2):
-        self.R=R
-        self.M=M
-        self.alpha=alpha
 
-    def get_gravity_at_point(self,eps,x,y,z):
-        r2=x**2+y**2+z**2
-        r=r2**0.5
-        m=self.M*(r/self.R)**self.alpha  
-        fr=constants.G*m/r2
-        ax=-fr*x/r
-        ay=-fr*y/r
-        az=-fr*z/r
-        return ax,ay,az
+    def __init__(self, R=1000. | units.parsec, M=1.6e10 | units.MSun, alpha=1.2):
+        self.R = R
+        self.M = M
+        self.alpha = alpha
 
-    def get_potential_at_point(self,eps,x,y,z):
-        r2=x**2+y**2+z**2
-        r=r2**0.5
-        c=constant.G*self.M/self.R**self.alpha    
-        phi=c/(alpha-1)*(r**(self.alpha-1)-R**(self.alpha-1))
-        return phi    
+    def get_gravity_at_point(self, eps, x, y, z):
+        r2 = x**2+y**2+z**2
+        r = r2**0.5
+        m = self.M*(r/self.R)**self.alpha
+        fr = constants.G*m/r2
+        ax = -fr*x/r
+        ay = -fr*y/r
+        az = -fr*z/r
+        return ax, ay, az
 
-    def vcirc(self,r):  
-        m=self.M*(r/self.R)**self.alpha  
-        vc=(constants.G*m/r)**0.5
+    def get_potential_at_point(self, eps, x, y, z):
+        r2 = x**2+y**2+z**2
+        r = r2**0.5
+        c = constant.G*self.M/self.R**self.alpha
+        phi = c/(alpha-1)*(r**(self.alpha-1)-R**(self.alpha-1))
+        return phi
+
+    def vcirc(self, r):
+        m = self.M*(r/self.R)**self.alpha
+        vc = (constants.G*m/r)**0.5
         return vc
-        
-def king_model_cluster(interface,N=1024,W0=3, Mcluster=4.e4 | units.MSun,
-                                 Rcluster= .7 | units.parsec,parameters=[]):
+
+
+def king_model_cluster(interface, N=1024, W0=3, Mcluster=4.e4 | units.MSun,
+                       Rcluster=.7 | units.parsec, parameters=[]):
     """
-    helper function to setup an nbody king model cluster (returns code with particles)
-    """      
-    converter=nbody_system.nbody_to_si(Mcluster,Rcluster)
+    helper function to setup an nbody king model cluster (returns code with
+    particles)
+    """
+    converter = nbody_system.nbody_to_si(Mcluster, Rcluster)
 
-    parts=new_king_model(N,W0,convert_nbody=converter)
-    parts.radius=0.0| units.parsec
+    parts = new_king_model(N, W0, convert_nbody=converter)
+    parts.radius = 0.0 | units.parsec
 
-    nb=interface(converter)
-    for name,value in parameters:
-      setattr(nb.parameters, name, value)
+    nb = interface(converter)
+    for name, value in parameters:
+        setattr(nb.parameters, name, value)
 
     nb.particles.add_particles(parts)
 
     return nb
 
-def shift_sys(system,dx,dy,dz,dvx,dvy,dvz):
+
+def shift_sys(system, dx, dy, dz, dvx, dvy, dvz):
     """
     helper function to shift system
     """
-    parts=system.particles.copy()
-    parts.x=parts.x+dx
-    parts.y=parts.y+dy
-    parts.z=parts.z+dz
-    parts.vx=parts.vx+dvx
-    parts.vy=parts.vy+dvy
-    parts.vz=parts.vz+dvz
-    channel=parts.new_channel_to(system.particles)
-    channel.copy_attributes(["x","y","z","vx","vy","vz"])
-    #      parts.copy_values_of_state_attributes_to(system.particles)
-    
+    parts = system.particles.copy()
+    parts.x = parts.x+dx
+    parts.y = parts.y+dy
+    parts.z = parts.z+dz
+    parts.vx = parts.vx+dvx
+    parts.vy = parts.vy+dvy
+    parts.vz = parts.vz+dvz
+    channel = parts.new_channel_to(system.particles)
+    channel.copy_attributes(["x", "y", "z", "vx", "vy", "vz"])
+    # parts.copy_values_of_state_attributes_to(system.particles)
+
+
 if __name__ == "__main__":
 
-# parameter setup:
-    N=1024
-    W0=3
-    Rinit=50. | units.parsec
-    timestep=0.01 | units.Myr
-    Mcluster=4.e4 | units.MSun
-    Rcluster=0.7 | units.parsec
+    # parameter setup:
+    N = 1024
+    W0 = 3
+    Rinit = 50. | units.parsec
+    timestep = 0.01 | units.Myr
+    Mcluster = 4.e4 | units.MSun
+    Rcluster = 0.7 | units.parsec
 
-# make cluster and Galactic center
-    cluster=king_model_cluster(Fi,N,W0, Mcluster,Rcluster, parameters=[
-                   ("epsilon_squared", (0.01 | units.parsec)**2), 
-                   ("periodic_box_size",200 | units.parsec),
-                   ("timestep",timestep/4)] )
-    center=GalacticCenterGravityCode()
-    
-# shift the cluster to an orbit around GC
-# (note the systems share the same coordinate frame, although units may differ)    
-    vcirc=center.vcirc(Rinit)
-    shift_sys(cluster,Rinit,0| units.parsec,0.|units.parsec,
-                  0| units.kms,0.8*vcirc,0| units.kms)
+    # make cluster and Galactic center
+    cluster = king_model_cluster(
+            Fi, N, W0, Mcluster, Rcluster, parameters=[
+                ("epsilon_squared",
+                (0.01 | units.parsec)**2),
+                ("periodic_box_size", 200 | units.parsec),
+                ("timestep", timestep/4)
+                ]
+            )
+    center = GalacticCenterGravityCode()
 
-# setup bridge; cluster is evolved under influence of GC
-    sys=bridge(verbose=False)
-    sys.add_system(cluster, (center,), False)   
+    # shift the cluster to an orbit around GC
+    # (note the systems share the same coordinate frame, although units may
+    # differ)
+    vcirc = center.vcirc(Rinit)
+    shift_sys(cluster, Rinit, 0 | units.parsec, 0. | units.parsec,
+              0 | units.kms, 0.8*vcirc, 0 | units.kms)
+
+    # setup bridge; cluster is evolved under influence of GC
+    sys = bridge(verbose=False)
+    sys.add_system(cluster, (center,), False)
 
 
-# evolve and make plots
-    times=units.Myr([0.,0.2,0.4,0.6,0.8,1.0,1.2,1.4])
-    f=pyplot.figure(figsize=(8,16))
+    # evolve and make plots
+    times = units.Myr([0., 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4])
+    f = pyplot.figure(figsize=(8, 16))
 
-    for i,t in enumerate(times):
-        sys.evolve_model(t,timestep=timestep)
+    for i, t in enumerate(times):
+        sys.evolve_model(t, timestep=timestep)
 
-        x=sys.particles.x.value_in(units.parsec)
-        y=sys.particles.y.value_in(units.parsec)
+        x = sys.particles.x.value_in(units.parsec)
+        y = sys.particles.y.value_in(units.parsec)
 
-        subplot=f.add_subplot(4,2,i+1)
-        subplot.plot(x,y,'r .')
-        subplot.plot([0.],[0.],'b +')
-        subplot.set_xlim(-60,60)
-        subplot.set_ylim(-60,60)
+        subplot = f.add_subplot(4, 2, i+1)
+        subplot.plot(x, y, 'r .')
+        subplot.plot([0.], [0.], 'b +')
+        subplot.set_xlim(-60, 60)
+        subplot.set_ylim(-60, 60)
         subplot.set_title(t)
-        if i==7:
+        if i == 7:
             subplot.set_xlabel('parsec')
-            
+
     cluster.stop()
     pyplot.show()
-#    pyplot.savefig('test.eps')
-    
+    # pyplot.savefig('test.eps')

--- a/examples/simple/galactic_center.py
+++ b/examples/simple/galactic_center.py
@@ -1,22 +1,22 @@
 """
 Evolves a cluster in the potention of the galactic center
-  
+
 Uses the bridge integrator to couple different codes.
 In this example a cluster is evolved  circling the galactic center, represented
 by a static potential.
 """
 from __future__ import print_function
 
-import numpy
+# import numpy
 
 from amuse.units import units
 from amuse.units import constants
 from amuse.units import nbody_system
 
 from amuse.ext.bridge import bridge
-from amuse.community.phiGRAPE.interface import PhiGRAPE
+# from amuse.community.phiGRAPE.interface import PhiGRAPE
 from amuse.community.fi.interface import Fi
-from amuse.community.gadget2.interface import Gadget2
+# from amuse.community.gadget2.interface import Gadget2
 
 from matplotlib import pyplot
 
@@ -30,7 +30,8 @@ class GalacticCenterGravityCode(object):
     'get_potential_at_point'. Note that both functions get arrays of points.
     """
 
-    def __init__(self, R=1000. | units.parsec, M=1.6e10 | units.MSun, alpha=1.2):
+    def __init__(
+            self, R=1000. | units.parsec, M=1.6e10 | units.MSun, alpha=1.2):
         self.R = R
         self.M = M
         self.alpha = alpha
@@ -48,8 +49,8 @@ class GalacticCenterGravityCode(object):
     def get_potential_at_point(self, eps, x, y, z):
         r2 = x**2+y**2+z**2
         r = r2**0.5
-        c = constant.G*self.M/self.R**self.alpha
-        phi = c/(alpha-1)*(r**(self.alpha-1)-R**(self.alpha-1))
+        c = constants.G*self.M/self.R**self.alpha
+        phi = c/(self.alpha-1)*(r**(self.alpha-1)-self.R**(self.alpha-1))
         return phi
 
     def vcirc(self, r):
@@ -107,8 +108,7 @@ if __name__ == "__main__":
     # make cluster and Galactic center
     cluster = king_model_cluster(
             Fi, N, W0, Mcluster, Rcluster, parameters=[
-                ("epsilon_squared",
-                (0.01 | units.parsec)**2),
+                ("epsilon_squared", (0.01 | units.parsec)**2),
                 ("periodic_box_size", 200 | units.parsec),
                 ("timestep", timestep/4)
                 ]
@@ -125,7 +125,6 @@ if __name__ == "__main__":
     # setup bridge; cluster is evolved under influence of GC
     sys = bridge(verbose=False)
     sys.add_system(cluster, (center,), False)
-
 
     # evolve and make plots
     times = units.Myr([0., 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4])

--- a/examples/simple/galactic_center_in_code.py
+++ b/examples/simple/galactic_center_in_code.py
@@ -15,92 +15,94 @@ from amuse.community.phiGRAPE.interface import PhiGRAPE
 from matplotlib import pyplot
 
 from amuse.ic.kingmodel import new_king_model
-        
-        
+
+
 def new_galactic_center(mass):
     result = particles.Particle()
     result.mass = mass
-    result.position = [0,0,0] | units.parsec
-    result.velocity = [0,0,0] | units.kms
+    result.position = [0, 0, 0] | units.parsec
+    result.velocity = [0, 0, 0] | units.kms
     result.radius = 0 | units.parsec
     return result
-    
-def circular_velocity_for_stable_orbit(radius, central_mass ):  
+
+
+def circular_velocity_for_stable_orbit(radius, central_mass):
     return (constants.G*central_mass/radius)**0.5
-    
+
+
 def new_cluster(
         number_of_particles,
         W0,
         converter
     ):
-            
-    particles=new_king_model(N,W0,convert_nbody=converter)
-    particles.radius=0.0| units.parsec
+    particles = new_king_model(N, W0, convert_nbody=converter)
+    particles.radius = 0.0 | units.parsec
     return particles
-    
-def new_gravity_code(converter, timestep = 0.0025 | units.Myr):
-    result=PhiGRAPE(converter)
+
+
+def new_gravity_code(converter, timestep=0.0025 | units.Myr):
+    result = PhiGRAPE(converter)
     result.parameters.epsilon_squared = (0.01 | units.parsec)**2
     return result
-    
-def shift_particles(particles,dx,dy,dz,dvx,dvy,dvz):
+
+
+def shift_particles(particles, dx, dy, dz, dvx, dvy, dvz):
     particles.x += dx
     particles.y += dy
     particles.z += dz
     particles.vx += dvx
     particles.vy += dvy
     particles.vz += dvz
-    
+
+
 if __name__ == "__main__":
     # parameter setup:
-    N=128
-    W0=3
-    Rinit=50. | units.parsec
-    timestep=0.01 | units.Myr
-    Mcluster=4.e4 | units.MSun
-    Rcluster=0.7 | units.parsec
+    N = 128
+    W0 = 3
+    Rinit = 50. | units.parsec
+    timestep = 0.01 | units.Myr
+    Mcluster = 4.e4 | units.MSun
+    Rcluster = 0.7 | units.parsec
     central_mass = 1.6e7 | units.MSun
-    
-    converter = nbody_system.nbody_to_si(Mcluster,Rcluster)
-    cluster = new_cluster(number_of_particles = N, W0 = W0, converter = converter)
-    code = new_gravity_code(converter, timestep = timestep)
+
+    converter = nbody_system.nbody_to_si(Mcluster, Rcluster)
+    cluster = new_cluster(number_of_particles=N, W0=W0, converter=converter)
+    code = new_gravity_code(converter, timestep=timestep)
     galactic_center = new_galactic_center(central_mass)
-    
+
     # shift the cluster to an orbit around GC
-    # (note the systems share the same coordinate frame, although units may differ)    
-    vcirc=circular_velocity_for_stable_orbit(Rinit, central_mass)
+    # (note the systems share the same coordinate frame, although units may differ)
+    vcirc = circular_velocity_for_stable_orbit(Rinit, central_mass)
     shift_particles(
         cluster,
-        Rinit,0| units.parsec,0.|units.parsec,
-        0| units.kms,0.8*vcirc,0| units.kms
+        Rinit, 0 | units.parsec, 0. | units.parsec,
+        0 | units.kms, 0.8*vcirc, 0 | units.kms
     )
 
     code.particles.add_particles(cluster)
-    
+
     # add galactic center to the code
     code.particles.add_particle(galactic_center)
 
-
     print("Start evolution")
     # evolve and make plots
-    times=units.Myr([0.,0.2,0.4,0.6])
-    f=pyplot.figure(figsize=(8,8))
-    for i,time in enumerate(times):
+    times = units.Myr([0., 0.2, 0.4, 0.6])
+    f = pyplot.figure(figsize=(8, 8))
+    for i, time in enumerate(times):
         code.evolve_model(time)
         print("Evolved to time:", time)
 
-        x=code.particles.x.value_in(units.parsec)
-        y=code.particles.y.value_in(units.parsec)
+        x = code.particles.x.value_in(units.parsec)
+        y = code.particles.y.value_in(units.parsec)
 
-        subplot=f.add_subplot(2,2,i+1)
-        subplot.plot(x,y,'r .')
-        subplot.plot([0.],[0.],'b +')
-        subplot.set_xlim(-60,60)
-        subplot.set_ylim(-60,60)
+        subplot = f.add_subplot(2, 2, i+1)
+        subplot.plot(x, y, 'r .')
+        subplot.plot([0.], [0.], 'b +')
+        subplot.set_xlim(-60, 60)
+        subplot.set_ylim(-60, 60)
         subplot.set_title(time)
-        if i==7:
+        if i == 7:
             subplot.set_xlabel('parsec')
-        
+
     code.stop()
     pyplot.show()
-    

--- a/examples/simple/galactic_center_in_code.py
+++ b/examples/simple/galactic_center_in_code.py
@@ -3,7 +3,7 @@ Evolves a cluster orbiting a massive central particle.
 """
 from __future__ import print_function
 
-import numpy
+# import numpy
 
 from amuse.units import units
 from amuse.units import constants
@@ -34,7 +34,7 @@ def new_cluster(
         number_of_particles,
         W0,
         converter
-    ):
+        ):
     particles = new_king_model(N, W0, convert_nbody=converter)
     particles.radius = 0.0 | units.parsec
     return particles
@@ -71,7 +71,8 @@ if __name__ == "__main__":
     galactic_center = new_galactic_center(central_mass)
 
     # shift the cluster to an orbit around GC
-    # (note the systems share the same coordinate frame, although units may differ)
+    # (note the systems share the same coordinate frame, although units may
+    # differ)
     vcirc = circular_velocity_for_stable_orbit(Rinit, central_mass)
     shift_particles(
         cluster,

--- a/examples/simple/gas_in_cluster.py
+++ b/examples/simple/gas_in_cluster.py
@@ -27,133 +27,142 @@ from amuse.units import nbody_system
 import numpy
 from matplotlib import pyplot
 
+
 class BridgeStarAndGasPlummerCode(object):
     """
     Calculates a cluster with stars and gas, using a fixed set of codes
     (Hermite for stars, Gadget2 for gas and BHTree for gas to star interaction).
     """
 
-    def __init__(self,
-        nstars = 10, 
-        ngas = None, 
-        total_mass = 1000  | units.MSun,
-        gas_fraction = 0.9,
-        rscale = 1.0  | units.parsec,
-        star_smoothing_fraction = 0.001,
-        gas_smoothing_fraction = 0.05,
-        seed = None,
-        interaction_timestep = 0.01 | nbody_system.time,
-        diagnostic_timestep = 0.1 | nbody_system.time
-    ):
-        
+    def __init__(
+            self,
+            nstars=10,
+            ngas=None,
+            total_mass=1000 | units.MSun,
+            gas_fraction=0.9,
+            rscale=1.0 | units.parsec,
+            star_smoothing_fraction=0.001,
+            gas_smoothing_fraction=0.05,
+            seed=None,
+            interaction_timestep=0.01 | nbody_system.time,
+            diagnostic_timestep=0.1 | nbody_system.time
+            ):
+
         if not seed is None:
             numpy.random.seed(seed)
-    
+
         if ngas is None:
             ngas = nstars * 10
-        
+
         self.ngas = ngas
         self.nstars = nstars
         self.total_mass = total_mass
         self.gas_fraction = gas_fraction
         self.star_fraction = 1.0 - self.gas_fraction
         self.rscale = rscale
-        
+
         self.star_epsilon = star_smoothing_fraction * self.rscale
         self.gas_epsilon = gas_smoothing_fraction * self.rscale
-        
+
         self.star_mass = self.star_fraction * self.total_mass
         self.gas_mass = self.gas_fraction * self.total_mass
-        
+
         self.converter = nbody_system.nbody_to_si(self.total_mass, self.rscale)
-        self.interaction_timestep_in_si = self.converter.to_si(interaction_timestep)
-        self.diagnostic_timestep_in_si = self.converter.to_si(diagnostic_timestep)
-        
-        self.time  = 0.0 * self.interaction_timestep_in_si
-        
+        self.interaction_timestep_in_si = self.converter.to_si(
+            interaction_timestep)
+        self.diagnostic_timestep_in_si = self.converter.to_si(
+            diagnostic_timestep)
+
+        self.time = 0.0 * self.interaction_timestep_in_si
+
         self.times = [] | nbody_system.time
         self.energy_at_time = [] | nbody_system.energy
-        self.coreradius_at_time = [] | self.rscale.unit    
-        
+        self.coreradius_at_time = [] | self.rscale.unit
+
     def setup(self):
         self.create_codes()
-        
+
         self.initialize_data()
-        
+
         self.create_bridge()
-        
+
         self.code = self.bridge_system
-        
-        self.print_log() 
-        
+
+        self.print_log()
+
         self.store_values()
-   
-        
+
     def create_codes(self):
         self.star_code = self.new_star_code_hermite()
         self.gas_code = self.new_gas_code_gadget()
-        
+
         def new_code_to_calculate_gravity_of_gas_particles():
             result = BHTree(self.converter)
             return result
-            
-        calculate_gravity_code=bridge.CalculateFieldForCodes(
-            new_code_to_calculate_gravity_of_gas_particles,  # the code that calculates the acceleration field
-            input_codes = [self.gas_code] # the codes to calculate the acceleration field of
+
+        calculate_gravity_code = bridge.CalculateFieldForCodes(
+            # the code that calculates the acceleration field
+            new_code_to_calculate_gravity_of_gas_particles,
+            # the codes to calculate the acceleration field of
+            input_codes=[self.gas_code]
         )
         self.gas_to_star_codes = [calculate_gravity_code]
         self.star_to_gas_codes = [self.star_code]
-    
+
     def initialize_data(self):
         self.particles = self.new_particles_cluster()
         self.gas_particles = self.new_gas_cluster()
-        
+
         self.star_code.particles.add_particles(self.particles)
         self.gas_code.gas_particles.add_particles(self.gas_particles)
-        
-        self.channel_from_code_to_memory_for_stars = self.star_code.particles.new_channel_to(self.particles)
-        self.channel_from_code_to_memory_for_gas = self.gas_code.gas_particles.new_channel_to(self.gas_particles)
-        
+
+        self.channel_from_code_to_memory_for_stars = self.star_code.particles.new_channel_to(
+            self.particles)
+        self.channel_from_code_to_memory_for_gas = self.gas_code.gas_particles.new_channel_to(
+            self.gas_particles)
+
     def create_bridge(self):
         self.bridge_system = bridge.Bridge(
-            timestep = self.interaction_timestep_in_si,
-            use_threading = False
+            timestep=self.interaction_timestep_in_si,
+            use_threading=False
         )
-        
+
         self.bridge_system.add_system(
-            self.gas_code, 
+            self.gas_code,
             self.star_to_gas_codes
         )
         self.bridge_system.add_system(
-            self.star_code, 
+            self.star_code,
             self.gas_to_star_codes
         )
-    
+
     def stop(self):
         self.star_code.stop()
         self.gas_code.stop()
-        
+
     def new_gas_code_gadget(self):
         result = Gadget2(self.converter)
         return result
-        
+
     def new_star_code_hermite(self):
         result = Hermite(self.converter)
         result.parameters.epsilon_squared = self.star_epsilon ** 2
         return result
-        
+
     def new_particles_cluster(self):
-        particles=plummer.new_plummer_model(self.nstars,convert_nbody=self.converter)
+        particles = plummer.new_plummer_model(
+            self.nstars, convert_nbody=self.converter)
         particles.radius = self.star_epsilon
         particles.mass = (1.0/self.nstars) * self.star_mass
         return particles
 
     def new_gas_cluster(self):
-        particles=gasplummer.new_plummer_gas_model(self.ngas,convert_nbody=self.converter)
+        particles = gasplummer.new_plummer_gas_model(
+            self.ngas, convert_nbody=self.converter)
         particles.h_smooth = self.gas_epsilon
         particles.mass = (1.0/self.ngas) * self.gas_mass
         return particles
-        
+
     def evolve_model(self, time_end):
 
         time_end_in_si = self.converter.to_si(time_end)
@@ -162,43 +171,47 @@ class BridgeStarAndGasPlummerCode(object):
             self.code.evolve_model(self.time)
             print("evolved to time:", self.converter.to_nbody(self.code.time))
             self.store_values()
-            
+
         self.channel_from_code_to_memory_for_stars.copy()
         self.channel_from_code_to_memory_for_gas.copy()
-        
+
         self.print_log()
-        
+
     def print_log(self):
         time = self.converter.to_nbody(self.time).value_in(nbody_system.time)
-        sum_energy = self.code.kinetic_energy + self.code.potential_energy + self.code.thermal_energy
-        energy = self.converter.to_nbody(sum_energy).value_in(nbody_system.energy)
+        sum_energy = self.code.kinetic_energy + \
+            self.code.potential_energy + self.code.thermal_energy
+        energy = self.converter.to_nbody(
+            sum_energy).value_in(nbody_system.energy)
         coreradius = self.star_code.particles.virial_radius().value_in(self.rscale.to_unit())
-        
+
         print("Time          :", time)
         print("Energy        :", energy)
         print("Virial radius :", coreradius)
-        
+
     def store_values(self):
-        
+
         time = self.converter.to_nbody(self.time)
-        sum_energy = self.code.kinetic_energy + self.code.potential_energy + self.code.thermal_energy
+        sum_energy = self.code.kinetic_energy + \
+            self.code.potential_energy + self.code.thermal_energy
         energy = self.converter.to_nbody(sum_energy)
         coreradius = self.star_code.particles.virial_radius()
-        
+
         self.times.append(time)
         self.energy_at_time.append(energy)
         self.coreradius_at_time.append(coreradius)
-    
+
+
 if __name__ == "__main__":
     code = BridgeStarAndGasPlummerCode(
-        nstars = 100,
-        diagnostic_timestep = 0.5 | nbody_system.time
+        nstars=100,
+        diagnostic_timestep=0.5 | nbody_system.time
     )
     code.setup()
     code.evolve_model(4.0 | nbody_system.time)
-    
-    figure = pyplot.figure(figsize= (5,10))
-    
+
+    figure = pyplot.figure(figsize=(5, 10))
+
     subplot = figure.add_subplot(2, 1, 1)
     subplot.plot(
         code.times.value_in(nbody_system.time),

--- a/examples/simple/gas_in_cluster.py
+++ b/examples/simple/gas_in_cluster.py
@@ -1,9 +1,12 @@
 """
 Simultaniously evolves gas and stars in a cluster.
 
-The stars and gas particles evolve in their respective codes (Hermite and Gadget2)
-The force of the gas particles on the star particles is calculated by a seperate code (BHTree)
-The force of the star particles on the gas particles is calculated by the star code (Hermite)
+The stars and gas particles evolve in their respective codes (Hermite and
+Gadget2)
+The force of the gas particles on the star particles is calculated by a
+seperate code (BHTree)
+The force of the star particles on the gas particles is calculated by the star
+code (Hermite)
 
 The bridge works in S.I. units, but for this example all times and energies are
 reported in nbody units.
@@ -20,8 +23,8 @@ from amuse.ic import plummer
 from amuse.ic import gasplummer
 
 from amuse.units import units
-from amuse.units import constants
-from amuse.units import quantities
+# from amuse.units import constants
+# from amuse.units import quantities
 from amuse.units import nbody_system
 
 import numpy
@@ -31,7 +34,8 @@ from matplotlib import pyplot
 class BridgeStarAndGasPlummerCode(object):
     """
     Calculates a cluster with stars and gas, using a fixed set of codes
-    (Hermite for stars, Gadget2 for gas and BHTree for gas to star interaction).
+    (Hermite for stars, Gadget2 for gas and BHTree for gas to star
+    interaction).
     """
 
     def __init__(
@@ -48,7 +52,7 @@ class BridgeStarAndGasPlummerCode(object):
             diagnostic_timestep=0.1 | nbody_system.time
             ):
 
-        if not seed is None:
+        if seed is not None:
             numpy.random.seed(seed)
 
         if ngas is None:
@@ -116,10 +120,10 @@ class BridgeStarAndGasPlummerCode(object):
         self.star_code.particles.add_particles(self.particles)
         self.gas_code.gas_particles.add_particles(self.gas_particles)
 
-        self.channel_from_code_to_memory_for_stars = self.star_code.particles.new_channel_to(
-            self.particles)
-        self.channel_from_code_to_memory_for_gas = self.gas_code.gas_particles.new_channel_to(
-            self.gas_particles)
+        self.channel_from_code_to_memory_for_stars = \
+            self.star_code.particles.new_channel_to(self.particles)
+        self.channel_from_code_to_memory_for_gas = \
+            self.gas_code.gas_particles.new_channel_to(self.gas_particles)
 
     def create_bridge(self):
         self.bridge_system = bridge.Bridge(
@@ -183,7 +187,8 @@ class BridgeStarAndGasPlummerCode(object):
             self.code.potential_energy + self.code.thermal_energy
         energy = self.converter.to_nbody(
             sum_energy).value_in(nbody_system.energy)
-        coreradius = self.star_code.particles.virial_radius().value_in(self.rscale.to_unit())
+        coreradius = self.star_code.particles.virial_radius().value_in(
+                self.rscale.to_unit())
 
         print("Time          :", time)
         print("Energy        :", energy)

--- a/examples/simple/grav_stellar_simple.py
+++ b/examples/simple/grav_stellar_simple.py
@@ -1,5 +1,6 @@
 """
-    simple coupling of a stellar evolution and a gravitational code to simulate a cluster of stars.
+    simple coupling of a stellar evolution and a gravitational code to simulate
+    a cluster of stars.
 """
 from __future__ import print_function
 

--- a/examples/simple/grav_stellar_simple.py
+++ b/examples/simple/grav_stellar_simple.py
@@ -23,7 +23,8 @@ from amuse.support.console import set_printing_strategy
 
 
 def create_stars(number_of_stars, size):
-    masses = new_salpeter_mass_distribution(number_of_stars, mass_min = 2|units.MSun)
+    masses = new_salpeter_mass_distribution(
+        number_of_stars, mass_min=2 | units.MSun)
     converter = nbody_system.nbody_to_si(masses.sum(), size)
     stars = new_plummer_model(number_of_stars, convert_nbody=converter)
     stars.mass = masses
@@ -31,18 +32,23 @@ def create_stars(number_of_stars, size):
 
     return stars, converter
 
+
 def plot_results(stars, time):
     mass_loss = stars.zams_mass - stars.mass
 
     x = stars.x.in_(units.parsec)
     y = stars.y.in_(units.parsec)
 
-    pyplot.figure(figsize=(8,8))
+    pyplot.figure(figsize=(8, 8))
     aplot.plot(x, y, "*")
 
     for x, y, mass_loss in zip(x.number, y.number, mass_loss):
-        pyplot.annotate("%0.2f"%abs(mass_loss.number), xy=(x,y+2),
-            horizontalalignment='center', verticalalignment='bottom')
+        pyplot.annotate(
+                "%0.2f" % abs(mass_loss.number),
+                xy=(x, y+2),
+                horizontalalignment='center',
+                verticalalignment='bottom',
+                )
 
     pyplot.axis('equal')
     pyplot.xlim([-60, 60])
@@ -59,7 +65,10 @@ def plot_results(stars, time):
     pyplot.savefig(name)
     pyplot.close()
 
-def gravity_and_stellar_evolution(number_of_stars, size, end_time, sync_timestep=1|units.Myr, plot_timestep=10|units.Myr):
+
+def gravity_and_stellar_evolution(
+        number_of_stars, size, end_time, sync_timestep=1 | units.Myr,
+        plot_timestep=10 | units.Myr):
 
     stars, converter = create_stars(number_of_stars, size)
 
@@ -72,7 +81,8 @@ def gravity_and_stellar_evolution(number_of_stars, size, end_time, sync_timestep
 
     bridge.add_system(gravity)
     bridge.add_system(stellar)
-    bridge.channels.add_channel(stellar.particles.new_channel_to(gravity.particles, attributes=["mass", "radius"]))
+    bridge.channels.add_channel(stellar.particles.new_channel_to(
+        gravity.particles, attributes=["mass", "radius"]))
 
     bridge.timestep = sync_timestep
 
@@ -90,19 +100,29 @@ def gravity_and_stellar_evolution(number_of_stars, size, end_time, sync_timestep
 
         time += plot_timestep
 
+
 def parse_arguments():
     parser = OptionParser()
-    parser.add_option("-N", dest="number_of_stars", type="int", default=100,
-        help="The number of stars in the cluster [%default].")
-    parser.add_option("-s", dest="size", type="float", unit=units.parsec, default=10,
-        help="The total size of the cluster [%default %unit].")
-    parser.add_option("-t", dest="end_time", type="float", unit=units.Gyr, default=0.1,
-        help="The end time of the simulation [%default %unit].")
+    parser.add_option(
+            "-N", dest="number_of_stars", type="int", default=100,
+            help="The number of stars in the cluster [%default].")
+    parser.add_option(
+            "-s", dest="size", type="float", unit=units.parsec, default=10,
+            help="The total size of the cluster [%default %unit].")
+    parser.add_option(
+            "-t", dest="end_time", type="float", unit=units.Gyr, default=0.1,
+            help="The end time of the simulation [%default %unit].")
 
     options, args = parser.parse_args()
     return options.__dict__
 
+
 if __name__ == "__main__":
     options = parse_arguments()
-    set_printing_strategy("custom", preferred_units = [units.MSun, units.parsec, units.Myr], precision=3)
+    set_printing_strategy(
+            "custom",
+            preferred_units=[
+                units.MSun, units.parsec, units.Myr
+                ],
+            precision=3)
     gravity_and_stellar_evolution(**options)

--- a/examples/simple/grid_potential.py
+++ b/examples/simple/grid_potential.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
-from amuse.lab import *
+from amuse.lab import (
+        units, nbody_system, Particle,
+        Athena, Hermite,
+        )
 
 from matplotlib import pyplot
 
@@ -77,7 +80,7 @@ def hydro_grid_in_potential_well(mass=1 | units.MSun, length=100 | units.AU):
     print(instance.get_timestep().value_in(units.yr))
     value_to_plot = instance.grid.rho[..., ..., 0].value_in(
         units.MSun / units.AU**3)
-    #value_to_plot = potential[...,...,0].value_in(potential.unit)
+    # value_to_plot = potential[...,...,0].value_in(potential.unit)
     plot_grid(value_to_plot)
 
 

--- a/examples/simple/grid_potential.py
+++ b/examples/simple/grid_potential.py
@@ -3,84 +3,92 @@ from amuse.lab import *
 
 from matplotlib import pyplot
 
-def hydro_grid_in_potential_well(mass = 1 | units.MSun, length = 100 | units.AU):
+
+def hydro_grid_in_potential_well(mass=1 | units.MSun, length=100 | units.AU):
     converter = nbody_system.nbody_to_si(mass, length)
-    
+
     # calculate density in field based on solar wind
     # gives a very low number
     molar_mass_hydrogen_proton = 1 | units.g / units.mol
     density_hydrogen_in_stellar_wind = 10 | 1 / units.cm**3
-    particles_per_mol =  6.022e23 | 1 / units.mol
-    density_hydrogen_in_stellar_wind_in_moles = density_hydrogen_in_stellar_wind / particles_per_mol
-    density_gas = 100 * (density_hydrogen_in_stellar_wind_in_moles * molar_mass_hydrogen_proton).as_quantity_in(units.MSun / units.AU**3)
-    
+    particles_per_mol = 6.022e23 | 1 / units.mol
+    density_hydrogen_in_stellar_wind_in_moles = (
+            density_hydrogen_in_stellar_wind
+            / particles_per_mol
+            )
+    density_gas = 100 * (
+            density_hydrogen_in_stellar_wind_in_moles
+            * molar_mass_hydrogen_proton
+            ).as_quantity_in(units.MSun / units.AU**3)
+
     # override with higher number for plotting
     density_gas = 1e-3 | units.MSun / units.AU**3
-    
-    instance=Athena(converter)
+
+    instance = Athena(converter)
     instance.initialize_code()
     instance.parameters.nx = 50
     instance.parameters.ny = 50
     instance.parameters.nz = 1
-    instance.parameters.length_x = length 
+    instance.parameters.length_x = length
     instance.parameters.length_y = length
     instance.parameters.length_z = length
-    instance.parameters.x_boundary_conditions = ("periodic","periodic")
-    instance.parameters.y_boundary_conditions = ("periodic","periodic")
-    instance.parameters.z_boundary_conditions = ("outflow","outflow")
-    
-    #instance.stopping_conditions.number_of_steps_detection.enable()
-    
+    instance.parameters.x_boundary_conditions = ("periodic", "periodic")
+    instance.parameters.y_boundary_conditions = ("periodic", "periodic")
+    instance.parameters.z_boundary_conditions = ("outflow", "outflow")
+
+    # instance.stopping_conditions.number_of_steps_detection.enable()
+
     instance.set_has_external_gravitational_potential(1)
-    
+
     instance.commit_parameters()
-    
+
     grid_in_memory = instance.grid.copy()
-    grid_in_memory.rho  = density_gas
-    pressure =  1 | units.Pa
-    
-    grid_in_memory.energy =  pressure / (instance.parameters.gamma- 1)
+    grid_in_memory.rho = density_gas
+    pressure = 1 | units.Pa
+
+    grid_in_memory.energy = pressure / (instance.parameters.gamma - 1)
     channel = grid_in_memory.new_channel_to(instance.grid)
     channel.copy()
-    
+
     instance.initialize_grid()
     particle = Particle(
-        mass = mass,
-        position = length * [0.5, 0.5, 0.5],
-        velocity = [0.0, 0.0, 0.0] | units.kms
+        mass=mass,
+        position=length * [0.5, 0.5, 0.5],
+        velocity=[0.0, 0.0, 0.0] | units.kms
     )
-    
+
     gravity = Hermite(converter)
-    dx = (grid_in_memory.x[1][0][0] - grid_in_memory.x[0][0][0]).as_quantity_in(units.AU)
-    gravity.parameters.epsilon_squared = dx**2 
+    dx = (grid_in_memory.x[1][0][0] - grid_in_memory.x[0]
+          [0][0]).as_quantity_in(units.AU)
+    gravity.parameters.epsilon_squared = dx**2
     gravity.particles.add_particle(particle)
-    
-    
+
     potential = gravity.get_potential_at_point(
         0 * instance.potential_grid.x.flatten(),
         instance.potential_grid.x.flatten(),
         instance.potential_grid.y.flatten(),
         instance.potential_grid.z.flatten()
     )
-    
-    potential =  potential.reshape(instance.potential_grid.x.shape)
-    instance.potential_grid.potential =  potential
-    
+
+    potential = potential.reshape(instance.potential_grid.x.shape)
+    instance.potential_grid.potential = potential
+
     instance.evolve_model(100 | units.yr)
     print(instance.get_timestep().value_in(units.yr))
-    value_to_plot = instance.grid.rho[...,...,0].value_in(units.MSun / units.AU**3)
+    value_to_plot = instance.grid.rho[..., ..., 0].value_in(
+        units.MSun / units.AU**3)
     #value_to_plot = potential[...,...,0].value_in(potential.unit)
     plot_grid(value_to_plot)
-    
+
+
 def plot_grid(x):
-    figure = pyplot.figure(figsize=(6,6))
-    plot = figure.add_subplot(1,1,1)
-    mappable = plot.imshow(x, origin = 'lower')
+    figure = pyplot.figure(figsize=(6, 6))
+    plot = figure.add_subplot(1, 1, 1)
+    mappable = plot.imshow(x, origin='lower')
     pyplot.colorbar(mappable)
-    #figure.savefig('orszag_tang.png')
+    # figure.savefig('orszag_tang.png')
     pyplot.show()
-    
-    
+
+
 if __name__ == '__main__':
     hydro_grid_in_potential_well()
-        

--- a/examples/simple/h2region.py
+++ b/examples/simple/h2region.py
@@ -19,16 +19,17 @@ from amuse.datamodel import Grid
 from amuse.io import write_set_to_file
 
 
-
 def make_grid(number_of_grid_cells, length, constant_hydrogen_density, inner_radius, outer_radius):
-    grid = Grid.create([number_of_grid_cells] * 3, length.as_vector_with_length(3))
-    
+    grid = Grid.create([number_of_grid_cells] * 3,
+                       length.as_vector_with_length(3))
+
     grid.radius = grid.position.lengths()
     grid.hydrogen_density = constant_hydrogen_density
     grid.hydrogen_density[grid.radius <= inner_radius] = 0 | units.cm ** -3
     grid.hydrogen_density[grid.radius >= outer_radius] = 0 | units.cm ** -3
     return grid
-    
+
+
 def setup_abundancies(code):
     table = code.abundancies_table()
     for atom in table.keys():
@@ -41,125 +42,131 @@ def setup_abundancies(code):
     table['Ne'] = 5.e-5
     table['S'] = 9.e-6
 
+
 def plot_temperature_line(radii, electron_temperatures):
-    
-    pyplot.figure(figsize=(8,8))
-    
+
+    pyplot.figure(figsize=(8, 8))
+
     pyplot.scatter(
         radii.value_in(1e17 * units.cm),
-        electron_temperatures.value_in(units.K)        
+        electron_temperatures.value_in(units.K)
     )
     pyplot.title('electron temperature')
     pyplot.xlabel('10^17 cm')
     pyplot.ylabel('K')
     pyplot.xlim(30, 100)
-    pyplot.ylim(5500,7500)
+    pyplot.ylim(5500, 7500)
     pyplot.show()
-    
-def main(number_of_grid_cells = 15, min_convergence = 20):
+
+
+def main(number_of_grid_cells=15, min_convergence=20):
     inner_radius = 30.0e17 | units.cm
     outer_radius = 95.0e17 | units.cm
-    
+
     hydrogen_density = 100 | units.cm ** -3
-    
-    star=Particle()
+
+    star = Particle()
     star.position = [0.0, 0.0, 0.0] | units.AU
     star.temperature = 20000 | units.K
     star.luminosity = 600.5 | 1e37 * units.erg * (units.s**-1)
-    
-    grid=make_grid(
-        number_of_grid_cells = number_of_grid_cells,
-        length = outer_radius,
-        constant_hydrogen_density = hydrogen_density,
-        inner_radius = inner_radius,
-        outer_radius = outer_radius
+
+    grid = make_grid(
+        number_of_grid_cells=number_of_grid_cells,
+        length=outer_radius,
+        constant_hydrogen_density=hydrogen_density,
+        inner_radius=inner_radius,
+        outer_radius=outer_radius
     )
-    
-    radiative_transfer = Mocassin(number_of_workers = 2) #, debugger = "xterm")
-    
-    radiative_transfer.set_input_directory(radiative_transfer.get_default_input_directory())
-    radiative_transfer.set_mocassin_output_directory(radiative_transfer.output_directory  + os.sep)
-    
+
+    radiative_transfer = Mocassin(number_of_workers=2)  # , debugger = "xterm")
+
+    radiative_transfer.set_input_directory(
+        radiative_transfer.get_default_input_directory())
+    radiative_transfer.set_mocassin_output_directory(
+        radiative_transfer.output_directory + os.sep)
+
     radiative_transfer.initialize_code()
-    
+
     radiative_transfer.set_symmetricXYZ(True)
-    
+
     radiative_transfer.parameters.length_x = outer_radius
     radiative_transfer.parameters.length_y = outer_radius
     radiative_transfer.parameters.length_z = outer_radius
-    radiative_transfer.parameters.mesh_size = [number_of_grid_cells, number_of_grid_cells, number_of_grid_cells]
+    radiative_transfer.parameters.mesh_size = [
+        number_of_grid_cells, number_of_grid_cells, number_of_grid_cells]
     setup_abundancies(radiative_transfer)
-    
+
     radiative_transfer.parameters.initial_nebular_temperature = 6000.0 | units.K
     radiative_transfer.parameters.high_limit_of_the_frequency_mesh = 15 | mocassin_rydberg_unit
-    radiative_transfer.parameters.low_limit_of_the_frequency_mesh  = 1.001e-5 | mocassin_rydberg_unit
-    
+    radiative_transfer.parameters.low_limit_of_the_frequency_mesh = 1.001e-5 | mocassin_rydberg_unit
+
     radiative_transfer.parameters.total_number_of_photons = 10000000
     radiative_transfer.parameters.total_number_of_points_in_frequency_mesh = 600
     radiative_transfer.parameters.convergence_limit = 0.09
     radiative_transfer.parameters.number_of_ionisation_stages = 6
-    
+
     radiative_transfer.commit_parameters()
     radiative_transfer.grid.hydrogen_density = grid.hydrogen_density
     radiative_transfer.commit_grid()
     radiative_transfer.particles.add_particle(star)
     radiative_transfer.commit_particles()
-    
+
     max_number_of_photons = radiative_transfer.parameters.total_number_of_photons * 100
-    
+
     previous_percentage_converged = 0.0
-    
+
     for i in range(20):
         radiative_transfer.step()
-        
+
         percentage_converged = radiative_transfer.get_percentage_converged()
-        print("percentage converged :", percentage_converged, ", step :", i, ", photons:", radiative_transfer.parameters.total_number_of_photons)
-        
+        print("percentage converged :", percentage_converged, ", step :", i,
+              ", photons:", radiative_transfer.parameters.total_number_of_photons)
+
         if percentage_converged >= min_convergence:
             break
-            
+
         if previous_percentage_converged > 5 and percentage_converged < 95:
-            convergence_increase = (percentage_converged-previous_percentage_converged)/previous_percentage_converged
+            convergence_increase = (
+                percentage_converged-previous_percentage_converged)/previous_percentage_converged
             if convergence_increase < 0.2 and radiative_transfer.parameters.total_number_of_photons < max_number_of_photons:
                 radiative_transfer.parameters.total_number_of_photons *= 2
-                    
-        previous_percentage_converged = percentage_converged    
-        
-    
+
+        previous_percentage_converged = percentage_converged
+
     grid.electron_temperature = radiative_transfer.grid.electron_temperature
-    
+
     radius = grid.radius.flatten()
     electron_temperature = grid.electron_temperature.flatten()
     selection = electron_temperature > 0 | units.K
-    
+
     plot_temperature_line(radius[selection], electron_temperature[selection])
-    
+
     write_set_to_file(grid, 'h2region.h5', 'amuse')
-    
+
 
 def new_option_parser():
     result = OptionParser()
     result.add_option(
-        "-n", "--gridcells", 
-        default = 13,
+        "-n", "--gridcells",
+        default=13,
         dest="number_of_grid_cells",
         help="number of cells in each direction",
         type="int"
     )
     result.add_option(
-        "-c", "--min-convergence", 
-        default = 60,
+        "-c", "--min-convergence",
+        default=60,
         dest="min_convergence",
         help="stop the iteratation when the solution is converged to the given percentage (in whole numbers between 10 and 100)",
         type="int"
     )
-    
+
     return result
-    
+
+
 if __name__ == "__plot__":
     main(13, 30)
-    
+
 if __name__ == "__main__":
     options, arguments = new_option_parser().parse_args()
     main(**options.__dict__)
-    

--- a/examples/simple/h2region.py
+++ b/examples/simple/h2region.py
@@ -3,7 +3,7 @@ Evolves the steady state solution of a star irridiating a H2 region.
 """
 from __future__ import print_function
 
-import numpy
+# import numpy
 import os
 from matplotlib import pyplot
 from optparse import OptionParser
@@ -11,15 +11,17 @@ from optparse import OptionParser
 from amuse.community.mocassin.interface import Mocassin, mocassin_rydberg_unit
 
 from amuse.units import units
-from amuse.units import nbody_system
+# from amuse.units import nbody_system
 
-from amuse.ext.protodisk import ProtoPlanetaryDisk
+# from amuse.ext.protodisk import ProtoPlanetaryDisk
 from amuse.datamodel import Particle
 from amuse.datamodel import Grid
 from amuse.io import write_set_to_file
 
 
-def make_grid(number_of_grid_cells, length, constant_hydrogen_density, inner_radius, outer_radius):
+def make_grid(
+        number_of_grid_cells, length, constant_hydrogen_density, inner_radius,
+        outer_radius):
     grid = Grid.create([number_of_grid_cells] * 3,
                        length.as_vector_with_length(3))
 
@@ -119,16 +121,23 @@ def main(number_of_grid_cells=15, min_convergence=20):
         radiative_transfer.step()
 
         percentage_converged = radiative_transfer.get_percentage_converged()
-        print("percentage converged :", percentage_converged, ", step :", i,
-              ", photons:", radiative_transfer.parameters.total_number_of_photons)
+        print(
+                "percentage converged :", percentage_converged,
+                ", step :", i,
+                ", photons:",
+                radiative_transfer.parameters.total_number_of_photons)
 
         if percentage_converged >= min_convergence:
             break
 
         if previous_percentage_converged > 5 and percentage_converged < 95:
             convergence_increase = (
-                percentage_converged-previous_percentage_converged)/previous_percentage_converged
-            if convergence_increase < 0.2 and radiative_transfer.parameters.total_number_of_photons < max_number_of_photons:
+                percentage_converged - previous_percentage_converged
+                ) / previous_percentage_converged
+            if (
+                    convergence_increase < 0.2
+                    and radiative_transfer.parameters.total_number_of_photons < max_number_of_photons
+                    ):
                 radiative_transfer.parameters.total_number_of_photons *= 2
 
         previous_percentage_converged = percentage_converged

--- a/examples/simple/helium_star.py
+++ b/examples/simple/helium_star.py
@@ -23,7 +23,9 @@ def main():
     stellar_evolution = MESA()
     se_star = stellar_evolution.particles.add_particle(star)
 
-    print("Evolving a", star.mass, "star with", stellar_evolution.__class__.__name__, end=' ')
+    print(
+            "Evolving a", star.mass,
+            "star with", stellar_evolution.__class__.__name__, end=' ')
     print("until its radius exceeds", stop_radius)
     while (se_star.radius < stop_radius):
         se_star.evolve_one_step()
@@ -69,10 +71,15 @@ def main():
           stellar_evolution.particles)
 
     stellar_evolution.stop()
-    return temperatures_original, luminosities_original, temperatures_helium, luminosities_helium
+    return (
+            temperatures_original, luminosities_original, temperatures_helium,
+            luminosities_helium
+            )
 
 
-def plot_tracks(temperatures_original, luminosities_original, temperatures_helium, luminosities_helium):
+def plot_tracks(
+        temperatures_original, luminosities_original, temperatures_helium,
+        luminosities_helium):
     pyplot.figure(figsize=(8, 6))
     pyplot.title('Hertzsprung-Russell diagram', fontsize=12)
 
@@ -87,6 +94,7 @@ def plot_tracks(temperatures_original, luminosities_original, temperatures_heliu
 
 
 if __name__ == "__main__":
-    temperatures_original, luminosities_original, temperatures_helium, luminosities_helium = main()
+    temperatures_original, luminosities_original, temperatures_helium, \
+            luminosities_helium = main()
     plot_tracks(temperatures_original, luminosities_original,
                 temperatures_helium, luminosities_helium)

--- a/examples/simple/helium_star.py
+++ b/examples/simple/helium_star.py
@@ -9,71 +9,84 @@ from amuse.community.mesa.interface import MESA
 from matplotlib import pyplot
 from amuse.plot import loglog, xlabel, ylabel
 
+
 def main():
     temperatures_original = [] | units.K
     luminosities_original = [] | units.LSun
     temperatures_helium = [] | units.K
     luminosities_helium = [] | units.LSun
-    
-    star =  Particle()
+
+    star = Particle()
     star.mass = 10.0 | units.MSun
     stop_radius = 100 | units.RSun
-    
+
     stellar_evolution = MESA()
     se_star = stellar_evolution.particles.add_particle(star)
-    
-    print("Evolving a", star.mass, "star with", stellar_evolution.__class__.__name__, end=' ') 
+
+    print("Evolving a", star.mass, "star with", stellar_evolution.__class__.__name__, end=' ')
     print("until its radius exceeds", stop_radius)
     while (se_star.radius < stop_radius):
         se_star.evolve_one_step()
         temperatures_original.append(se_star.temperature)
         luminosities_original.append(se_star.luminosity)
-    
+
     number_of_zones = se_star.get_number_of_zones()
-    composition     = se_star.get_chemical_abundance_profiles(number_of_zones = number_of_zones)
-    index = (composition[0] > 1.0e-9).nonzero()[0][0] # first index where H fraction > 1.0e-9
-    
-    print("Creating helium star, from the inner", index, "(out of", str(number_of_zones)+") shells.")
+    composition = se_star.get_chemical_abundance_profiles(
+        number_of_zones=number_of_zones)
+    # first index where H fraction > 1.0e-9
+    index = (composition[0] > 1.0e-9).nonzero()[0][0]
+
+    print("Creating helium star, from the inner", index,
+          "(out of", str(number_of_zones)+") shells.")
     helium_star = stellar_evolution.new_particle_from_model(dict(
-        mass = (se_star.get_cumulative_mass_profile(number_of_zones = number_of_zones) * se_star.mass)[:index],
-        radius = se_star.get_radius_profile(number_of_zones = number_of_zones)[:index],
-        rho    = se_star.get_density_profile(number_of_zones = number_of_zones)[:index],
-        temperature = se_star.get_temperature_profile(number_of_zones = number_of_zones)[:index],
-        luminosity  = se_star.get_luminosity_profile(number_of_zones = number_of_zones)[:index],
-        X_H  = composition[0][:index],
-        X_He = composition[1][:index] + composition[2][:index],
-        X_C  = composition[3][:index],
-        X_N  = composition[4][:index],
-        X_O  = composition[5][:index],
-        X_Ne = composition[6][:index],
-        X_Mg = composition[7][:index],
-        X_Si = composition[7][:index]*0.0,
-        X_Fe = composition[7][:index]*0.0), 0.0 | units.Myr)
-    
-    print("\nStar properties before helium star evolution:\n", stellar_evolution.particles)
+        mass=(se_star.get_cumulative_mass_profile(
+            number_of_zones=number_of_zones) * se_star.mass)[:index],
+        radius=se_star.get_radius_profile(
+            number_of_zones=number_of_zones)[:index],
+        rho=se_star.get_density_profile(
+            number_of_zones=number_of_zones)[:index],
+        temperature=se_star.get_temperature_profile(
+            number_of_zones=number_of_zones)[:index],
+        luminosity=se_star.get_luminosity_profile(
+            number_of_zones=number_of_zones)[:index],
+        X_H=composition[0][:index],
+        X_He=composition[1][:index] + composition[2][:index],
+        X_C=composition[3][:index],
+        X_N=composition[4][:index],
+        X_O=composition[5][:index],
+        X_Ne=composition[6][:index],
+        X_Mg=composition[7][:index],
+        X_Si=composition[7][:index]*0.0,
+        X_Fe=composition[7][:index]*0.0), 0.0 | units.Myr)
+
+    print("\nStar properties before helium star evolution:\n",
+          stellar_evolution.particles)
     for i in range(1000):
         helium_star.evolve_one_step()
         temperatures_helium.append(helium_star.temperature)
         luminosities_helium.append(helium_star.luminosity)
-    print("\nStar properties after helium star evolution:\n", stellar_evolution.particles)
-    
+    print("\nStar properties after helium star evolution:\n",
+          stellar_evolution.particles)
+
     stellar_evolution.stop()
     return temperatures_original, luminosities_original, temperatures_helium, luminosities_helium
 
+
 def plot_tracks(temperatures_original, luminosities_original, temperatures_helium, luminosities_helium):
-    pyplot.figure(figsize = (8, 6))
+    pyplot.figure(figsize=(8, 6))
     pyplot.title('Hertzsprung-Russell diagram', fontsize=12)
-    
+
     loglog(temperatures_original, luminosities_original, label='progenitor')
     loglog(temperatures_helium, luminosities_helium, label='helium star')
     xlabel('Effective Temperature')
     ylabel('Luminosity')
     pyplot.xlim(pyplot.xlim()[::-1])
-    pyplot.ylim(1.0,1.0e5)
+    pyplot.ylim(1.0, 1.0e5)
     pyplot.legend(loc=3)
     pyplot.show()
 
 
-if __name__ == "__main__":       
+if __name__ == "__main__":
     temperatures_original, luminosities_original, temperatures_helium, luminosities_helium = main()
-    plot_tracks(temperatures_original, luminosities_original, temperatures_helium, luminosities_helium)
+    plot_tracks(temperatures_original, luminosities_original,
+                temperatures_helium, luminosities_helium)

--- a/examples/simple/hrdiagram.py
+++ b/examples/simple/hrdiagram.py
@@ -3,8 +3,8 @@ Generates a Hertzsprung-Russell diagram for a single star
 """
 from __future__ import print_function
 
-import sys
-import numpy
+# import sys
+# import numpy
 from matplotlib import pyplot
 from amuse.plot import loglog, xlabel, ylabel
 
@@ -12,7 +12,7 @@ from amuse.units import units
 from amuse.community.sse.interface import SSE
 
 from amuse import datamodel
-from amuse.rfi.core import is_mpd_running
+# from amuse.rfi.core import is_mpd_running
 end_time = 2 | units.Gyr
 stellar_mass = 2.0 | units.MSun
 

--- a/examples/simple/hrdiagram.py
+++ b/examples/simple/hrdiagram.py
@@ -14,19 +14,20 @@ from amuse.community.sse.interface import SSE
 from amuse import datamodel
 from amuse.rfi.core import is_mpd_running
 end_time = 2 | units.Gyr
-stellar_mass =  2.0 | units.MSun
+stellar_mass = 2.0 | units.MSun
+
 
 def simulate_evolution_tracks():
     stellar_evolution = SSE()
 
     star = datamodel.Particle()
     star.mass = stellar_mass
-    
+
     star = stellar_evolution.particles.add_particle(star)
-    
+
     luminosity_at_time = [] | units.LSun
     temperature_at_time = [] | units.K
-    
+
     print("Evolving a star with mass:", stellar_mass)
     is_evolving = True
     while is_evolving and star.age < end_time:
@@ -39,23 +40,24 @@ def simulate_evolution_tracks():
         # is seen in the hr diagram
         stellar_evolution.evolve_model()
         is_evolving = (star.age != previous_age)
-        
+
     stellar_evolution.stop()
-    
+
     return temperature_at_time, luminosity_at_time
-    
+
+
 def plot_track(temperature_at_time, luminosity_at_time):
-    pyplot.figure(figsize = (8, 6))
+    pyplot.figure(figsize=(8, 6))
     pyplot.title('Hertzsprung-Russell diagram', fontsize=12)
-    
+
     loglog(temperature_at_time, luminosity_at_time)
     xlabel('Effective Temperature')
     ylabel('Luminosity')
     pyplot.xlim(pyplot.xlim()[::-1])
-    pyplot.ylim(.1,1.e4)
+    pyplot.ylim(.1, 1.e4)
     pyplot.show()
-    
 
-if __name__ == "__main__":    
+
+if __name__ == "__main__":
     temperatures, luminosities = simulate_evolution_tracks()
     plot_track(temperatures, luminosities)

--- a/examples/simple/hydro_star.py
+++ b/examples/simple/hydro_star.py
@@ -9,19 +9,21 @@ from amuse.ext.star_to_sph import convert_stellar_model_to_SPH
 from amuse.plot import sph_particles_plot, native_plot
 from amuse.datamodel import Particle
 
+
 def create_particles():
-    star =  Particle()
+    star = Particle()
     star.mass = 3.0 | units.MSun
-    
+
     stellar_evolution = EVtwin()
     se_star = stellar_evolution.particles.add_particle(star)
-    
-    print("Evolving", star.mass, "star with", stellar_evolution.__class__.__name__, "up to", 100 | units.Myr)
+
+    print("Evolving", star.mass, "star with",
+          stellar_evolution.__class__.__name__, "up to", 100 | units.Myr)
     stellar_evolution.evolve_model(100 | units.Myr)
-    
+
     print("Creating SPH particles from the (1D) stellar evolution model")
     sph_particles = convert_stellar_model_to_SPH(
-        se_star, 
+        se_star,
         1000
     ).gas_particles
     stellar_evolution.stop()
@@ -30,6 +32,6 @@ def create_particles():
 
 if __name__ == "__main__":
     sph_particles = create_particles()
-    native_plot.figure(figsize = (6, 6), dpi = 50)
+    native_plot.figure(figsize=(6, 6), dpi=50)
     sph_particles_plot(sph_particles)
     native_plot.show()

--- a/examples/simple/isochrone.py
+++ b/examples/simple/isochrone.py
@@ -8,26 +8,29 @@ from amuse.ic.brokenimf import new_scalo_mass_distribution
 from amuse.ext.particles_with_color import new_particles_with_blackbody_color
 from amuse.community.seba.interface import SeBa
 
+
 def simulate_stellar_evolution(particles, endtime):
     stellar_evolution = SeBa()
     stellar_evolution.particles.add_particles(particles)
     from_code_to_model = stellar_evolution.particles.new_channel_to(particles)
-    print("Evolving {0} stars using {1} up to {2}.".format(len(particles), stellar_evolution.__class__.__name__, endtime))
+    print("Evolving {0} stars using {1} up to {2}.".format(
+        len(particles), stellar_evolution.__class__.__name__, endtime))
     stellar_evolution.evolve_model(endtime)
     from_code_to_model.copy_all_attributes()
     stellar_evolution.stop()
 
+
 def plot_isochrone(particles):
     particles = new_particles_with_blackbody_color(particles)
-    pyplot.figure(figsize = (7, 8))
+    pyplot.figure(figsize=(7, 8))
     pyplot.title('Hertzsprung-Russell diagram', fontsize=12)
-    
+
     pyplot.scatter(
-        particles.temperature.value_in(units.K), 
-        particles.luminosity.value_in(units.LSun), 
-        s=particles.radius.maximum(0.1|units.RSun).value_in(units.RSun)*100, 
-        c=particles.color, 
-        edgecolors = "none", 
+        particles.temperature.value_in(units.K),
+        particles.luminosity.value_in(units.LSun),
+        s=particles.radius.maximum(0.1 | units.RSun).value_in(units.RSun)*100,
+        c=particles.color,
+        edgecolors="none",
     )
     pyplot.xlabel('Effective Temperature (K)')
     pyplot.ylabel('Luminosity (L$_{\odot}$)')
@@ -37,6 +40,7 @@ def plot_isochrone(particles):
     pyplot.ylim(1.0e-3, 1.0e3)
     pyplot.gca().set_axis_bgcolor('#808080')
     pyplot.show()
+
 
 if __name__ == "__main__":
     particles = Particles(mass=new_scalo_mass_distribution(4000))

--- a/examples/simple/kelvin_helmholtz.py
+++ b/examples/simple/kelvin_helmholtz.py
@@ -3,9 +3,11 @@ Runs the Kelvin-Helmholtz Instability problem in two dimensions with Athena.
 """
 import numpy
 from matplotlib import pyplot
-#from amuse.lab import *
+# from amuse.lab import *
 from amuse.community.athena.interface import Athena
-from amuse.units.generic_unit_system import *
+from amuse.units.generic_unit_system import (
+        length, mass, speed, time
+        )
 from amuse.datamodel import Grid
 
 GAMMA = 1.4

--- a/examples/simple/kelvin_helmholtz.py
+++ b/examples/simple/kelvin_helmholtz.py
@@ -9,92 +9,103 @@ from amuse.units.generic_unit_system import *
 from amuse.datamodel import Grid
 
 GAMMA = 1.4
-DIMENSIONS_OF_MESH = (200,200,1)
+DIMENSIONS_OF_MESH = (200, 200, 1)
 PERTUBATION_AMPLITUDE = 0.1 | speed
 
+
 def new_instance_of_hydro_code(number_of_workers=1):
-    result=Athena(number_of_workers = number_of_workers)
+    result = Athena(number_of_workers=number_of_workers)
     result.parameters.gamma = GAMMA
-    result.parameters.courant_number=0.8
+    result.parameters.courant_number = 0.8
     return result
+
 
 def set_parameters(instance):
     instance.parameters.mesh_size = DIMENSIONS_OF_MESH
-    
+
     instance.parameters.length_x = 1 | length
     instance.parameters.length_y = 1 | length
     instance.parameters.length_z = 1 | length
-    
-    instance.parameters.x_boundary_conditions = ("periodic","periodic")
-    instance.parameters.y_boundary_conditions = ("periodic","periodic")
-    instance.parameters.z_boundary_conditions = ("periodic","periodic")
-    
-    
+
+    instance.parameters.x_boundary_conditions = ("periodic", "periodic")
+    instance.parameters.y_boundary_conditions = ("periodic", "periodic")
+    instance.parameters.z_boundary_conditions = ("periodic", "periodic")
+
+
 def new_grid():
-    grid = Grid.create(DIMENSIONS_OF_MESH, [1,1,1] | length)
+    grid = Grid.create(DIMENSIONS_OF_MESH, [1, 1, 1] | length)
     clear_grid(grid)
     return grid
-    
+
+
 def clear_grid(grid):
     density = mass / length**3
-    momentum =  speed * density
-    energy =  mass / (time**2 * length)
+    momentum = speed * density
+    energy = mass / (time**2 * length)
 
-    grid.rho =  0.0 | density
+    grid.rho = 0.0 | density
     grid.rhovx = 0.0 | momentum
     grid.rhovy = 0.0 | momentum
     grid.rhovz = 0.0 | momentum
     grid.energy = 0.0 | energy
 
     return grid
-    
-def initialize_grid(grid):        
+
+
+def initialize_grid(grid):
     vx = 0.5 | speed
     p = 2.5 | (mass / (length * time**2))
-    
+
     halfway = DIMENSIONS_OF_MESH[0]/2 - 1
-    
-    outerregion = numpy.logical_or(grid.y <= 0.25 | length, grid.y >= 0.75 | length)
-    innerregion = numpy.logical_and(grid.y > 0.25 | length, grid.y < 0.75 | length)
-    
-    grid[outerregion].rho = 1  | density
-    grid[outerregion].rhovx =  vx * grid[outerregion].rho
-    
-    grid[innerregion].rho = 2.0  | density
+
+    outerregion = numpy.logical_or(
+        grid.y <= 0.25 | length, grid.y >= 0.75 | length)
+    innerregion = numpy.logical_and(
+        grid.y > 0.25 | length, grid.y < 0.75 | length)
+
+    grid[outerregion].rho = 1 | density
+    grid[outerregion].rhovx = vx * grid[outerregion].rho
+
+    grid[innerregion].rho = 2.0 | density
     grid[innerregion].rhovx = -vx * grid[innerregion].rho
-    
+
     grid.energy = p / (GAMMA - 1)
-        
+
+
 def pertubate_grid(grid):
-    grid.rhovx += grid.rho * PERTUBATION_AMPLITUDE * (numpy.random.rand(*grid.shape) - 0.5)
-    grid.rhovy += grid.rho * PERTUBATION_AMPLITUDE * (numpy.random.rand(*grid.shape) - 0.5)
-    
-    grid.energy += 0.5 * (grid.rhovx ** 2  + grid.rhovy ** 2 + grid.rhovz ** 2) / grid.rho
-        
+    grid.rhovx += grid.rho * PERTUBATION_AMPLITUDE * \
+        (numpy.random.rand(*grid.shape) - 0.5)
+    grid.rhovy += grid.rho * PERTUBATION_AMPLITUDE * \
+        (numpy.random.rand(*grid.shape) - 0.5)
+
+    grid.energy += 0.5 * (grid.rhovx ** 2 + grid.rhovy **
+                          2 + grid.rhovz ** 2) / grid.rho
+
+
 def simulate_kelvin_helmholtz_instability(end_time):
-    instance=new_instance_of_hydro_code()
+    instance = new_instance_of_hydro_code()
     set_parameters(instance)
-    
+
     print("setup grid")
     for x in instance.itergrids():
         inmem = x.copy()
-        
+
         clear_grid(inmem)
         initialize_grid(inmem)
         pertubate_grid(inmem)
-        
+
         from_model_to_code = inmem.new_channel_to(x)
         from_model_to_code.copy()
-    
+
     print("start evolve")
     dt = end_time / 10.0
     t = dt
     while t < end_time:
         instance.evolve_model(t)
-        
+
         print("time : ", t)
         t += dt
-    
+
     print("copying results")
     result = []
     for x in instance.itergrids():
@@ -104,15 +115,17 @@ def simulate_kelvin_helmholtz_instability(end_time):
     instance.stop()
 
     return result
-    
+
+
 def plot_grid(grid):
-    rho = grid.rho[...,0].value_in(density)
-    figure = pyplot.figure(figsize=(6,6))
-    plot = figure.add_subplot(1,1,1)
-    plot.imshow(rho, origin = 'lower')
+    rho = grid.rho[..., 0].value_in(density)
+    figure = pyplot.figure(figsize=(6, 6))
+    plot = figure.add_subplot(1, 1, 1)
+    plot.imshow(rho, origin='lower')
     figure.savefig('kelvin_helmholtz.png')
     pyplot.show()
-    
+
+
 if __name__ == "__main__":
     grids = simulate_kelvin_helmholtz_instability(1.0 | time)
     plot_grid(grids[0])

--- a/examples/simple/lagrange_points.py
+++ b/examples/simple/lagrange_points.py
@@ -1,9 +1,10 @@
 """
-Make a contour plot of the effective potential of the Sun-Earth system (left) 
-and a system with a 10000 times more massive Earth with the Lagrangian points visible.
+Make a contour plot of the effective potential of the Sun-Earth system (left)
+and a system with a 10000 times more massive Earth with the Lagrangian points
+visible.
 """
 
-import numpy
+# import numpy
 from matplotlib import pyplot
 from amuse.plot import xlabel, ylabel, effective_iso_potential_plot
 

--- a/examples/simple/lagrange_points.py
+++ b/examples/simple/lagrange_points.py
@@ -11,71 +11,78 @@ from amuse.units import units, constants, nbody_system
 from amuse.community.hermite0.interface import Hermite
 from amuse.datamodel import Particles
 
+
 def new_sun_earth_system():
     particles = Particles(2)
     particles.mass = [1, 3.0024584e-6] | units.MSun
     particles.position = [[0, 0, 0], [1.0, 0, 0]] | units.AU
     particles.velocity = [0, 0, 0] | units.km / units.s
-    particles[1].vy = (constants.G * particles.total_mass() / particles[1].x).sqrt()
+    particles[1].vy = (
+        constants.G * particles.total_mass() / particles[1].x).sqrt()
     return particles
 
+
 def setup_gravity_code():
-    converter = nbody_system.nbody_to_si(1.0|units.MSun, 1.0|units.AU)
+    converter = nbody_system.nbody_to_si(1.0 | units.MSun, 1.0 | units.AU)
     gravity = Hermite(converter)
     gravity.parameters.epsilon_squared = 1e-6 | units.RSun**2
     gravity.particles.add_particles(new_sun_earth_system())
     return gravity
 
+
 def make_effective_iso_potential_plot(gravity_code):
-    omega = (constants.G * gravity_code.particles.total_mass() / (1.0|units.AU**3)).sqrt()
+    omega = (constants.G * gravity_code.particles.total_mass() /
+             (1.0 | units.AU**3)).sqrt()
     center_of_mass = gravity_code.particles.center_of_mass()[:2]
-    figure = pyplot.figure(figsize = (9, 8))
+    figure = pyplot.figure(figsize=(9, 8))
     current_axes = pyplot.subplot(2, 2, 1)
-    current_axes.set_aspect("equal", adjustable = "box")
-    effective_iso_potential_plot(gravity_code, 
-        omega, 
-        center_of_rotation = center_of_mass,
-        fraction_screen_filled=0.7)
+    current_axes.set_aspect("equal", adjustable="box")
+    effective_iso_potential_plot(gravity_code,
+                                 omega,
+                                 center_of_rotation=center_of_mass,
+                                 fraction_screen_filled=0.7)
     xlabel('x')
     ylabel('y')
-    
+
     current_axes = pyplot.subplot(2, 2, 3)
-    current_axes.set_aspect("equal", adjustable = "box")
-    effective_iso_potential_plot(gravity_code, 
-        omega, 
-        center_of_rotation = center_of_mass,
-        xlim=[0.9, 1.1]|units.AU, 
-        ylim=[-0.1, 0.1]|units.AU,
-        number_of_contours=20)
+    current_axes.set_aspect("equal", adjustable="box")
+    effective_iso_potential_plot(gravity_code,
+                                 omega,
+                                 center_of_rotation=center_of_mass,
+                                 xlim=[0.9, 1.1] | units.AU,
+                                 ylim=[-0.1, 0.1] | units.AU,
+                                 number_of_contours=20)
     xlabel('x')
     ylabel('y')
-    
+
     gravity_code.particles[1].mass *= 10000
-    omega = (constants.G * gravity_code.particles.total_mass() / (1.0|units.AU**3)).sqrt()
+    omega = (constants.G * gravity_code.particles.total_mass() /
+             (1.0 | units.AU**3)).sqrt()
     center_of_mass = gravity_code.particles.center_of_mass()[:2]
     current_axes = pyplot.subplot(2, 2, 2)
-    current_axes.set_aspect("equal", adjustable = "box")
-    effective_iso_potential_plot(gravity_code, 
-        omega, 
-        center_of_rotation = center_of_mass,
-        number_of_contours=20,
-        fraction_screen_filled=0.7)
+    current_axes.set_aspect("equal", adjustable="box")
+    effective_iso_potential_plot(gravity_code,
+                                 omega,
+                                 center_of_rotation=center_of_mass,
+                                 number_of_contours=20,
+                                 fraction_screen_filled=0.7)
     xlabel('x')
     ylabel('y')
-    
+
     current_axes = pyplot.subplot(2, 2, 4)
-    current_axes.set_aspect("equal", adjustable = "box")
-    effective_iso_potential_plot(gravity_code, 
-        omega, 
-        center_of_rotation = center_of_mass,
-        xlim=[0.6, 1.4]|units.AU, 
-        ylim=[-0.4, 0.4]|units.AU,
-        number_of_contours=20,
-        fraction_screen_filled=0.9)
+    current_axes.set_aspect("equal", adjustable="box")
+    effective_iso_potential_plot(gravity_code,
+                                 omega,
+                                 center_of_rotation=center_of_mass,
+                                 xlim=[0.6, 1.4] | units.AU,
+                                 ylim=[-0.4, 0.4] | units.AU,
+                                 number_of_contours=20,
+                                 fraction_screen_filled=0.9)
     xlabel('x')
     ylabel('y')
-    pyplot.show()   
-    
+    pyplot.show()
+
+
 if __name__ == "__main__":
     gravity = setup_gravity_code()
     make_effective_iso_potential_plot(gravity)

--- a/examples/simple/massloss.py
+++ b/examples/simple/massloss.py
@@ -15,35 +15,36 @@ from amuse.plot import *
 def simulate_massloss(time):
     return units.MSun(0.5*(1.0+1.0/(1.0+numpy.exp((time.value_in(time.unit)-70.0)/15.))))
 
+
 if __name__ == "__main__":
 
     convert_nbody = nbody_system.nbody_to_si(1.0 | units.MSun, 1.0 | units.AU)
-    
+
     particles = datamodel.Particles(2)
     sun = particles[0]
     sun.mass = 1.0 | units.MSun
     sun.position = [0.0, 0.0, 0.0] | units.AU
     sun.velocity = [0.0, 0.0, 0.0] | units.AU / units.yr
     sun.radius = 1.0 | units.RSun
-    
+
     earth = particles[1]
     earth.mass = 5.9736e24 | units.kg
     earth.radius = 6371.0 | units.km
     earth.position = [0.0, 1.0, 0.0] | units.AU
     earth.velocity = [2.0*numpy.pi, -0.0001, 0.0] | units.AU / units.yr
-    
+
     instance = Hermite(convert_nbody)
     instance.particles.add_particles(particles)
 
     channelp = instance.particles.new_channel_to(particles)
-    
-    start = 0 |units.yr
+
+    start = 0 | units.yr
     end = 150 | units.yr
-    step = 10|units.day
+    step = 10 | units.day
 
     timerange = VectorQuantity.arange(start, end, step)
 
-    masses = []|units.MSun
+    masses = [] | units.MSun
 
     for i, time in enumerate(timerange):
         instance.evolve_model(time)
@@ -52,7 +53,7 @@ if __name__ == "__main__":
         if (i % 220 == 0):
             instance.particles[0].mass = simulate_massloss(time)
         masses.append(instance.particles[0].mass)
- 
+
     instance.stop()
 
     particle = particles[1]
@@ -60,6 +61,6 @@ if __name__ == "__main__":
     t, pos = particle.get_timeline_of_attribute_as_vector("position")
     distances = pos.lengths().as_quantity_in(units.AU)
 
-    plot(timerange, distances , timerange, masses)
+    plot(timerange, distances, timerange, masses)
 
     native_plot.show()

--- a/examples/simple/massloss.py
+++ b/examples/simple/massloss.py
@@ -4,16 +4,19 @@ Evolves the sun and earth where the sun will lose mass every 220th step.
 
 import numpy
 from amuse.community.hermite0.interface import Hermite
-from amuse.community.sse.interface import SSE
+# from amuse.community.sse.interface import SSE
 from amuse import datamodel
 from amuse.units import units
 from amuse.units import nbody_system
 from amuse.units.quantities import VectorQuantity
-from amuse.plot import *
+from amuse.plot import (
+        plot, native_plot)
 
 
 def simulate_massloss(time):
-    return units.MSun(0.5*(1.0+1.0/(1.0+numpy.exp((time.value_in(time.unit)-70.0)/15.))))
+    return units.MSun(
+            0.5*(1.0+1.0/(1.0+numpy.exp((time.value_in(time.unit)-70.0)/15.)))
+            )
 
 
 if __name__ == "__main__":

--- a/examples/simple/molecular_cloud.py
+++ b/examples/simple/molecular_cloud.py
@@ -1,14 +1,16 @@
 """
 Evolves a molecular cloud with explictly split gravtiy evolution
 
-The gas is evolved in a sph code, and it's gravity is determined by a tree code.
+The gas is evolved in a sph code, and it's gravity is determined by a tree
+code.
 
-Initial condition is a smooth spherical cloud with random velocities as in Bonnell et al. (2003)  
-"""  
+Initial condition is a smooth spherical cloud with random velocities as in
+Bonnell et al. (2003)
+"""
 
 import numpy
-  
-from matplotlib import pyplot 
+
+from matplotlib import pyplot
 
 from amuse.units import nbody_system
 from amuse.units import units
@@ -20,103 +22,111 @@ from amuse.ext.molecular_cloud import molecular_cloud
 from amuse.ext.evrard_test import body_centered_grid_unit_cube
 from amuse.couple import bridge
 
-def make_map(sph, N=100, grid_size= 1 | units.parsec):
-    
+
+def make_map(sph, N=100, grid_size=1 | units.parsec):
+
     cell_center_positions_1d = numpy.linspace(-0.5, 0.5, N)
-    x,y = numpy.meshgrid(cell_center_positions_1d, cell_center_positions_1d)
+    x, y = numpy.meshgrid(cell_center_positions_1d, cell_center_positions_1d)
     x = x.flatten()
     y = y.flatten()
-    
+
     x *= grid_size
     y *= grid_size
     z = x * 0.0
-    
-    vx=0.0 * x / (1.0 | units.s)
-    vy=0.0 * x / (1.0 | units.s)
-    vz=0.0 * x / (1.0 | units.s)
-    
-    rho,rhovx,rhovy,rhovz,rhoe=sph.get_hydro_state_at_point(x,y,z,vx,vy,vz)
-    rho=rho.reshape((N,N))
+
+    vx = 0.0 * x / (1.0 | units.s)
+    vy = 0.0 * x / (1.0 | units.s)
+    vz = 0.0 * x / (1.0 | units.s)
+
+    rho, rhovx, rhovy, rhovz, rhoe = sph.get_hydro_state_at_point(
+        x, y, z, vx, vy, vz)
+    rho = rho.reshape((N, N))
 
     return rho
-    
-def run_mc(N=5000,Mcloud=10000. | units.MSun,Rcloud=1. | units.parsec):
 
-    conv = nbody_system.nbody_to_si(Mcloud,Rcloud)
+
+def run_mc(N=5000, Mcloud=10000. | units.MSun, Rcloud=1. | units.parsec):
+
+    conv = nbody_system.nbody_to_si(Mcloud, Rcloud)
 
     interaction_timestep = 0.01 | units.Myr
-    time_end=0.36 | units.Myr
+    time_end = 0.36 | units.Myr
 
-    parts=molecular_cloud(targetN=N,convert_nbody=conv,
+    parts = molecular_cloud(
+            targetN=N, convert_nbody=conv,
             base_grid=body_centered_grid_unit_cube).result
 
-    sph=Fi(conv)
+    sph = Fi(conv)
 
     # need to turn off self gravity, the bridge will calculate this
-    sph.parameters.self_gravity_flag=False
-    
+    sph.parameters.self_gravity_flag = False
+
     # some typical Fi flags (just for reference, most are default values)
-    sph.parameters.use_hydro_flag=True
-    sph.parameters.isothermal_flag=True
-    sph.parameters.integrate_entropy_flag=False
-    sph.parameters.gamma=1
+    sph.parameters.use_hydro_flag = True
+    sph.parameters.isothermal_flag = True
+    sph.parameters.integrate_entropy_flag = False
+    sph.parameters.gamma = 1
     sph.parameters.verbosity = 0
-    
+
     # setting the hydro timestep is important
     # the sph code will take 2 timesteps every interaction timestep
-    sph.parameters.timestep=interaction_timestep/2  
+    sph.parameters.timestep = interaction_timestep/2
 
     sph.gas_particles.add_particles(parts)
 
     def new_code_to_calculate_gravity_of_gas_particles():
         result = BHTree(conv)
         return result
-        
-    calculate_gravity_code=bridge.CalculateFieldForCodes(
-        new_code_to_calculate_gravity_of_gas_particles,  # the code that calculates the acceleration field
-        input_codes = [sph] # the codes to calculate the acceleration field of
+
+    calculate_gravity_code = bridge.CalculateFieldForCodes(
+        # the code that calculates the acceleration field
+        new_code_to_calculate_gravity_of_gas_particles,
+        # the codes to calculate the acceleration field of
+        input_codes=[sph]
     )
-    
+
     bridged_system = bridge.Bridge()
-    bridged_system.timestep=interaction_timestep
+    bridged_system.timestep = interaction_timestep
 
     bridged_system.add_system(
-        sph,                     # the code to move the particles of
-        [calculate_gravity_code] # the codes that provide the acceleration field
+        # the code to move the particles of
+        sph,
+        # the codes that provide the acceleration field
+        [calculate_gravity_code]
     )
 
-    fig=pyplot.figure(figsize=(12,12))
+    fig = pyplot.figure(figsize=(12, 12))
 
-    ncolumn=2
-    nrow=2
-    nplot=ncolumn*nrow
+    ncolumn = 2
+    nrow = 2
+    nplot = ncolumn*nrow
 
     grid_size = 3 | units.parsec
     extent = (grid_size * (-0.5, 0.5, -0.5, 0.5)).value_in(units.parsec)
-    
+
     if nplot > 1:
         plot_timestep = time_end / (nplot - 1)
     else:
         plot_timestep = time_end
-        
+
     for i in range(nplot):
-        ttarget=i*plot_timestep
+        ttarget = i*plot_timestep
         print("evolving to time:", ttarget.as_quantity_in(units.Myr))
-        bridged_system.evolve_model(ttarget) 
-        
-        rho=make_map(sph,N=200,grid_size=grid_size)
-        subplot=fig.add_subplot(ncolumn,nrow,i+1)
+        bridged_system.evolve_model(ttarget)
+
+        rho = make_map(sph, N=200, grid_size=grid_size)
+        subplot = fig.add_subplot(ncolumn, nrow, i+1)
         subplot.imshow(
             numpy.log10(1.e-5+rho.value_in(units.amu/units.cm**3)),
-            extent = extent,
+            extent=extent,
             vmin=1,
             vmax=5
         )
         subplot.set_title(ttarget.as_quantity_in(units.Myr))
-    
+
     sph.stop()
     pyplot.show()
-  
+
+
 if __name__ == "__main__":
     run_mc(10000, Mcloud=1000. | units.MSun, Rcloud=1. | units.parsec)
-  

--- a/examples/simple/molecular_cloud_chemistry.py
+++ b/examples/simple/molecular_cloud_chemistry.py
@@ -1,10 +1,11 @@
 """
 Evolves a molecular cloud with chemical evolution
 
-The dynamics is evolved in the sph code Fi, chemistry with Krome, assuming 
+The dynamics is evolved in the sph code Fi, chemistry with Krome, assuming
 an isothermal cloud (hence passive chemical evolution).
 
-Initial condition is a smooth spherical cloud with random velocities as in Bonnell et al. (2003)  
+Initial condition is a smooth spherical cloud with random velocities as in
+Bonnell et al. (2003)
 """
 import numpy
 

--- a/examples/simple/molecular_cloud_chemistry.py
+++ b/examples/simple/molecular_cloud_chemistry.py
@@ -5,97 +5,101 @@ The dynamics is evolved in the sph code Fi, chemistry with Krome, assuming
 an isothermal cloud (hence passive chemical evolution).
 
 Initial condition is a smooth spherical cloud with random velocities as in Bonnell et al. (2003)  
-"""  
+"""
 import numpy
-  
-from matplotlib import pyplot 
-from amuse.units import units,constants,nbody_system
+
+from matplotlib import pyplot
+from amuse.units import units, constants, nbody_system
 
 from amuse.community.fi.interface import Fi
 from amuse.community.krome.interface import Krome
 
 from amuse.ext.molecular_cloud import molecular_cloud
 
-gamma=1.4
-meanmwt=1.35 | units.amu
+gamma = 1.4
+meanmwt = 1.35 | units.amu
 
-def update_chem(sph_parts,chem_parts):
-  parts=sph_parts.empty_copy()
-  channel=sph_parts.new_channel_to(parts)
-  channel.copy_attributes(["density","u"])
-  parts.number_density=parts.density/meanmwt
-  parts.temperature=((gamma-1)*meanmwt*parts.u/constants.kB)
-  parts.ionrate=2.e-17 | units.s**-1
-  channel=parts.new_channel_to(chem_parts)
-  channel.copy_attributes(["number_density","temperature","ionrate"])
-    
-def evolve_sph_with_chemistry(sph,chem,tend):
-  sph.evolve_model(tend)
-  update_chem(sph.particles,chem.particles)
-  chem.evolve_model(tend)
-  
-def run_mc(N=5000,Mcloud=10000. | units.MSun,Rcloud=1. | units.parsec):
+
+def update_chem(sph_parts, chem_parts):
+    parts = sph_parts.empty_copy()
+    channel = sph_parts.new_channel_to(parts)
+    channel.copy_attributes(["density", "u"])
+    parts.number_density = parts.density/meanmwt
+    parts.temperature = ((gamma-1)*meanmwt*parts.u/constants.kB)
+    parts.ionrate = 2.e-17 | units.s**-1
+    channel = parts.new_channel_to(chem_parts)
+    channel.copy_attributes(["number_density", "temperature", "ionrate"])
+
+
+def evolve_sph_with_chemistry(sph, chem, tend):
+    sph.evolve_model(tend)
+    update_chem(sph.particles, chem.particles)
+    chem.evolve_model(tend)
+
+
+def run_mc(N=5000, Mcloud=10000. | units.MSun, Rcloud=1. | units.parsec):
     timestep = 0.005 | units.Myr
-    end_time=0.12 | units.Myr
+    end_time = 0.12 | units.Myr
 
-    conv = nbody_system.nbody_to_si(Mcloud,Rcloud)
-    parts=molecular_cloud(targetN=N,convert_nbody=conv,ethep_ratio=0.05,ekep_ratio=0.5).result
-    
-    rho_cloud=Mcloud/(4/3.*numpy.pi*Rcloud**3)
-    
-    tff=1/(4*numpy.pi*constants.G*rho_cloud)**0.5
-    parts.density=rho_cloud
+    conv = nbody_system.nbody_to_si(Mcloud, Rcloud)
+    parts = molecular_cloud(targetN=N, convert_nbody=conv,
+                            ethep_ratio=0.05, ekep_ratio=0.5).result
 
-    update_chem(parts,parts)
+    rho_cloud = Mcloud/(4/3.*numpy.pi*Rcloud**3)
+
+    tff = 1/(4*numpy.pi*constants.G*rho_cloud)**0.5
+    parts.density = rho_cloud
+
+    update_chem(parts, parts)
 
     print("Tcloud:", parts.temperature.max().in_(units.K))
-    print("cloud n_H:",parts.number_density.max().in_(units.cm**-3))
-    print("freefall time:",tff.in_(units.Myr))
+    print("cloud n_H:", parts.number_density.max().in_(units.cm**-3))
+    print("freefall time:", tff.in_(units.Myr))
 
-    sph=Fi(conv)
-    chem=Krome(redirection="none")
+    sph = Fi(conv)
+    chem = Krome(redirection="none")
 
-    sph.parameters.self_gravity_flag=True    
-    sph.parameters.use_hydro_flag=True
-    sph.parameters.isothermal_flag=True
-    sph.parameters.integrate_entropy_flag=False
-    sph.parameters.gamma=1
+    sph.parameters.self_gravity_flag = True
+    sph.parameters.use_hydro_flag = True
+    sph.parameters.isothermal_flag = True
+    sph.parameters.integrate_entropy_flag = False
+    sph.parameters.gamma = 1
     sph.parameters.verbosity = 0
 
-    sph.parameters.timestep=timestep/2
-    
+    sph.parameters.timestep = timestep/2
+
     sph.gas_particles.add_particles(parts)
     chem.particles.add_particles(parts)
 
-    tnow=sph.model_time
+    tnow = sph.model_time
 
-    f=pyplot.figure()
+    f = pyplot.figure()
     pyplot.ion()
     pyplot.show()
 
-    i=0
-    while i<(end_time/timestep+0.5):
-      evolve_sph_with_chemistry(sph,chem,i*timestep)
-      tnow=sph.model_time
-      print("done with step:",i,tnow.in_(units.Myr))
-      i+=1
+    i = 0
+    while i < (end_time/timestep+0.5):
+        evolve_sph_with_chemistry(sph, chem, i*timestep)
+        tnow = sph.model_time
+        print("done with step:", i, tnow.in_(units.Myr))
+        i += 1
 
-      n=(sph.particles.density/meanmwt).value_in(units.cm**-3)
-      fh2=chem.particles.abundances[:,chem.species["H2"]]
-      co=chem.particles.abundances[:,chem.species["CO"]]
+        n = (sph.particles.density/meanmwt).value_in(units.cm**-3)
+        fh2 = chem.particles.abundances[:, chem.species["H2"]]
+        co = chem.particles.abundances[:, chem.species["CO"]]
 
-      f.clear()
-      pyplot.loglog(n,fh2,'r.')
-      pyplot.loglog(n,co,'g.')
-      pyplot.xlim(1.e3,1.e6)
-      pyplot.ylim(1.e-6,1)
-      pyplot.xlabel("density (cm**-3)")
-      pyplot.ylabel("H_2,CO abundance")
-      pyplot.draw()
-    
+        f.clear()
+        pyplot.loglog(n, fh2, 'r.')
+        pyplot.loglog(n, co, 'g.')
+        pyplot.xlim(1.e3, 1.e6)
+        pyplot.ylim(1.e-6, 1)
+        pyplot.xlabel("density (cm**-3)")
+        pyplot.ylabel("H_2,CO abundance")
+        pyplot.draw()
+
     print("done. press key to exit")
     raw_input()
-    
+
+
 if __name__ == "__main__":
     run_mc(N=1000, Mcloud=2000. | units.MSun, Rcloud=.5 | units.parsec)
-

--- a/examples/simple/orbit_in_potential.py
+++ b/examples/simple/orbit_in_potential.py
@@ -10,20 +10,21 @@ from amuse.units.optparse import OptionParser
 from math import atan
 from math import log
 from amuse.lab import *
-from matplotlib import pyplot 
+from matplotlib import pyplot
 from amuse.plot import plot
 
+
 class MilkyWay_galaxy(object):
-    def __init__(self,potential="point_particle", M=1.6e10 | units.MSun):
+    def __init__(self, potential="point_particle", M=1.6e10 | units.MSun):
         print("pot=", potential)
-        if potential.find("Milky")>=0:
+        if potential.find("Milky") >= 0:
             print("Milky Way Potential")
             self.potential = self.Milky_Way_potential
         else:
             self.potential = self.point_particle_potential
         self.M = M
 
-    #Generic function to get gravity at a point given the potential
+    # Generic function to get gravity at a point given the potential
     def get_gravity_at_point(self, pos):
         phi_0 = self.get_potential_at_point(pos)
         grav = AdaptingVectorQuantity()
@@ -37,15 +38,15 @@ class MilkyWay_galaxy(object):
 
     def get_potential_at_point(self, pos):
         phi = self.potential(pos)
-        return phi    
+        return phi
 
     def point_particle_potential(self, pos):
         return self.Kepler_potential(self.M, pos)
 
-    def Kepler_potential(self, mass, pos, eps2=0.0|units.kpc**2):
+    def Kepler_potential(self, mass, pos, eps2=0.0 | units.kpc**2):
         return self.Power_law_potential(mass, pos, eps2=eps2, eta=1)
 
-    def Power_law_potential(self, mass, pos, eps2=0.0|units.kpc**2, eta=1):
+    def Power_law_potential(self, mass, pos, eps2=0.0 | units.kpc**2, eta=1):
         return constants.G*mass/(pos.length()**2+eps2)**(eta/2.)
 
     def disk_and_bulge_potentials(self, pos, a, b, mass):
@@ -53,23 +54,24 @@ class MilkyWay_galaxy(object):
         return constants.G * mass /\
             (r**2 + (a + (pos.z**2 + b**2).sqrt())**2).sqrt()
 
-    def halo_potential(self, pos, Mc=5.0E+10|units.MSun, Rc=1.0|units.kpc**2):
+    def halo_potential(self, pos, Mc=5.0E+10 | units.MSun, Rc=1.0 | units.kpc**2):
         r = pos.length()
         rr = (r/Rc)
-        return -constants.G * (Mc/Rc)*(0.5*log(1 +rr**2) + atan(rr)/rr)
+        return -constants.G * (Mc/Rc)*(0.5*log(1 + rr**2) + atan(rr)/rr)
 
-    #1990ApJ...348..485P
+    # 1990ApJ...348..485P
     def Milky_Way_potential(self, pos):
         pot_disk = self.disk_and_bulge_potentials(pos,
-                                                  0.0|units.kpc, 
-                                                  0.277|units.kpc, 
-                                                  1.12E+10|units.MSun) 
-        pot_bulge = self.disk_and_bulge_potentials(pos, 3.7|units.kpc, 
-                                                   0.20|units.kpc, 
-                                                   8.07E+10|units.MSun) 
-        pot_halo = self.halo_potential(pos, Mc=5.0E+10|units.MSun, 
-                                       Rc=6.0|units.kpc)
+                                                  0.0 | units.kpc,
+                                                  0.277 | units.kpc,
+                                                  1.12E+10 | units.MSun)
+        pot_bulge = self.disk_and_bulge_potentials(pos, 3.7 | units.kpc,
+                                                   0.20 | units.kpc,
+                                                   8.07E+10 | units.MSun)
+        pot_halo = self.halo_potential(pos, Mc=5.0E+10 | units.MSun,
+                                       Rc=6.0 | units.kpc)
         return pot_disk + pot_bulge + pot_halo
+
 
 def new_single_star(mass, pos, vel):
     single_star = Particle()
@@ -79,15 +81,17 @@ def new_single_star(mass, pos, vel):
     single_star.radius = 1.0 | units.RSun
     return single_star
 
+
 def evolve_particle_in_potential(single_star, potential, t_end):
     time = 0 | units.Myr
-    dt_min = 0.1*t_end 
+    dt_min = 0.1*t_end
     while time < t_end:
         acc = potential.get_gravity_at_point(single_star.position)
         dt = min(dt_min, 0.1*single_star.velocity.length()/acc.length())
         single_star.velocity += acc*dt
         single_star.position += single_star.velocity*dt
         time += dt
+
 
 def evolve_particle_trajectory_in_potential(single_star, potential, dt_diag, t_end):
     time = 0 | units.Myr
@@ -103,48 +107,51 @@ def evolve_particle_trajectory_in_potential(single_star, potential, dt_diag, t_e
         z.append(single_star.y)
     return x, y, z
 
+
 def plot_orbit(x, y):
-    pyplot.figure(figsize=(10,10))
-    plot(x,y)
+    pyplot.figure(figsize=(10, 10))
+    plot(x, y)
     pyplot.show()
+
 
 def new_option_parser():
     result = OptionParser()
-    result.add_option("-t", dest="t_end", type="float",default = 250,
-                      unit = units.Myr, help="end time [%unit]")
-    result.add_option("-d", dest="dt_diag", type="float",default = 10,
-                      unit = units.Myr, help="diagnostic timestep [%unit]")
-    result.add_option("-P", dest="potential", default = "MilkyWay",
+    result.add_option("-t", dest="t_end", type="float", default=250,
+                      unit=units.Myr, help="end time [%unit]")
+    result.add_option("-d", dest="dt_diag", type="float", default=10,
+                      unit=units.Myr, help="diagnostic timestep [%unit]")
+    result.add_option("-P", dest="potential", default="MilkyWay",
                       help="name of potential")
-    result.add_option("-M", dest="mass", type="float",default = 1.e+11,
-                      unit = units.MSun, help="mass of the galaxy [%unit]")
-    result.add_option("-e", dest="eps", type="float",default = 0.0,
-                      unit = units.parsec, help="softening of the potential [%unit]")
-    result.add_option("-x", dest="x", type="float",default = 8500,
-                      unit = units.parsec, help="x-position [%unit]")
-    result.add_option("-y", dest="y", type="float",default = 0,
-                      unit = units.parsec, help="y-position [%unit]")
-    result.add_option("-z", dest="z", type="float",default = 0,
-                      unit = units.parsec, help="z-position [%unit]")
-    result.add_option("--vx", dest="vx", type="float",default = 0,
-                      unit = units.km/units.s,help="x-velocity [%unit]")
-    result.add_option("--vy", dest="vy", type="float",default = 220,
-                      unit = units.km/units.s,help="y-velocity [%unit]")
-    result.add_option("--vz", dest="vz", type="float",default = 0,
-                      unit = units.km/units.s, help="z-velocity [%unit]")
+    result.add_option("-M", dest="mass", type="float", default=1.e+11,
+                      unit=units.MSun, help="mass of the galaxy [%unit]")
+    result.add_option("-e", dest="eps", type="float", default=0.0,
+                      unit=units.parsec, help="softening of the potential [%unit]")
+    result.add_option("-x", dest="x", type="float", default=8500,
+                      unit=units.parsec, help="x-position [%unit]")
+    result.add_option("-y", dest="y", type="float", default=0,
+                      unit=units.parsec, help="y-position [%unit]")
+    result.add_option("-z", dest="z", type="float", default=0,
+                      unit=units.parsec, help="z-position [%unit]")
+    result.add_option("--vx", dest="vx", type="float", default=0,
+                      unit=units.km/units.s, help="x-velocity [%unit]")
+    result.add_option("--vy", dest="vy", type="float", default=220,
+                      unit=units.km/units.s, help="y-velocity [%unit]")
+    result.add_option("--vz", dest="vz", type="float", default=0,
+                      unit=units.km/units.s, help="z-velocity [%unit]")
     return result
-    
-if __name__ == "__main__":
-    o, arguments  = new_option_parser().parse_args()
 
-    t_end = o.t_end 
-    dt_diag = min(o.dt_diag, 0.1*o.t_end) 
+
+if __name__ == "__main__":
+    o, arguments = new_option_parser().parse_args()
+
+    t_end = o.t_end
+    dt_diag = min(o.dt_diag, 0.1*o.t_end)
     size_unit = units.parsec
-    mass = 1.0 
+    mass = 1.0
     pos = [o.x, o.y, o.z]
     vel = [o.vx, o.vy, o.vz]
     single_star = new_single_star(mass, pos, vel)
-    galaxy=MilkyWay_galaxy(o.potential, M=o.mass)
-    x, y, z = evolve_particle_trajectory_in_potential(single_star, galaxy, dt_diag, t_end)
-    plot_orbit(x,y)
-    
+    galaxy = MilkyWay_galaxy(o.potential, M=o.mass)
+    x, y, z = evolve_particle_trajectory_in_potential(
+        single_star, galaxy, dt_diag, t_end)
+    plot_orbit(x, y)

--- a/examples/simple/orbit_in_potential.py
+++ b/examples/simple/orbit_in_potential.py
@@ -1,15 +1,18 @@
 """
 Integrates a stellar orbit in the galactic potential
-  
-This example illustrates the use of a simple external potential and simple integrator, no
+
+This example illustrates the use of a simple external potential and simple
+integrator, no
 amuse community code is used.
 """
 
-import numpy
+# import numpy
 from amuse.units.optparse import OptionParser
 from math import atan
 from math import log
-from amuse.lab import *
+from amuse.lab import (
+        units, constants, AdaptingVectorQuantity, Particle
+        )
 from matplotlib import pyplot
 from amuse.plot import plot
 
@@ -54,7 +57,8 @@ class MilkyWay_galaxy(object):
         return constants.G * mass /\
             (r**2 + (a + (pos.z**2 + b**2).sqrt())**2).sqrt()
 
-    def halo_potential(self, pos, Mc=5.0E+10 | units.MSun, Rc=1.0 | units.kpc**2):
+    def halo_potential(
+            self, pos, Mc=5.0E+10 | units.MSun, Rc=1.0 | units.kpc**2):
         r = pos.length()
         rr = (r/Rc)
         return -constants.G * (Mc/Rc)*(0.5*log(1 + rr**2) + atan(rr)/rr)
@@ -93,7 +97,8 @@ def evolve_particle_in_potential(single_star, potential, t_end):
         time += dt
 
 
-def evolve_particle_trajectory_in_potential(single_star, potential, dt_diag, t_end):
+def evolve_particle_trajectory_in_potential(
+        single_star, potential, dt_diag, t_end):
     time = 0 | units.Myr
     x = [] | size_unit
     y = [] | size_unit
@@ -101,7 +106,9 @@ def evolve_particle_trajectory_in_potential(single_star, potential, dt_diag, t_e
     while time < t_end:
         evolve_particle_in_potential(single_star, potential, dt_diag)
         time += dt_diag
-        print("time=", time, single_star.position.length().as_quantity_in(units.AU))
+        print(
+                "time=", time,
+                single_star.position.length().as_quantity_in(units.AU))
         x.append(single_star.x)
         y.append(single_star.y)
         z.append(single_star.y)
@@ -125,7 +132,8 @@ def new_option_parser():
     result.add_option("-M", dest="mass", type="float", default=1.e+11,
                       unit=units.MSun, help="mass of the galaxy [%unit]")
     result.add_option("-e", dest="eps", type="float", default=0.0,
-                      unit=units.parsec, help="softening of the potential [%unit]")
+                      unit=units.parsec,
+                      help="softening of the potential [%unit]")
     result.add_option("-x", dest="x", type="float", default=8500,
                       unit=units.parsec, help="x-position [%unit]")
     result.add_option("-y", dest="y", type="float", default=0,

--- a/examples/simple/orszag_tang.py
+++ b/examples/simple/orszag_tang.py
@@ -10,34 +10,36 @@ handle such turbulence and MHD shocks.'
 
 import numpy
 from matplotlib import pyplot
-    
+
 
 from amuse.community.athena.interface import Athena
 
 from amuse.units.generic_unit_system import *
 from amuse.datamodel import Grid
 density = mass / length**3
-momentum =  speed * density
-energy =  mass / (time**2 * length)
+momentum = speed * density
+energy = mass / (time**2 * length)
 magnetic_field = mass / current / time**2
 vector_potential = magnetic_field * length
 
 PI = numpy.pi
 
 GAMMA = 5.0/3.0
-DIMENSIONS_OF_MESH = (256,256,1)
-DIMENSIONS_OF_A_MESH = (258,258,1)
+DIMENSIONS_OF_MESH = (256, 256, 1)
+DIMENSIONS_OF_A_MESH = (258, 258, 1)
 B0 = 1.0/numpy.sqrt(4.0*PI) | magnetic_field
-D0 = 25.0/(36.0*PI)   | density
-V0 = 1.0              | speed
-P0 = 5.0/(12.0*PI)    | energy
+D0 = 25.0/(36.0*PI) | density
+V0 = 1.0 | speed
+P0 = 5.0/(12.0*PI) | energy
+
 
 def new_instance_of_hydro_code(number_of_workers=1):
-    result=Athena(number_of_workers = number_of_workers, mode='mhd')
+    result = Athena(number_of_workers=number_of_workers, mode='mhd')
     result.initialize_code()
     result.parameters.gamma = GAMMA
-    result.parameters.courant_number=0.8
+    result.parameters.courant_number = 0.8
     return result
+
 
 def set_parameters(instance):
     instance.parameters.mesh_size = DIMENSIONS_OF_MESH
@@ -46,97 +48,121 @@ def set_parameters(instance):
     instance.parameters.length_y = 1 | length
     instance.parameters.length_z = 1 | length
 
-    instance.parameters.x_boundary_conditions = ("periodic","periodic")
-    instance.parameters.y_boundary_conditions = ("periodic","periodic")
-    instance.parameters.z_boundary_conditions = ("periodic","periodic")
+    instance.parameters.x_boundary_conditions = ("periodic", "periodic")
+    instance.parameters.y_boundary_conditions = ("periodic", "periodic")
+    instance.parameters.z_boundary_conditions = ("periodic", "periodic")
 
     result = instance.commit_parameters()
 
+
 def new_grid():
-    grid = Grid.create(DIMENSIONS_OF_MESH, [1,1,1] | length)
+    grid = Grid.create(DIMENSIONS_OF_MESH, [1, 1, 1] | length)
     self.clear_grid(grid)
     return grid
 
+
 def clear_grid(grid):
-    grid.rho =  0.0 | density
+    grid.rho = 0.0 | density
     grid.rhovx = 0.0 | momentum
     grid.rhovy = 0.0 | momentum
     grid.rhovz = 0.0 | momentum
     grid.energy = 0.0 | energy
 
+
 def clear_magnetic_field_grid(grid):
-    grid.B1i    = 0.0 | magnetic_field
-    grid.B2i    = 0.0 | magnetic_field
-    grid.B3i    = 0.0 | magnetic_field
+    grid.B1i = 0.0 | magnetic_field
+    grid.B2i = 0.0 | magnetic_field
+    grid.B3i = 0.0 | magnetic_field
 
     return grid
 
-def initialize_grid(grid, magentic_field_grid):        
 
-    temp = [1,1,1] | length
-    l    = 1.0 | length;
-    A_grid = Grid.create(DIMENSIONS_OF_A_MESH, temp + grid.cellsize()*[2,2,0])
-    A_grid.position -= A_grid.cellsize()*[0.5,0.5,0.0]
+def initialize_grid(grid, magentic_field_grid):
+
+    temp = [1, 1, 1] | length
+    l = 1.0 | length
+    A_grid = Grid.create(
+            DIMENSIONS_OF_A_MESH,
+            temp + grid.cellsize()*[2, 2, 0]
+            )
+    A_grid.position -= A_grid.cellsize()*[0.5, 0.5, 0.0]
     A_grid.Az = (
-        B0*l/(4.0*PI)*numpy.cos(4.0*PI/l*A_grid.x) + 
-        B0*l/(2.0*PI)*numpy.cos(2.0*PI/l*A_grid.y)) 
+        B0*l/(4.0*PI)*numpy.cos(4.0*PI/l*A_grid.x)
+        + B0*l/(2.0*PI)*numpy.cos(2.0*PI/l*A_grid.y)
+        )
 
     assert grid.cellsize().x == A_grid.cellsize().x
     assert grid.cellsize().y == A_grid.cellsize().y
-#    assert grid.dim[0]      == A_grid.dim[0]
+    # assert grid.dim[0]      == A_grid.dim[0]
 
-    magentic_field_grid.B1i =  (A_grid.Az[:-1,1:,...] - A_grid.Az[:-1,:-1,...])/A_grid.cellsize().y;
-    magentic_field_grid.B2i = -(A_grid.Az[1:,:-1,...] - A_grid.Az[:-1,:-1,...])/A_grid.cellsize().x;
-    magentic_field_grid.B3i =  0.0 | magnetic_field;
-    
-    #magentic_field_grid.B1i[-1,...,...] = magentic_field_grid.B1i[0,...,...]
-    #magentic_field_grid.B2i[...,-1,...] = magentic_field_grid.B2i[...,0,...]
-    
-    magentic_field_grid.B1c = 0.0 | magnetic_field;
-    magentic_field_grid.B2c = 0.0 | magnetic_field;
-    magentic_field_grid.B3c = 0.0 | magnetic_field;
+    magentic_field_grid.B1i = (
+            A_grid.Az[:-1, 1:, ...] - A_grid.Az[:-1, :-1, ...]
+            ) / A_grid.cellsize().y
+    magentic_field_grid.B2i = (
+            - (A_grid.Az[1:, :-1, ...] - A_grid.Az[:-1, :-1, ...]
+                ) / A_grid.cellsize().x
+            )
+    magentic_field_grid.B3i = 0.0 | magnetic_field
+
+    # magentic_field_grid.B1i[-1,...,...] = magentic_field_grid.B1i[0,...,...]
+    # magentic_field_grid.B2i[...,-1,...] = magentic_field_grid.B2i[...,0,...]
+
+    magentic_field_grid.B1c = 0.0 | magnetic_field
+    magentic_field_grid.B2c = 0.0 | magnetic_field
+    magentic_field_grid.B3c = 0.0 | magnetic_field
     magentic_field_grid.divB = 0.0 | (magnetic_field / length)
 
-    magentic_field_grid.B1c[:-1,...,...] = (magentic_field_grid.B1i[:-1,...,...] + magentic_field_grid.B1i[1:,...,...])*0.5
-    magentic_field_grid.B2c[...,:-1,...] = (magentic_field_grid.B2i[...,:-1,...] + magentic_field_grid.B2i[...,1:,...])*0.5
+    magentic_field_grid.B1c[:-1, ..., ...] = (
+            magentic_field_grid.B1i[:-1, ..., ...]
+            + magentic_field_grid.B1i[1:, ..., ...])*0.5
+    magentic_field_grid.B2c[..., :-1, ...] = (
+            magentic_field_grid.B2i[..., :-1, ...]
+            + magentic_field_grid.B2i[..., 1:, ...])*0.5
     magentic_field_grid.B3c = magentic_field_grid.B3i
 
    # magentic_field_grid.B1c[-1,...,...] = magentic_field_grid.B1c[0,...,...]
    # magentic_field_grid.B2c[...,-1,...] = magentic_field_grid.B2c[...,0,...]
 
-
     mu0 = 1.0 | (mass*length/time**2/current**2)
 
-    magentic_field_grid.divB[0:-1,0:-1,...] = (
-        (magentic_field_grid.B1i[:-1,:-1,...] - magentic_field_grid.B1i[1:,:-1,...])/grid.cellsize().x +
-        (magentic_field_grid.B2i[:-1,:-1,...] - magentic_field_grid.B2i[:-1,1:,...])/grid.cellsize().y
-        )
+    magentic_field_grid.divB[0:-1, 0:-1, ...] = (
+            (
+                magentic_field_grid.B1i[:-1, :-1, ...]
+                - magentic_field_grid.B1i[1:, :-1, ...]
+                ) / grid.cellsize().x
+            + (
+                magentic_field_grid.B2i[:-1, :-1, ...]
+                - magentic_field_grid.B2i[:-1, 1:, ...]
+                ) / grid.cellsize().y
+            )
 
-    assert (abs(magentic_field_grid.divB[:-1,:-1,:-1]) < 1.0e-10 | magentic_field_grid.divB.unit).all()
+    assert (abs(magentic_field_grid.divB[:-1, :-1, :-1])
+            < 1.0e-10 | magentic_field_grid.divB.unit).all()
 
     assert magentic_field_grid.B1i.unit == magnetic_field
 
-    grid.rho   =  D0 
+    grid.rho = D0
     grid.rhovx = -D0*V0*numpy.sin(2.0*PI/l*grid.y)
-    grid.rhovy =  D0*V0*numpy.sin(2.0*PI/l*grid.x)
-    grid.rhovz =  0.0 | momentum
-
-
+    grid.rhovy = D0*V0*numpy.sin(2.0*PI/l*grid.x)
+    grid.rhovz = 0.0 | momentum
 
     print("sum rho vx:", grid.rhovx.sum())
-    print("sum rho vy:",grid.rhovy.sum())
-    print("sum rho vz:",grid.rhovz.sum())
+    print("sum rho vy:", grid.rhovy.sum())
+    print("sum rho vz:", grid.rhovz.sum())
 
     grid.energy = (
-      P0 / (GAMMA - 1) + 
-      0.5 * (grid.rhovx**2 + grid.rhovy**2 + grid.rhovz**2)/grid.rho +
-      0.5 * (magentic_field_grid.B1c[:-1,:-1,:-1]**2   + magentic_field_grid.B2c[:-1,:-1,:-1]**2   + magentic_field_grid.B3c[:-1,:-1,:-1]**2)/mu0
-      )
-
+            P0 / (GAMMA - 1)
+            + 0.5 * (grid.rhovx**2 + grid.rhovy**2 + grid.rhovz**2)/grid.rho
+            + 0.5 * (
+                magentic_field_grid.B1c[:-1, :-1, :-1]**2
+                + magentic_field_grid.B2c[:-1, :-1, :-1]**2
+                + magentic_field_grid.B3c[:-1, :-1, :-1]**2
+                )/mu0
+            )
 
 
 def simulate_orszag_tang_problem(end_time):
-    instance=new_instance_of_hydro_code()
+    instance = new_instance_of_hydro_code()
     set_parameters(instance)
 
     print("setup grid")
@@ -146,14 +172,14 @@ def simulate_orszag_tang_problem(end_time):
 
         clear_grid(inmem)
         clear_magnetic_field_grid(inmem_mhd)
-        
+
         initialize_grid(inmem, inmem_mhd)
 
         from_model_to_code = inmem.new_channel_to(hydro_grid)
         from_model_to_code.copy()
         from_model_to_code = inmem_mhd.new_channel_to(mhd_grid)
         from_model_to_code.copy()
-        
+
     instance.initialize_grid()
 
     print("start evolve")
@@ -168,19 +194,20 @@ def simulate_orszag_tang_problem(end_time):
     print("copying results")
     result = []
     for x in instance.itergrids():
-      result.append(x.copy())
+        result.append(x.copy())
 
     print("terminating code")
     instance.stop()
 
     return result
 
+
 if __name__ == "__main__":
-    rho = grid.rho[...,...,0].value_in(density)
+    rho = grid.rho[..., ..., 0].value_in(density)
     print(rho)
-    figure = pyplot.figure(figsize=(6,6))
-    plot = figure.add_subplot(1,1,1)
-    plot.imshow(rho, origin = 'lower')
+    figure = pyplot.figure(figsize=(6, 6))
+    plot = figure.add_subplot(1, 1, 1)
+    plot.imshow(rho, origin='lower')
     figure.savefig('orszag_tang.png')
     pyplot.show()
 

--- a/examples/simple/orszag_tang.py
+++ b/examples/simple/orszag_tang.py
@@ -2,10 +2,9 @@
 Runs the Orszag-Tang Vortex problem described in the Athena test-suite
 (http://www.astro.virginia.edu/VITA/ATHENA/ot.html):
 
-'The Orszag-Tang Vortex is a well-known test for MHD codes. The 
-intial conditions lead to a system of supersonic MHD turbulence,
-making this problem a good test of the algorithm's ability to 
-handle such turbulence and MHD shocks.' 
+'The Orszag-Tang Vortex is a well-known test for MHD codes. The intial
+conditions lead to a system of supersonic MHD turbulence, making this problem a
+good test of the algorithm's ability to handle such turbulence and MHD shocks.'
 """
 
 import numpy
@@ -14,7 +13,9 @@ from matplotlib import pyplot
 
 from amuse.community.athena.interface import Athena
 
-from amuse.units.generic_unit_system import *
+from amuse.units.generic_unit_system import (
+        mass, length, speed, time, current
+        )
 from amuse.datamodel import Grid
 density = mass / length**3
 momentum = speed * density
@@ -99,7 +100,8 @@ def initialize_grid(grid, magentic_field_grid):
             A_grid.Az[:-1, 1:, ...] - A_grid.Az[:-1, :-1, ...]
             ) / A_grid.cellsize().y
     magentic_field_grid.B2i = (
-            - (A_grid.Az[1:, :-1, ...] - A_grid.Az[:-1, :-1, ...]
+            - (
+                A_grid.Az[1:, :-1, ...] - A_grid.Az[:-1, :-1, ...]
                 ) / A_grid.cellsize().x
             )
     magentic_field_grid.B3i = 0.0 | magnetic_field
@@ -120,8 +122,8 @@ def initialize_grid(grid, magentic_field_grid):
             + magentic_field_grid.B2i[..., 1:, ...])*0.5
     magentic_field_grid.B3c = magentic_field_grid.B3i
 
-   # magentic_field_grid.B1c[-1,...,...] = magentic_field_grid.B1c[0,...,...]
-   # magentic_field_grid.B2c[...,-1,...] = magentic_field_grid.B2c[...,0,...]
+    # magentic_field_grid.B1c[-1,...,...] = magentic_field_grid.B1c[0,...,...]
+    # magentic_field_grid.B2c[...,-1,...] = magentic_field_grid.B2c[...,0,...]
 
     mu0 = 1.0 | (mass*length/time**2/current**2)
 

--- a/examples/simple/plot_with_units.py
+++ b/examples/simple/plot_with_units.py
@@ -1,8 +1,12 @@
 """
 Creates a number of plots using the AMUSE unit aware plot functions.
 """
-from amuse.lab import *
-from amuse.plot import *
+from amuse.lab import (
+        units, quantities
+        )
+from amuse.plot import (
+        native_plot, plot, scatter, xlabel, ylabel, hist
+        )
 import numpy as np
 
 if __name__ == "__main__":

--- a/examples/simple/plot_with_units.py
+++ b/examples/simple/plot_with_units.py
@@ -7,22 +7,23 @@ import numpy as np
 
 if __name__ == "__main__":
 
-    #latex_support()
+    # latex_support()
 
-    x = np.pi/20.0 * (range(-10,10) | units.m)
+    x = np.pi/20.0 * (range(-10, 10) | units.m)
     y1 = units.MSun.new_quantity(np.sin(x.number))
     y2 = units.MSun.new_quantity(x.number)
-    native_plot.subplot(2,2,1)
+    native_plot.subplot(2, 2, 1)
     plot(x, y2, label='model')
     scatter(x, y1, label='data')
     xlabel('x')
-    ylabel('mass [$M_\odot$]')#overrides auto unit!
+    ylabel('mass [$M_\odot$]')  # overrides auto unit!
     native_plot.legend(loc=2)
 
     x = range(50) | units.Myr
-    y1 = quantities.new_quantity(np.sin(np.arange(0,1.5,0.03)), 1e50*units.erg)
+    y1 = quantities.new_quantity(
+        np.sin(np.arange(0, 1.5, 0.03)), 1e50*units.erg)
     y2 = -(1e43 | units.J) - y1
-    native_plot.subplot(2,2,2)
+    native_plot.subplot(2, 2, 2)
     plot(x, y1, label='$E_\mathrm{kin}$')
     plot(x, y2, label='$E_\mathrm{pot}$')
     xlabel('t')
@@ -32,19 +33,19 @@ if __name__ == "__main__":
     x = range(7) | units.day
     y1 = [0, 4, 2, 3, 2, 5, 1]
     y2 = [3, 0, 2, 2, 3, 0, 4]
-    native_plot.subplot(2,2,3)
+    native_plot.subplot(2, 2, 3)
     plot(x, y1, 'ks', label='coffee')
     plot(x, y2, 'yo', label='tea')
     xlabel('time')
     ylabel('consumption / day')
     native_plot.legend()
 
-    y1 = units.N.new_quantity(np.random.normal(0.0,1.0,100))
+    y1 = units.N.new_quantity(np.random.normal(0.0, 1.0, 100))
     x = units.N.new_quantity(np.arange(-3, 3, 0.1))
     y2 = np.exp(-np.arange(-3, 3, 0.1)**2)/np.sqrt(np.pi)
-    native_plot.subplot(2,2,4)
+    native_plot.subplot(2, 2, 4)
     plot(x, y2, 'y--', label='model')
-    hist(y1, bins=12, range=(-3,3), normed=True, label='data')
+    hist(y1, bins=12, range=(-3, 3), normed=True, label='data')
     xlabel('force')
     ylabel('pdf')
     native_plot.legend()

--- a/examples/simple/pre_main_sequence_evolution.py
+++ b/examples/simple/pre_main_sequence_evolution.py
@@ -1,5 +1,6 @@
 """
-Calculated theoretical pre-main-sequance evolutionary tracks for stars of various masses.
+Calculated theoretical pre-main-sequance evolutionary tracks for stars of
+various masses.
 After Iben, ApJ 141, 993, 1965
 """
 

--- a/examples/simple/pre_main_sequence_evolution.py
+++ b/examples/simple/pre_main_sequence_evolution.py
@@ -9,65 +9,75 @@ from amuse.units import units
 from amuse.community.mesa.interface import MESA
 from amuse import datamodel
 
-def simulate_evolution_tracks(masses = [0.5, 1.0, 1.25, 1.5, 2.25, 3.0, 5.0, 9.0, 15.0] | units.MSun):
+
+def simulate_evolution_tracks(
+        masses=[0.5, 1.0, 1.25, 1.5, 2.25, 3.0, 5.0, 9.0, 15.0] | units.MSun
+        ):
     stellar_evolution = MESA()
     stellar_evolution.parameters.AGB_wind_scheme = 0
     stellar_evolution.parameters.RGB_wind_scheme = 0
 
     stars = datamodel.Particles(len(masses), mass=masses)
     stars = stellar_evolution.pre_ms_stars.add_particles(stars)
-    
-    data={}
-    
+
+    data = {}
+
     for star in stars:
         luminosity = [] | units.LSun
         temperature = [] | units.K
         time = [] | units.yr
-        
+
         print('Evolving pre main sequence star with')
         print('    mass:', star.mass)
         print('    luminosity:', star.luminosity)
         print('    radius:', star.radius)
-        
+
         while star.stellar_type == 17 | units.stellar_type:
             luminosity.append(star.luminosity)
             temperature.append(star.temperature)
             time.append(star.age)
             star.evolve_one_step()
-            
+
         print('Evolved pre main sequence star to:', star.stellar_type)
         print('    age:', star.age)
         print('    mass:', star.mass)
         print('    luminosity:', star.luminosity)
         print('    radius:', star.radius)
         print()
-        
+
         stardata = {}
         stardata['luminosity'] = luminosity
         stardata['temperature'] = temperature
         stardata['time'] = time
         data[star.mass] = stardata
-        
+
     return data
-    
+
+
 def plot_track(data):
-    figure = pyplot.figure(figsize = (6, 8))
-    plot = figure.add_subplot(1,1,1)
+    figure = pyplot.figure(figsize=(6, 8))
+    plot = figure.add_subplot(1, 1, 1)
     plot.set_title('Hertzsprung-Russell diagram', fontsize=12)
     temp_unit = units.K
     luminosity_unit = units.LSun
-    for mass,stardata in data.items():
-        temperature=stardata['temperature']
-        luminosity=stardata['luminosity']
-        plot.loglog(temperature[4:].value_in(temp_unit), luminosity[4:].value_in(luminosity_unit), marker="s") # first few points show transient
-        plot.text(1.25*temperature[-1].value_in(temp_unit), 0.5*luminosity[-1].value_in(luminosity_unit), str(mass))
+    for mass, stardata in data.items():
+        temperature = stardata['temperature']
+        luminosity = stardata['luminosity']
+        plot.loglog(
+                temperature[4:].value_in(temp_unit),
+                luminosity[4:].value_in(luminosity_unit),
+                marker="s")  # first few points show transient
+        plot.text(
+                1.25*temperature[-1].value_in(temp_unit),
+                0.5 * luminosity[-1].value_in(luminosity_unit),
+                str(mass))
     plot.set_xlabel('Effective Temperature ['+str(temp_unit)+']')
     plot.set_ylabel('Luminosity ['+str(luminosity_unit)+']')
     plot.set_xlim(10**4.6, 10**3.5)
-    plot.set_ylim(1.0e-2,1.e5)
-    pyplot.show()   
-    
+    plot.set_ylim(1.0e-2, 1.e5)
+    pyplot.show()
+
+
 if __name__ == "__main__":
-    data = simulate_evolution_tracks(masses = [0.5, 1.0, 1.25] | units.MSun)
+    data = simulate_evolution_tracks(masses=[0.5, 1.0, 1.25] | units.MSun)
     plot_track(data)
-    

--- a/examples/simple/protoplanetarydisk.py
+++ b/examples/simple/protoplanetarydisk.py
@@ -13,73 +13,76 @@ from amuse.units import nbody_system
 from amuse.ext.protodisk import ProtoPlanetaryDisk
 from amuse.datamodel import Particles
 
-def make_map(sph,N=100,L=1):
 
-    x,y=numpy.indices( ( N+1,N+1 ))
+def make_map(sph, N=100, L=1):
 
-    x=L*(x.flatten()-N/2.)/N
-    y=L*(y.flatten()-N/2.)/N
-    z=x*0.
-    vx=0.*x
-    vy=0.*x
-    vz=0.*x
+    x, y = numpy.indices((N+1, N+1))
 
-    x=units.AU(x)
-    y=units.AU(y)
-    z=units.AU(z)
-    vx=units.kms(vx)
-    vy=units.kms(vy)
-    vz=units.kms(vz)
+    x = L*(x.flatten()-N/2.)/N
+    y = L*(y.flatten()-N/2.)/N
+    z = x*0.
+    vx = 0.*x
+    vy = 0.*x
+    vz = 0.*x
 
-    rho,rhovx,rhovy,rhovz,rhoe=sph.get_hydro_state_at_point(x,y,z,vx,vy,vz)
-    rho=rho.reshape((N+1,N+1))
+    x = units.AU(x)
+    y = units.AU(y)
+    z = units.AU(z)
+    vx = units.kms(vx)
+    vy = units.kms(vy)
+    vz = units.kms(vz)
+
+    rho, rhovx, rhovy, rhovz, rhoe = sph.get_hydro_state_at_point(
+        x, y, z, vx, vy, vz)
+    rho = rho.reshape((N+1, N+1))
 
     return numpy.transpose(rho)
-                    
+
+
 if __name__ == "__main__":
 
-    N=20000
-    tend=1. | units.yr
-    Mstar=1. | units.MSun
-        
-    convert=nbody_system.nbody_to_si(Mstar, 1. | units.AU)
-    proto=ProtoPlanetaryDisk(N,convert_nbody=convert,densitypower=1.5,Rmin=4,Rmax=20,q_out=1.)
-    gas=proto.result
-    gas.h_smooth=0.06 | units.AU 
-             
-    sun=Particles(1)
-    sun.mass=Mstar
-    sun.radius=2. | units.AU
-    sun.x=0.|units.AU
-    sun.y=0.|units.AU
-    sun.z=0.|units.AU
-    sun.vx=0.|units.kms
-    sun.vy=0.|units.kms
-    sun.vz=0.|units.kms
- 
-    sph=Fi(convert)
- 
-    sph.parameters.use_hydro_flag=True
-    sph.parameters.radiation_flag=False
-    sph.parameters.self_gravity_flag=True
-    sph.parameters.gamma=1.
-    sph.parameters.isothermal_flag=True
-    sph.parameters.integrate_entropy_flag=False
-    sph.parameters.timestep=0.125 | units.yr  
+    N = 20000
+    tend = 1. | units.yr
+    Mstar = 1. | units.MSun
+
+    convert = nbody_system.nbody_to_si(Mstar, 1. | units.AU)
+    proto = ProtoPlanetaryDisk(
+        N, convert_nbody=convert, densitypower=1.5, Rmin=4, Rmax=20, q_out=1.)
+    gas = proto.result
+    gas.h_smooth = 0.06 | units.AU
+
+    sun = Particles(1)
+    sun.mass = Mstar
+    sun.radius = 2. | units.AU
+    sun.x = 0. | units.AU
+    sun.y = 0. | units.AU
+    sun.z = 0. | units.AU
+    sun.vx = 0. | units.kms
+    sun.vy = 0. | units.kms
+    sun.vz = 0. | units.kms
+
+    sph = Fi(convert)
+
+    sph.parameters.use_hydro_flag = True
+    sph.parameters.radiation_flag = False
+    sph.parameters.self_gravity_flag = True
+    sph.parameters.gamma = 1.
+    sph.parameters.isothermal_flag = True
+    sph.parameters.integrate_entropy_flag = False
+    sph.parameters.timestep = 0.125 | units.yr
 
     sph.gas_particles.add_particles(gas)
     sph.particles.add_particles(sun)
-        
-    sph.evolve_model(tend)    
-            
-    L=50
-    rho=make_map(sph,N=200,L=L)
+
+    sph.evolve_model(tend)
+
+    L = 50
+    rho = make_map(sph, N=200, L=L)
     sph.stop()
-    pyplot.figure(figsize=(8,8))
+    pyplot.figure(figsize=(8, 8))
     pyplot.imshow(numpy.log10(1.e-5+rho.value_in(units.amu/units.cm**3)),
-        extent=[-L/2,L/2,-L/2,L/2],vmin=10,vmax=15)    
+                  extent=[-L/2, L/2, -L/2, L/2], vmin=10, vmax=15)
     pyplot.title(tend)
     pyplot.xlabel('AU')
     pyplot.savefig('test.png')
     pyplot.show()
-         

--- a/examples/simple/pythagorean.py
+++ b/examples/simple/pythagorean.py
@@ -15,63 +15,64 @@ from amuse.units.quantities import AdaptingVectorQuantity
 from matplotlib import pyplot
 from amuse.datamodel import Particles
 
+
 def new_particles():
     particles = Particles(3)
-    
-    particles.mass=[3.,4.,5.] | nbody_system.mass
+
+    particles.mass = [3., 4., 5.] | nbody_system.mass
     particles.position = [
         [1, 3, 0],
         [-2, -1, 0],
         [1, -1, 0],
     ] | nbody_system.length
-        
-    particles.velocity = [0.,0.,0.] | nbody_system.speed
+
+    particles.velocity = [0., 0., 0.] | nbody_system.speed
     particles.radius = 0 | nbody_system.length
-    
+
     return particles
 
-def run_pyth(interface,tend=100,dt=0.125,parameters=[]):
-  
+
+def run_pyth(interface, tend=100, dt=0.125, parameters=[]):
+
     code = interface()
-    
-    for name,value in parameters:
+
+    for name, value in parameters:
         setattr(code.parameters, name, value)
-        
+
     code.particles.add_particles(new_particles())
     code.commit_particles()
 
     x = AdaptingVectorQuantity()
     y = AdaptingVectorQuantity()
-    t=0. | nbody_system.time
+    t = 0. | nbody_system.time
     while(t < tend-dt/2):
-        t=t+dt
+        t = t+dt
         code.evolve_model(t)
         x.append(code.particles.x)
         y.append(code.particles.y)
     code.stop()
 
-    return x,y
+    return x, y
+
 
 if __name__ == "__main__":
-  codes_to_run=[ ('Hermite0, $\eta=0.03$', Hermite,  [("dt_param",0.03)] ),
-                 ('Hermite0, $\eta=0.01$', Hermite,  [("dt_param",0.01)] ),
-                 ('Hermite0, $\eta=0.003$', Hermite,  [("dt_param",0.003)] ),
-                 ('Hermite0, $\eta=0.001$', Hermite,  [("dt_param",0.001)] ) ]
-  N=(len(codes_to_run)-1)/2+1
-  f=pyplot.figure(figsize=(8,4*N))
-  
-  for i,(label,interface,parameters) in enumerate(codes_to_run):
-    x,y=run_pyth(interface,tend=100 | nbody_system.time ,dt=0.0625 | nbody_system.time,parameters=parameters)
-    x = x.value_in(nbody_system.length)
-    y = y.value_in(nbody_system.length)
-    subplot=f.add_subplot(N,2,i+1)
-    subplot.plot(x[:,0],y[:,0],'r')
-    subplot.plot(x[:,1],y[:,1],'b')
-    subplot.plot(x[:,2],y[:,2],'g')
-    subplot.set_title(label)
-    subplot.set_xlim(-8,8)
-    subplot.set_ylim(-6,6)
-  pyplot.show()
+    codes_to_run = [('Hermite0, $\eta=0.03$', Hermite,  [("dt_param", 0.03)]),
+                    ('Hermite0, $\eta=0.01$', Hermite,  [("dt_param", 0.01)]),
+                    ('Hermite0, $\eta=0.003$', Hermite,  [("dt_param", 0.003)]),
+                    ('Hermite0, $\eta=0.001$', Hermite,  [("dt_param", 0.001)])]
+    N = (len(codes_to_run)-1)/2+1
+    f = pyplot.figure(figsize=(8, 4*N))
 
-
-  
+    for i, (label, interface, parameters) in enumerate(codes_to_run):
+        x, y = run_pyth(interface, tend=100 | nbody_system.time,
+                        dt=0.0625 | nbody_system.time, parameters=parameters)
+        x = x.value_in(nbody_system.length)
+        y = y.value_in(nbody_system.length)
+        subplot = f.add_subplot(N, 2, i+1)
+        subplot.plot(x[:, 0], y[:, 0], 'r')
+        subplot.plot(x[:, 1], y[:, 1], 'b')
+        subplot.plot(x[:, 2], y[:, 2], 'g')
+        subplot.set_title(label)
+        subplot.set_xlim(-8, 8)
+        subplot.set_ylim(-6, 6)
+    pyplot.show()

--- a/examples/simple/pythagorean.py
+++ b/examples/simple/pythagorean.py
@@ -3,13 +3,13 @@ Calculates the Pythagorean 3-body problem using different values for
 the smoothing length in the n-body code.
 """
 
-import numpy
-import time
+# import numpy
+# import time
 
-from amuse.community.phiGRAPE.interface import PhiGRAPE
+# from amuse.community.phiGRAPE.interface import PhiGRAPE
 from amuse.community.hermite0.interface import Hermite
-from amuse.community.huayno.interface import Huayno
-from amuse.community.bhtree.interface import BHTree
+# from amuse.community.huayno.interface import Huayno
+# from amuse.community.bhtree.interface import BHTree
 from amuse.units import nbody_system
 from amuse.units.quantities import AdaptingVectorQuantity
 from matplotlib import pyplot
@@ -56,10 +56,10 @@ def run_pyth(interface, tend=100, dt=0.125, parameters=[]):
 
 
 if __name__ == "__main__":
-    codes_to_run = [('Hermite0, $\eta=0.03$', Hermite,  [("dt_param", 0.03)]),
-                    ('Hermite0, $\eta=0.01$', Hermite,  [("dt_param", 0.01)]),
-                    ('Hermite0, $\eta=0.003$', Hermite,  [("dt_param", 0.003)]),
-                    ('Hermite0, $\eta=0.001$', Hermite,  [("dt_param", 0.001)])]
+    codes_to_run = [('Hermite0, $\eta=0.03$', Hermite, [("dt_param", 0.03)]),
+                    ('Hermite0, $\eta=0.01$', Hermite, [("dt_param", 0.01)]),
+                    ('Hermite0, $\eta=0.003$', Hermite, [("dt_param", 0.003)]),
+                    ('Hermite0, $\eta=0.001$', Hermite, [("dt_param", 0.001)])]
     N = (len(codes_to_run)-1)/2+1
     f = pyplot.figure(figsize=(8, 4*N))
 

--- a/examples/simple/salpeter.py
+++ b/examples/simple/salpeter.py
@@ -1,5 +1,6 @@
 """
-Generates a cluster using a plummer model with a salpeter Initial Mass Function.
+Generates a cluster using a plummer model with a salpeter Initial Mass
+Function.
 Compares the generated IMF against the expected line.
 """
 

--- a/examples/simple/salpeter.py
+++ b/examples/simple/salpeter.py
@@ -3,19 +3,20 @@ Generates a cluster using a plummer model with a salpeter Initial Mass Function.
 Compares the generated IMF against the expected line.
 """
 
-import numpy 
+import numpy
 from matplotlib import pyplot
 from amuse.units import units
 from amuse.units import nbody_system
 from amuse.ic.plummer import new_plummer_model
 from amuse.ic.salpeter import new_salpeter_mass_distribution
 
-def new_cluster(number_of_stars = 1000):
+
+def new_cluster(number_of_stars=1000):
     masses = new_salpeter_mass_distribution(
-        number_of_stars, 
-        mass_min = 0.1 | units.MSun,
-        mass_max = 125.0 | units.MSun, 
-        alpha = -2.35
+        number_of_stars,
+        mass_min=0.1 | units.MSun,
+        mass_max=125.0 | units.MSun,
+        alpha=-2.35
     )
     nbody_converter = nbody_system.nbody_to_si(masses.sum(), 1 | units.parsec)
     particles = new_plummer_model(number_of_stars, nbody_converter)
@@ -23,51 +24,53 @@ def new_cluster(number_of_stars = 1000):
     particles.move_to_center()
     return particles
 
+
 def plot_particles_and_mass_distribution(particles):
-    figure = pyplot.figure(figsize= (12,6))
-    
+    figure = pyplot.figure(figsize=(12, 6))
+
     subplot = figure.add_subplot(1, 2, 1)
-        
+
     subplot.scatter(
         particles.x.value_in(units.parsec),
         particles.y.value_in(units.parsec),
-        s = particles.mass.value_in(units.MSun),# * len(particles),
-        edgecolors = 'red',
-        facecolors = 'red'
+        s=particles.mass.value_in(units.MSun),  # * len(particles),
+        edgecolors='red',
+        facecolors='red'
     )
-    
-    subplot.set_xlim(-4,4)
-    subplot.set_ylim(-4,4)
+
+    subplot.set_xlim(-4, 4)
+    subplot.set_ylim(-4, 4)
     subplot.set_xlabel('x (parsec)')
     subplot.set_ylabel('y (parsec)')
-    
+
     subplot = figure.add_subplot(1, 2, 2)
-    
+
     masses = particles.mass.value_in(units.MSun)
-    
+
     bins = 10**numpy.linspace(-1, 2, 100)
-    number_of_particles, bin_edges= numpy.histogram(masses, bins = bins)
-    
+    number_of_particles, bin_edges = numpy.histogram(masses, bins=bins)
+
     bin_sizes = bin_edges[1:] - bin_edges[:-1]
-    
+
     y = number_of_particles / bin_sizes
     x = (bin_edges[1:] + bin_edges[:-1]) / 2.0
-    
-    y = y[number_of_particles > 10.0] 
+
+    y = y[number_of_particles > 10.0]
     x = x[number_of_particles > 10.0]
     subplot.scatter(x, y)
-    
+
     c = ((0.1**-1.35) - (125.0**-1.35)) / 1.35
-    subplot.plot(x, len(particles)/ c * (x**-2.35))
-    
+    subplot.plot(x, len(particles) / c * (x**-2.35))
+
     subplot.set_xscale('log')
     subplot.set_yscale('log')
-    
+
     subplot.set_xlabel(u'M [M\u2299]')
     subplot.set_ylabel('N')
-    
+
     pyplot.show()
-    
+
+
 if __name__ == "__main__":
     particles = new_cluster(20000)
     plot_particles_and_mass_distribution(particles)

--- a/examples/simple/save_and_load_particles.py
+++ b/examples/simple/save_and_load_particles.py
@@ -4,7 +4,7 @@ The 'write_set_to_file' and 'read_set_from_file' functionso can hadle
 files in a variety of formats.
 """
 
-from amuse.units import nbody_system
+# from amuse.units import nbody_system
 from amuse.ic.plummer import new_plummer_model
 from amuse.plot import plot, native_plot
 

--- a/examples/simple/save_and_load_particles.py
+++ b/examples/simple/save_and_load_particles.py
@@ -17,23 +17,23 @@ import os.path
 if __name__ == "__main__":
     if os.path.exists('plummer128.hdf'):
         os.remove('plummer128.hdf')
-        
+
     # generate a particle set
-    plummer=new_plummer_model(128)
+    plummer = new_plummer_model(128)
 
     # write the set to file 'testfile'
     # the third argument is the file format, 'amuse' is an hdf5 based format
     # that saves all information. Other formats
     # available are e.g. csv, txt, gadget, starlab
-    write_set_to_file(plummer,'plummer128.hdf','amuse')
-    
+    write_set_to_file(plummer, 'plummer128.hdf', 'amuse')
+
     # reading back the file
     # we close the file, causing all data to be copied to memory
     # instead of being read from an open file
-    particles=read_set_from_file('plummer128.hdf','amuse', close_file = True)
+    particles = read_set_from_file('plummer128.hdf', 'amuse', close_file=True)
 
     # plotting
-    plot(particles.x, particles.y,'r.')
-    native_plot.xlim(-5,5)
-    native_plot.ylim(-5,5)
+    plot(particles.x, particles.y, 'r.')
+    native_plot.xlim(-5, 5)
+    native_plot.ylim(-5, 5)
     native_plot.show()

--- a/examples/simple/stellar_lifetime_vs_mass.py
+++ b/examples/simple/stellar_lifetime_vs_mass.py
@@ -1,12 +1,14 @@
-""" 
-Calculates the stellar lifetime in a range of masses between 
+"""
+Calculates the stellar lifetime in a range of masses between
 Mmax and Mmin using SSE (or another stellar evolution code)
 and an analytic expression.
 """
 
 import numpy
 from optparse import OptionParser
-from amuse.lab import *
+from amuse.lab import (
+        units, Particle
+        )
 from amuse.plot import plot
 from matplotlib import pyplot as plt
 from amuse.community.sse.interface import SSE
@@ -28,7 +30,7 @@ def stellar_lifetime(mZAMS, z=0.02):
     while not stellar_remnant_state(se.particles[0]):
         se.evolve_model()
     t_end = se.particles[0].age
-    tpe = se.particles[0].stellar_type
+    # tpe = se.particles[0].stellar_type
     se.particles.remove_particle(se.particles[0])
     return t_end
 

--- a/examples/simple/stellar_lifetime_vs_mass.py
+++ b/examples/simple/stellar_lifetime_vs_mass.py
@@ -13,9 +13,11 @@ from amuse.community.sse.interface import SSE
 
 se = None
 
+
 def stellar_remnant_state(star):
     return 10 <= star.stellar_type.value_in(units.stellar_type) and \
         star.stellar_type.value_in(units.stellar_type) < 16
+
 
 def stellar_lifetime(mZAMS, z=0.02):
     global se
@@ -30,14 +32,16 @@ def stellar_lifetime(mZAMS, z=0.02):
     se.particles.remove_particle(se.particles[0])
     return t_end
 
+
 def power_law_fit_to_main_sequence_lifetime(mZAMS):
     return 2 + 1.0E+4/pow(mZAMS.value_in(units.MSun), 2.5) | units.Myr
+
 
 def main(n=10, mmin=1.0, mmax=100, z=0.02):
     dm = (mmax-mmin)/n
     mZAMS = numpy.arange(mmin, mmax, dm) | units.MSun
-    mmin=mmin|units.MSun
-    mmax=mmax|units.MSun
+    mmin = mmin | units.MSun
+    mmax = mmax | units.MSun
     print(mZAMS)
     t_sse = [] | units.Myr
     t_analytic = [] | units.Myr
@@ -45,25 +49,26 @@ def main(n=10, mmin=1.0, mmax=100, z=0.02):
         t_sse.append(stellar_lifetime(mi, z))
         t_analytic.append(power_law_fit_to_main_sequence_lifetime(mi))
     plot(mZAMS, t_sse, label="sse")
-    plot(mZAMS, t_analytic,label="analytic")
+    plot(mZAMS, t_analytic, label="analytic")
     plt.loglog()
     plt.legend()
     plt.title("comparison between SSE and analytic with z="+str(z))
     plt.show()
 
+
 def new_option_parser():
     result = OptionParser()
-    result.add_option("-n", dest="n", type="int",default = 10,
+    result.add_option("-n", dest="n", type="int", default=10,
                       help="number of stars")
-    result.add_option("-m", dest="mmin", type="float", default = 1.0,
+    result.add_option("-m", dest="mmin", type="float", default=1.0,
                       help="Minimal mass [1.0] MSun")
-    result.add_option("-M", dest="mmax", type="float", default = 100.0,
+    result.add_option("-M", dest="mmax", type="float", default=100.0,
                       help="Maximal mass [100] MSun")
-    result.add_option("-z", dest="z", type="float", default = 0.02,
+    result.add_option("-z", dest="z", type="float", default=0.02,
                       help="metalicity [0.02]")
     return result
 
-if __name__ == "__main__":
-    o, arguments  = new_option_parser().parse_args()
-    main(**o.__dict__)
 
+if __name__ == "__main__":
+    o, arguments = new_option_parser().parse_args()
+    main(**o.__dict__)

--- a/examples/simple/stellar_mass_loss.py
+++ b/examples/simple/stellar_mass_loss.py
@@ -3,10 +3,10 @@
     in the stellar evolution using MESA
     and calculate the effect this has on the stellar radius.
 """
-import numpy
+# import numpy
 
 from amuse.units import units
-from amuse.datamodel import Particle, Particles
+from amuse.datamodel import Particle
 from amuse.support.console import set_printing_strategy
 
 from amuse.community.mesa.interface import MESA

--- a/examples/simple/stellar_mass_loss.py
+++ b/examples/simple/stellar_mass_loss.py
@@ -31,7 +31,8 @@ def print_report(star1, star2, mdot):
             rdot=(star2.radius-star1.radius)/(star2.age-star1.age),
             d_age=star2.age-star1.age,
             d_radius=star2.radius-star1.radius,
-            d_mass = star2.mass-star1.mass))
+            d_mass=star2.mass-star1.mass))
+
 
 def evolve_star_and_apply_mass_loss(radius, mdot):
     print("Evolve to radius = ", radius, "and then apply mdot =", mdot)
@@ -42,7 +43,7 @@ def evolve_star_and_apply_mass_loss(radius, mdot):
     stev.parameters.AGB_wind_scheme = 0
     stev.parameters.RGB_wind_scheme = 0
 
-    star = stev.particles.add_particle(Particle(mass=2|units.MSun))
+    star = stev.particles.add_particle(Particle(mass=2 | units.MSun))
 
     while star.radius < radius:
         star.evolve_one_step()
@@ -51,14 +52,23 @@ def evolve_star_and_apply_mass_loss(radius, mdot):
     star1 = star.copy()
 
     # High mass loss rates can only be calculated for small time steps
-    star.time_step = 1.|units.yr
+    star.time_step = 1. | units.yr
     star.mass_change = mdot
     print(star.mass_change)
     star.evolve_one_step()
 
     print_report(star1, star, mdot)
 
-if __name__ == "__main__":
-    set_printing_strategy("custom", preferred_units = [units.RSun, units.MSun, units.Myr, units.MSun/units.yr, units.RSun/units.yr])
 
-    evolve_star_and_apply_mass_loss(39.|units.RSun, -1e-3|units.MSun/units.yr)
+if __name__ == "__main__":
+    set_printing_strategy(
+            "custom",
+            preferred_units=[
+                units.RSun, units.MSun, units.Myr,
+                units.MSun/units.yr,
+                units.RSun/units.yr,
+                ]
+            )
+
+    evolve_star_and_apply_mass_loss(
+        39. | units.RSun, -1e-3 | units.MSun/units.yr)

--- a/examples/simple/stellar_mean_mass.py
+++ b/examples/simple/stellar_mean_mass.py
@@ -4,13 +4,15 @@ This routine was used to measure the <m> of a star cluster in order to
 incorporate <m>(t) and d<m>/dt in a parametrized cluster evolution code.
 """
 
-import sys
-import numpy
-from matplotlib import pyplot
-from amuse.plot import loglog, xlabel, ylabel
+# import sys
+# import numpy
+# from matplotlib import pyplot
+# from amuse.plot import loglog, xlabel, ylabel
 
 from amuse.community.sse.interface import SSE
-from amuse.lab import *
+from amuse.lab import (
+        units, Particles, new_salpeter_mass_distribution
+        )
 
 from optparse import OptionParser
 

--- a/examples/simple/stellar_mean_mass.py
+++ b/examples/simple/stellar_mean_mass.py
@@ -13,33 +13,33 @@ from amuse.community.sse.interface import SSE
 from amuse.lab import *
 
 from optparse import OptionParser
-    
-if __name__ == "__main__":    
+
+if __name__ == "__main__":
 
     result = OptionParser()
-    result.add_option("-t", dest="t_end", type="float",default = 12000,
+    result.add_option("-t", dest="t_end", type="float", default=12000,
                       help="End time for calculation in Myr. [12000 Myr]")
-    result.add_option("-d", dest="dt", type="float",default = 10,
+    result.add_option("-d", dest="dt", type="float", default=10,
                       help="output time step in Myr. [10 Myr]")
-    result.add_option("-N", dest="N", type="int",default = 10,
+    result.add_option("-N", dest="N", type="int", default=10,
                       help="number of stars to calculate <m>. [10]")
-    result.add_option("-m", dest="Mmin", type="float",default = 0.15,
+    result.add_option("-m", dest="Mmin", type="float", default=0.15,
                       help="Minimal mass of the IMF in MSun. [0.15MSun]")
-    result.add_option("-M", dest="Mmax", type="float",default = 100,
+    result.add_option("-M", dest="Mmax", type="float", default=100,
                       help="Maximal mass of the IMF in MSun. [100MSun]")
-    result.add_option("-x", dest="x_imf", type="float",default = -2.35,
+    result.add_option("-x", dest="x_imf", type="float", default=-2.35,
                       help="Slope of the IMF. [-2.35]")
-    result.add_option("-v", dest="verbose", action="store_true",default=False,
+    result.add_option("-v", dest="verbose", action="store_true", default=False,
                       help="verbose output [True]")
 
-    o, arguments  = result.parse_args()
+    o, arguments = result.parse_args()
     t_end = o.t_end | units.Myr
     dt = o.dt | units.Myr
 
     stellar_evolution = SSE()
     stellar_evolution.commit_parameters()
 
-    stars=Particles(o.N)
+    stars = Particles(o.N)
     Mmin = o.Mmin | units.MSun
     Mmax = o.Mmax | units.MSun
     if o.verbose:
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         print("#\tN=", o.N)
         print("#\tIMF=", o.Mmin, "MSun", o.Mmax, "MSun", o.x_imf)
         print("#\t t [Myr] \t <m> [MSun] \t\t d<m>/dt [MSun/Myr]")
-        
+
     stars.mass = new_salpeter_mass_distribution(
         o.N, mass_min=Mmin, mass_max=Mmax, alpha=o.x_imf)
 
@@ -55,14 +55,15 @@ if __name__ == "__main__":
     stellar_evolution.commit_particles()
     t = 0 | units.Myr
     mm = stars.mass.sum()/len(stars)
-    while t<t_end:
+    while t < t_end:
         mm_last = mm
         t += dt
         stellar_evolution.evolve_model(t)
         mm = stars.mass.sum()/len(stars)
         dmm_dt = (mm_last-mm)/dt
         if o.verbose:
-            print("t = ", t, "<m>=", mm.as_quantity_in(units.MSun), " d<m>/dt = ", dmm_dt.as_quantity_in(units.MSun/units.Myr))
+            print("t = ", t, "<m>=", mm.as_quantity_in(units.MSun),
+                  " d<m>/dt = ", dmm_dt.as_quantity_in(units.MSun/units.Myr))
         else:
-            print("\t", t, "\t", mm.as_quantity_in(units.MSun), " \t ", dmm_dt.as_quantity_in(units.MSun/units.Myr))
-
+            print("\t", t, "\t", mm.as_quantity_in(units.MSun),
+                  " \t ", dmm_dt.as_quantity_in(units.MSun/units.Myr))

--- a/examples/simple/stellar_structure.py
+++ b/examples/simple/stellar_structure.py
@@ -4,7 +4,7 @@ Make plots of the stellar structure of a star of given mass and age
 
 import numpy
 from matplotlib import pyplot
-from amuse.plot import plot, semilogx, semilogy, loglog, xlabel, ylabel
+from amuse.plot import semilogy, xlabel, ylabel
 
 from amuse.units import units
 from amuse.community.evtwin.interface import EVtwin

--- a/examples/simple/stellar_structure.py
+++ b/examples/simple/stellar_structure.py
@@ -10,61 +10,78 @@ from amuse.units import units
 from amuse.community.evtwin.interface import EVtwin
 from amuse.datamodel import Particle
 
+
 def structure_from_star(mass, age):
     stellar_evolution = EVtwin()
     star = stellar_evolution.particles.add_particle(Particle(mass=mass))
     star.evolve_for(age)
-    
+
     radius_profile = star.get_radius_profile()
     density_profile = star.get_density_profile()
     if hasattr(star, "get_mass_profile"):
-        mass_profile = star.get_mass_profile()* star.mass
+        mass_profile = star.get_mass_profile() * star.mass
     else:
         radii_cubed = radius_profile**3
-        radii_cubed.prepend(0|units.m**3)
-        mass_profile = (4.0/3.0 * numpy.pi) * density_profile * (radii_cubed[1:] - radii_cubed[:-1])
+        radii_cubed.prepend(0 | units.m**3)
+        mass_profile = (
+                (4.0/3.0 * numpy.pi) * density_profile
+                * (radii_cubed[1:] - radii_cubed[:-1])
+            )
         print("Derived mass profile from density and radius.")
-    
+
     return dict(
-        radius = radius_profile.as_quantity_in(units.RSun),
-        density = density_profile,
-        mass = mass_profile,
-        temperature = star.get_temperature_profile(),
-        pressure = star.get_pressure_profile(),
-        composition = star.get_chemical_abundance_profiles(),
-        species_names = star.get_names_of_species()
+        radius=radius_profile.as_quantity_in(units.RSun),
+        density=density_profile,
+        mass=mass_profile,
+        temperature=star.get_temperature_profile(),
+        pressure=star.get_pressure_profile(),
+        composition=star.get_chemical_abundance_profiles(),
+        species_names=star.get_names_of_species()
     )
 
+
 def temperature_density_plot(data, mass, age):
-    figure = pyplot.figure(figsize = (8, 10))
+    figure = pyplot.figure(figsize=(8, 10))
     pyplot.subplot(2, 1, 1)
     ax = pyplot.gca()
-    plotT = semilogy(data["radius"], data["temperature"], 'r-', label = r'$T(r)$')
+    plotT = semilogy(data["radius"], data["temperature"],
+                     'r-', label=r'$T(r)$')
     xlabel('Radius')
     ylabel('Temperature')
     ax.twinx()
-    plotrho = semilogy(data["radius"], data["density"], 'g-', label = r'$\rho(r)$')
+    plotrho = semilogy(data["radius"], data["density"],
+                       'g-', label=r'$\rho(r)$')
     plots = plotT + plotrho
     labels = [one_plot.get_label() for one_plot in plots]
     ax.legend(plots, labels, loc=3)
     ylabel('Density')
     pyplot.subplot(2, 1, 2)
-    semilogy(data["radius"], data["composition"][0], label = data["species_names"][0])
-    semilogy(data["radius"], data["composition"][1], label = data["species_names"][1])
-    semilogy(data["radius"], data["composition"][2], label = data["species_names"][2])
-    semilogy(data["radius"], data["composition"][3], label = data["species_names"][3])
-    semilogy(data["radius"], data["composition"][4], label = data["species_names"][4])
+    semilogy(
+            data["radius"], data["composition"][0],
+            label=data["species_names"][0])
+    semilogy(
+            data["radius"], data["composition"][1],
+            label=data["species_names"][1])
+    semilogy(
+            data["radius"], data["composition"][2],
+            label=data["species_names"][2])
+    semilogy(
+            data["radius"], data["composition"][3],
+            label=data["species_names"][3])
+    semilogy(
+            data["radius"], data["composition"][4],
+            label=data["species_names"][4])
     pyplot.ylim(0.0, 1.0)
     xlabel('Radius')
     ylabel('Mass fraction')
     pyplot.legend()
     pyplot.suptitle('Structure of a {0} star at {1}'.format(mass, age))
-    pyplot.show()   
-    
+    pyplot.show()
+
+
 if __name__ == "__main__":
     mass = 1.0 | units.MSun
     age = 5.0 | units.Gyr
-    
+
     data = structure_from_star(mass, age)
     temperature_density_plot(data, mass, age)
-    

--- a/examples/simple/sunandearth.py
+++ b/examples/simple/sunandearth.py
@@ -11,72 +11,75 @@ from amuse.community.hermite0.interface import Hermite
 from matplotlib import pyplot
 
 from amuse import datamodel
+
+
 def new_system_of_sun_and_earth():
     stars = datamodel.Particles(2)
-    
+
     sun = stars[0]
     sun.mass = 1.0 | units.MSun
-    sun.position = (0.0,0.0,0.0) | units.m
-    sun.velocity = (0.0,0.0,0.0) | (units.m / units.s)
+    sun.position = (0.0, 0.0, 0.0) | units.m
+    sun.velocity = (0.0, 0.0, 0.0) | (units.m / units.s)
     sun.radius = 1.0 | units.RSun
 
     earth = stars[1]
     earth.mass = 5.9736e24 | units.kg
     earth.radius = 6371.0 | units.km
-    earth.position = (149.5e6,0.0,0.0) | units.km
-    earth.velocity = (0.0,29800,0.0) | (units.m / units.s) 
-    
+    earth.position = (149.5e6, 0.0, 0.0) | units.km
+    earth.velocity = (0.0, 29800, 0.0) | (units.m / units.s)
+
     return stars
 
+
 def simulate_system_until(particles, end_time):
-    convert_nbody = nbody_system.nbody_to_si(1.0 | units.MSun, 149.5e6 | units.km)
+    convert_nbody = nbody_system.nbody_to_si(
+        1.0 | units.MSun, 149.5e6 | units.km)
 
     instance = Hermite(convert_nbody)
     instance.parameters.epsilon_squared = 0.0 | units.AU**2
     instance.particles.add_particles(particles)
-    
-    
+
     t0 = 0 | units.day
     dt = 10 | units.day
     t = t0
     earth = instance.particles[1]
-    
+
     x_values = quantities.AdaptingVectorQuantity()
     y_values = quantities.AdaptingVectorQuantity()
-    
+
     while t < end_time:
         instance.evolve_model(t)
-        
+
         x_values.append(earth.x)
         y_values.append(earth.y)
-        
-        t += dt
-    
-    instance.stop()
-    
-    return x_values, y_values
-    
-    
-def plot_track(x,y):
 
-    figure = pyplot.figure(figsize=(5,5))
-    plot = figure.add_subplot(1,1,1)
-    
+        t += dt
+
+    instance.stop()
+
+    return x_values, y_values
+
+
+def plot_track(x, y):
+
+    figure = pyplot.figure(figsize=(5, 5))
+    plot = figure.add_subplot(1, 1, 1)
+
     x_values_in_AU = x.value_in(units.AU)
     y_values_in_AU = y.value_in(units.AU)
-    
-    plot.plot(x_values_in_AU,y_values_in_AU, color = "b")
-    
+
+    plot.plot(x_values_in_AU, y_values_in_AU, color="b")
+
     plot.set_xlim(-1.5, 1.5)
     plot.set_ylim(-1.5, 1.5)
-    
+
     plot.set_xlabel('x (AU)')
     plot.set_ylabel('y (AU)')
-               
+
     pyplot.show()
+
 
 if __name__ == "__main__":
     particles = new_system_of_sun_and_earth()
-    x,y = simulate_system_until(particles, 20 | units.yr)
-    plot_track(x,y)
-    
+    x, y = simulate_system_until(particles, 20 | units.yr)
+    plot_track(x, y)

--- a/examples/simple/supernova_in_binary_nbody.py
+++ b/examples/simple/supernova_in_binary_nbody.py
@@ -1,15 +1,22 @@
 import numpy
-from amuse.lab import *
+from amuse.lab import (
+        constants, units, Particles, nbody_system, Hermite
+        )
+from amuse.ext.orbital_elements import orbital_elements_from_binary
 
 
 def get_relative_velocity(total_mass, semimajor_axis, ecc):
-    return (constants.G * total_mass * ((1.0 + ecc)/(1.0 - ecc)) / semimajor_axis).sqrt()
+    return (
+            constants.G * total_mass * ((1.0 + ecc)/(1.0 - ecc))
+            / semimajor_axis).sqrt()
 
 
 def make_circular_binary(M, m, a):
     masses = [M.value_in(units.MSun), m.value_in(units.MSun)] | units.MSun
-    orbital_period = (4 * numpy.pi**2 * a**3 /
-                      (constants.G * masses.sum())).sqrt().as_quantity_in(units.day)
+    orbital_period = (
+            4 * numpy.pi**2 * a**3
+            / (constants.G * masses.sum())
+            ).sqrt().as_quantity_in(units.day)
 
     print "   Initializing inner binary"
     print "   Orbital period inner binary:", orbital_period
@@ -39,9 +46,6 @@ def post_supernova_eccentricity(M0, m0, M1, m1, a0, r0):
     e = numpy.sqrt(1 - (1-e0**2)
                    * ((1-(2*a0/r0)*(dM/(M0+m0)))) / ((1-dM/(m0+m0))**2))
     return e
-
-
-from amuse.ext.orbital_elements import orbital_elements_from_binary
 
 
 def supernova_in_binary_nbody(M0, m0, a0, tsn):
@@ -75,7 +79,10 @@ def supernova_in_binary_nbody(M0, m0, a0, tsn):
         M0, m0, stars[0].mass, stars[1].mass, a, r0)
     e_ana = post_supernova_eccentricity(
         M0, m0, stars[0].mass, stars[1].mass, a, r0)
-    print "Analytic solution to post orbit orbital parameters: a=", a_ana, "e=", e_ana
+    print(
+            "Analytic solution to post orbit orbital parameters: a=",
+            a_ana, "e=", e_ana,
+            )
     gravity.stop()
 
 

--- a/examples/simple/supernova_in_binary_nbody.py
+++ b/examples/simple/supernova_in_binary_nbody.py
@@ -2,18 +2,18 @@ import numpy
 from amuse.lab import *
 
 
-
 def get_relative_velocity(total_mass, semimajor_axis, ecc):
     return (constants.G * total_mass * ((1.0 + ecc)/(1.0 - ecc)) / semimajor_axis).sqrt()
 
+
 def make_circular_binary(M, m, a):
     masses = [M.value_in(units.MSun), m.value_in(units.MSun)] | units.MSun
-    orbital_period = (4 * numpy.pi**2 * a**3 / 
-        (constants.G * masses.sum())).sqrt().as_quantity_in(units.day)
-    
+    orbital_period = (4 * numpy.pi**2 * a**3 /
+                      (constants.G * masses.sum())).sqrt().as_quantity_in(units.day)
+
     print "   Initializing inner binary"
     print "   Orbital period inner binary:", orbital_period
-    stars =  Particles(2)
+    stars = Particles(2)
     stars.mass = masses
     stars.position = [0.0, 0.0, 0.0] | units.AU
     stars.velocity = [0.0, 0.0, 0.0] | units.km / units.s
@@ -23,25 +23,33 @@ def make_circular_binary(M, m, a):
     return stars
 
 # from Hills 1983 (Eq. 1) 1983ApJ...267..322H
+
+
 def post_supernova_semimajor_axis(M0, m0, M1, m1, a0, r0):
     dM = M0-M1
     a = 0.5 * (M0+m0 - dM)/(0.5*(M0+m0) - (a0/r0)*dM)
     return a
 
 # from Hills 1983 (Eq. 6) 1983ApJ...267..322H
+
+
 def post_supernova_eccentricity(M0, m0, M1, m1, a0, r0):
     dM = M0-M1
     e0 = 0.0
     e = numpy.sqrt(1 - (1-e0**2)
-                   * ( (1-(2*a0/r0)*(dM/(M0+m0)))) / ((1-dM/(m0+m0))**2))
+                   * ((1-(2*a0/r0)*(dM/(M0+m0)))) / ((1-dM/(m0+m0))**2))
     return e
 
 
 from amuse.ext.orbital_elements import orbital_elements_from_binary
+
+
 def supernova_in_binary_nbody(M0, m0, a0, tsn):
     stars = make_circular_binary(M0, m0, a0)
-    M, m, a, e, ta_out, inc, lan_out, aop_out = orbital_elements_from_binary(stars, G=constants.G)
-    print "Initial binary: a=", a.in_(units.AU), "e=", e, "M=", stars[0].mass, "and m=", stars[1].mass
+    M, m, a, e, ta_out, inc, lan_out, aop_out = orbital_elements_from_binary(
+        stars, G=constants.G)
+    print "Initial binary: a=", a.in_(
+        units.AU), "e=", e, "M=", stars[0].mass, "and m=", stars[1].mass
 
     converter = nbody_system.nbody_to_si(M+m, a)
     gravity = Hermite(converter)
@@ -49,7 +57,8 @@ def supernova_in_binary_nbody(M0, m0, a0, tsn):
 
     print "Integrate binary to t=", tsn.in_(units.day)
     gravity.evolve_model(tsn)
-    M, m, a, e, ta_out, inc, lan_out, aop_out = orbital_elements_from_binary(stars, G=constants.G)
+    M, m, a, e, ta_out, inc, lan_out, aop_out = orbital_elements_from_binary(
+        stars, G=constants.G)
     print "Pre supernova orbit: a=", a.in_(units.AU), "e=", e
     stars[0].mass *= 0.1
     print "Reduce stellar mass to: M=", stars[0].mass, "and m=", stars[1].mass
@@ -57,20 +66,23 @@ def supernova_in_binary_nbody(M0, m0, a0, tsn):
     v_kick = (0, 0, 0) | units.kms
     stars[0].velocity += v_kick
     gravity.evolve_model(2*tsn)
-    M, m, a, e, ta_out, inc, lan_out, aop_out = orbital_elements_from_binary(stars, G=constants.G)
+    M, m, a, e, ta_out, inc, lan_out, aop_out = orbital_elements_from_binary(
+        stars, G=constants.G)
     print "Post supernova orbit: a=", a.in_(units.AU), "e=", e
 
     r0 = a
-    a_ana = post_supernova_semimajor_axis(M0, m0, stars[0].mass, stars[1].mass, a, r0)
-    e_ana = post_supernova_eccentricity(M0, m0, stars[0].mass, stars[1].mass, a, r0)
+    a_ana = post_supernova_semimajor_axis(
+        M0, m0, stars[0].mass, stars[1].mass, a, r0)
+    e_ana = post_supernova_eccentricity(
+        M0, m0, stars[0].mass, stars[1].mass, a, r0)
     print "Analytic solution to post orbit orbital parameters: a=", a_ana, "e=", e_ana
     gravity.stop()
-    
+
+
 if __name__ in ('__main__'):
-    M = 10|units.MSun
-    m = 10|units.MSun
+    M = 10 | units.MSun
+    m = 10 | units.MSun
     a = 1 | units.AU
     orbital_period = (4 * numpy.pi**2 * a**3 / (constants.G * (M+m))).sqrt()
     tsn = 10*orbital_period
     supernova_in_binary_nbody(M, m, a, tsn)
-

--- a/examples/simple/unstable_binary.py
+++ b/examples/simple/unstable_binary.py
@@ -1,14 +1,14 @@
 """
-Evolves two stars dynamically (hermit, nbody code) each star will 
+Evolves two stars dynamically (hermit, nbody code) each star will
 lose mass during the evolution (evtwin, stellar evolution code)
 
 We start with two stars, one 10.0 and one 1.0 solar mass star. These
-stars start orbiting with a stable kepler orbit. 
+stars start orbiting with a stable kepler orbit.
 After 2 orbital periods the stars will begin to lose mass and the binary
 will become unstable.
 """
 
-from amuse.plot import scatter, xlabel, ylabel, plot
+from amuse.plot import xlabel, ylabel, plot
 from matplotlib import pyplot
 from math import pi
 from amuse.units.optparse import OptionParser
@@ -17,7 +17,7 @@ from amuse.units import units
 from amuse.units import constants
 from amuse.units.nbody_system import nbody_to_si
 from amuse.community.evtwin.interface import EVtwin
-from amuse.community.sse.interface import SSE
+# from amuse.community.sse.interface import SSE
 from amuse.community.hermite0.interface import Hermite
 
 from amuse.datamodel import Particles
@@ -126,7 +126,7 @@ def main(
         kinetic_to_potential_ratio=0.8,
         periods=10,
         age=10 | units.Myr
-    ):
+        ):
     t_offset_stars = age
     t_end = periods * orbital_period
 

--- a/examples/simple/unstable_binary.py
+++ b/examples/simple/unstable_binary.py
@@ -25,24 +25,30 @@ from amuse.datamodel import Particles
 
 def set_up_initial_conditions(orbital_period, kinetic_to_potential_ratio):
     print("Setting up initial conditions")
-    stars =  Particles(2)
+    stars = Particles(2)
     stars.mass = [10.0, 1.0] | units.MSun
     stars.radius = 0 | units.RSun
     stars.position = [0.0, 0.0, 0.0] | units.AU
     stars.velocity = [0.0, 0.0, 0.0] | units.km / units.s
-    
-    print("Binary with masses: "+str(stars.mass)+", and orbital period: ", orbital_period)
-    semimajor_axis = ((constants.G * stars.total_mass() * (orbital_period / (2 * pi))**2.0)**(1.0/3.0))
+
+    print("Binary with masses: "+str(stars.mass) +
+          ", and orbital period: ", orbital_period)
+    semimajor_axis = ((constants.G * stars.total_mass() *
+                       (orbital_period / (2 * pi))**2.0)**(1.0/3.0))
     separation = 2 * semimajor_axis * (1 - kinetic_to_potential_ratio)
     print("Initial separation:", separation.as_quantity_in(units.AU))
-    relative_velocity = ( (kinetic_to_potential_ratio / (1.0 - kinetic_to_potential_ratio)) * 
-        constants.G * stars.total_mass() / semimajor_axis).sqrt()
-    print("Initial relative velocity:", relative_velocity.as_quantity_in(units.km / units.s))
-    
+    relative_velocity = (
+            (kinetic_to_potential_ratio / (1.0 - kinetic_to_potential_ratio))
+            * constants.G * stars.total_mass() / semimajor_axis
+            ).sqrt()
+    print("Initial relative velocity:",
+          relative_velocity.as_quantity_in(units.km / units.s))
+
     stars[0].x = separation
     stars[0].vy = relative_velocity
     stars.move_to_center()
     return stars
+
 
 def set_up_stellar_evolution_code(stars):
     stellar_evolution = EVtwin()
@@ -52,45 +58,56 @@ def set_up_stellar_evolution_code(stars):
     # stellar_evolution.parameters.reimers_wind_efficiency = 1.0e6 # ridiculous, but instructive
     stellar_evolution.particles.add_particles(stars)
     return stellar_evolution
-    
+
+
 def set_up_gravitational_dynamics_code(stars):
     convert_nbody = nbody_to_si(11.0 | units.MSun, 10.0 | units.AU)
     gravitational_dynamics = Hermite(convert_nbody)
     gravitational_dynamics.parameters.epsilon_squared = 0.0 | units.AU ** 2
-    view_on_the_primary = gravitational_dynamics.particles.add_particle(stars[0])
+    view_on_the_primary = gravitational_dynamics.particles.add_particle(
+        stars[0])
     gravitational_dynamics.particles.add_particle(stars[1])
     return gravitational_dynamics, view_on_the_primary
-    
+
 
 def simulate_binary_evolution(binary, orbital_period, t_offset_stars, t_end):
     distance = [] | units.AU
     mass = [] | units.MSun
     time = [] | units.yr
-    
+
     stellar_evolution = set_up_stellar_evolution_code(binary)
-    gravitational_dynamics, primary = set_up_gravitational_dynamics_code(binary)
-    from_se_to_gd = stellar_evolution.particles.new_channel_to(gravitational_dynamics.particles)
-    
+    gravitational_dynamics, primary = set_up_gravitational_dynamics_code(
+        binary)
+    from_se_to_gd = stellar_evolution.particles.new_channel_to(
+        gravitational_dynamics.particles)
+
     current_time = 0.0 * t_end
-    
-        
+
     print("Evolving with stellar wind")
     while current_time < t_end:
         current_time += orbital_period / 10
         gravitational_dynamics.evolve_model(current_time)
         stellar_evolution.evolve_model(current_time + t_offset_stars)
         from_se_to_gd.copy_attributes(['mass'])
-        separation = (gravitational_dynamics.particles[0].position - gravitational_dynamics.particles[1].position).length()
+        separation = (
+            gravitational_dynamics.particles[0].position
+            - gravitational_dynamics.particles[1].position
+            ).length()
         distance.append(separation)
         mass.append(primary.mass)
         time.append(current_time)
-        print("System evolved to time: ", current_time, ", primary mass:", primary.mass.as_quantity_in(units.MSun), ", separation:", separation.as_quantity_in(units.AU))
-    
+        print(
+                "System evolved to time: ", current_time,
+                ", primary mass:", primary.mass.as_quantity_in(
+                    units.MSun),
+                ", separation:", separation.as_quantity_in(units.AU))
+
     print("Evolution done")
     return distance, mass, time
 
+
 def orbit_plot(distance, mass, time):
-    figure = pyplot.figure(figsize = (6, 10), dpi = 100)
+    figure = pyplot.figure(figsize=(6, 10), dpi=100)
     subplot = figure.add_subplot(2, 1, 1)
     plot(time, distance)
     xlabel('t')
@@ -103,61 +120,63 @@ def orbit_plot(distance, mass, time):
     pyplot.margins(0.05)
     pyplot.show()
 
+
 def main(
-        orbital_period = 1000.0 | units.yr, 
-        kinetic_to_potential_ratio = 0.8, 
-        periods = 10,
-        age = 10 | units.Myr
+        orbital_period=1000.0 | units.yr,
+        kinetic_to_potential_ratio=0.8,
+        periods=10,
+        age=10 | units.Myr
     ):
-    
     t_offset_stars = age
     t_end = periods * orbital_period
-    
-    binary = set_up_initial_conditions(orbital_period, kinetic_to_potential_ratio)
-    distance, mass, time = simulate_binary_evolution(binary, orbital_period, t_offset_stars, t_end)
+
+    binary = set_up_initial_conditions(
+        orbital_period, kinetic_to_potential_ratio)
+    distance, mass, time = simulate_binary_evolution(
+        binary, orbital_period, t_offset_stars, t_end)
     orbit_plot(distance, mass, time)
-    
+
+
 def new_option_parser():
     result = OptionParser()
     result.add_option(
-        "-o", "--orbitalperiod", 
-        default = 1000 | units.yr,
+        "-o", "--orbitalperiod",
+        default=1000 | units.yr,
         dest="orbital_period",
         help="initial orbital period of the binary (in years)",
         type="float",
         unit=units.yr
     )
-    
+
     result.add_option(
-        "-k", "--kpratio", 
-        default = 0.8,
+        "-k", "--kpratio",
+        default=0.8,
         dest="kinetic_to_potential_ratio",
         help="kinetec to potential energy ratio, values less than 1.0 correspond to bound systems",
         type="float"
     )
     result.add_option(
-        "--periods", 
-        default = 10,
+        "--periods",
+        default=10,
         dest="periods",
         help="number of orbital periods to evolve the binary",
         type="int"
     )
     result.add_option(
-        "--age", 
-        default = 10 | units.Myr,
+        "--age",
+        default=10 | units.Myr,
         dest="age",
         help="initial age of the stars to start the simulation with",
         type="float",
         unit=units.Myr
     )
-    
-    
+
     return result
-    
-    
+
+
 if __name__ == "__plot__":
     main(1000 | units.yr, 0.8, 10, 10 | units.Myr)
-    
+
 if __name__ == "__main__":
     options, args = new_option_parser().parse_args()
     main(**options.__dict__)


### PR DESCRIPTION
Initial changes done with autopep8, with some manual fixes where autopep8 made strange choices.
Additional changes to remove "import *" occurrences and unused imports

This makes the "simple" examples (mostly) complient with the Amuse style guide