### PR TITLE
add ignore files and dirs for editors and ides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -467,3 +467,19 @@ src/amuse/community/mosse/src/mosse
 test/core_tests/test.txt
 test_concurrent
 test_python_sockets_implementation
+
+# editors and ides
+*.tmp
+*.bak
+*.swp
+*~.nib
+*~
+
+.metadata
+.settings/
+*.pydevproject
+.cproject
+.autotools
+.buildpath
+
+.idea


### PR DESCRIPTION
Hi,

i added some ignore files, mainly for:

   - emacs
   - vi/vim
   - eclipse
   - pycharm et. al (IDEA related products)
