### PR TITLE
multiple async requests on the same code

### DIFF
--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -280,7 +280,7 @@ class ASyncSocketRequest(AbstractASyncRequest):
     def is_socket_request(self):
         return True
 
-class FakeASyncRequest(object):
+class FakeASyncRequest(AbstractASyncRequest):
         
     def __init__(self, result):
         self.is_finished = False

--- a/src/amuse/rfi/core.py
+++ b/src/amuse/rfi/core.py
@@ -27,6 +27,7 @@ from amuse.rfi.channel import MultiprocessingMPIChannel
 from amuse.rfi.channel import DistributedChannel
 from amuse.rfi.channel import SocketChannel
 from amuse.rfi.channel import is_mpd_running
+from amuse.rfi.channel import DependentASyncRequest
 
 try:
     from amuse import config
@@ -121,9 +122,7 @@ class CodeFunction(object):
         
         return result
     
-
-
-    def async(self, *arguments_list, **keyword_arguments):
+    def _async_request(self, *arguments_list, **keyword_arguments):
         dtype_to_values = self.converted_keyword_and_list_arguments( arguments_list, keyword_arguments)
         
         handle_as_array = self.must_handle_as_array(dtype_to_values)
@@ -133,7 +132,7 @@ class CodeFunction(object):
         self.interface.channel.send_message(call_id, self.specification.id, dtype_to_arguments = dtype_to_values)
         
         request = self.interface.channel.nonblocking_recv_message(call_id, self.specification.id, handle_as_array)
-        
+
         def handle_result(function):
             try:
                 dtype_to_result = function()
@@ -142,9 +141,29 @@ class CodeFunction(object):
             return self.converted_results(dtype_to_result, handle_as_array)
             
         request.add_result_handler(handle_result)
+        
         return request
-        
-        
+
+    def async(self, *arguments_list, **keyword_arguments):
+        if self.interface.async_request is not None:
+            def factory():
+              return self._async_request(*arguments_list, **keyword_arguments)
+            request=DependentASyncRequest( self.interface.async_request, factory) 
+        else:
+            request=self._async_request(*arguments_list, **keyword_arguments)
+
+        def handle_result(function):
+
+            result=function()
+            if  self.interface.async_request==request:
+                self.interface.async_request=None
+            return result
+
+        request.add_result_handler(handle_result)
+
+        self.interface.async_request=request
+
+        return request
     
     def must_handle_as_array(self, keyword_arguments):
         for argument_type, argument_values in keyword_arguments.items():
@@ -695,8 +714,9 @@ class CodeInterface(OptionalAttributes):
         :argument hostname: Start the worker on the node with this name
         """
         OptionalAttributes.__init__(self, **options)
-           
-       
+        
+        self.async_request=None
+
         self.instances.append(weakref.ref(self))
         #
         #ave: no more redirection in the code
@@ -1164,7 +1184,7 @@ class CodeFunctionWithUnits(CodeFunction):
         
         return result
     
-    def async(self, *arguments_list, **keyword_arguments):
+    def _async_request(self, *arguments_list, **keyword_arguments):
         dtype_to_values, units = self.converted_keyword_and_list_arguments( arguments_list, keyword_arguments)
         encoded_units = self.convert_input_units_to_floats(units)
         

--- a/src/amuse/support/methods.py
+++ b/src/amuse/support/methods.py
@@ -102,6 +102,10 @@ class CodeMethodWrapper(AbstractCodeMethodWrapper):
         self.definition.check_wrapped_method(self)
     
     def __call__(self, *list_arguments, **keyword_arguments):
+        if keyword_arguments.get("async", False):
+            keyword_arguments.pop("async")
+            return self.async(*list_arguments, **keyword_arguments)
+        
         object = self.precall()
         list_arguments, keyword_arguments = self.convert_arguments(list_arguments, keyword_arguments)
         result = self.method(*list_arguments, **keyword_arguments)
@@ -126,11 +130,11 @@ class CodeMethodWrapper(AbstractCodeMethodWrapper):
         def handle_result(function):
             
             result = function()
-            
+
             result = self.convert_result(result)
         
             self.postcall(object)
-            
+                        
             return result
         
         request.add_result_handler(handle_result)

--- a/test/compile_tests/test_async.py
+++ b/test/compile_tests/test_async.py
@@ -1,0 +1,171 @@
+from amuse.support.interface import InCodeComponentImplementation
+
+from amuse.test.amusetest import TestWithMPI
+from amuse.support import exceptions
+from amuse.support import options
+
+import os
+import time
+from amuse.units import nbody_system
+from amuse.units import units
+from amuse import datamodel
+from amuse.rfi.tools import create_c
+from amuse.rfi import channel
+from amuse.rfi.core import *
+
+import test_c_implementation
+
+from amuse.test import compile_tools
+
+
+codestring=test_c_implementation.codestring+"""
+#include <unistd.h>
+
+int do_sleep(int in) {
+    sleep(in);
+    return 0;
+}
+
+"""
+
+class ForTestingInterface(test_c_implementation.ForTestingInterface):
+    @legacy_function
+    def do_sleep():
+        function = LegacyFunctionSpecification()
+        function.addParameter('int_in', dtype='int32', direction=function.IN)
+        function.result_type = 'int32'
+        return function 
+
+class ForTesting(InCodeComponentImplementation):
+    
+    def __init__(self, exefile, **options):
+        InCodeComponentImplementation.__init__(self, ForTestingInterface(exefile, **options), **options)
+
+class TestASync(TestWithMPI):
+
+    def setUp(self):
+        super(TestASync, self).setUp()
+        print "building...",
+        self.check_can_compile_modules()
+        try:
+            self.exefile = compile_tools.build_worker(codestring, self.get_path_to_results(), ForTestingInterface)
+        except Exception as ex:
+            print ex
+            raise
+        print "done"
+        
+    def test1(self):
+        instance = ForTestingInterface(self.exefile)
+        int_out, error = instance.echo_int(10)
+        instance.stop()
+        self.assertEquals(int_out, 10)
+        self.assertEquals(error, 0)
+
+    def test2(self):
+        instance = ForTestingInterface(self.exefile)
+        request = instance.echo_int.async(10)
+        self.assertEqual(request, instance.async_request)
+        request.wait()
+        int_out,error=request.result()
+        self.assertEquals(int_out, 10)
+        self.assertEquals(error, 0)
+        instance.stop()
+
+    def test3(self):
+        instance = ForTestingInterface(self.exefile)
+        request1 = instance.do_sleep.async(1)
+        request2 = instance.echo_int.async(10)
+        self.assertEqual(request2, instance.async_request)
+        request2.wait()
+        int_out,error=request2.result()
+        self.assertEquals(int_out, 10)
+        self.assertEquals(error, 0)
+        instance.stop()
+
+    def test4(self):
+        instance = ForTesting(self.exefile)
+        request1 = instance.do_sleep(1, async=True)
+        request2 = instance.echo_int(10, async=True)
+        self.assertEqual(request2, instance.async_request)
+        instance.async_request.wait()
+        int_out=request2.result()
+        self.assertEquals(int_out, 10)
+        instance.stop()
+
+    def test5(self):
+        instance = ForTesting(self.exefile)
+        instance.do_sleep(1, async=True)
+        requests=[]
+        for x in range(10):
+            requests.append(instance.echo_int(x, async=True))
+        instance.async_request.wait()
+        for i,x in enumerate(requests):
+            self.assertEquals(x.result(), i)
+        instance.stop()
+
+    def test6(self):
+        instance = ForTesting(self.exefile)
+        requests=[]
+        for x in range(10):
+            requests.append(instance.echo_int(x, async=True))
+        instance.async_request.wait()
+        for i,x in enumerate(requests):
+            self.assertEquals(x.result(), i)
+        instance.stop()
+
+    def test7(self):
+        instance1 = ForTesting(self.exefile)
+        instance2 = ForTesting(self.exefile)
+        t1=time.time()
+
+        requests=[]
+        for x in range(10):
+            requests.append([instance1.echo_int(x, async=True),x])
+        for x in range(10):
+            requests.append([instance2.echo_int(x, async=True),x])
+
+        instance1.do_sleep(1, async=True)
+        instance2.do_sleep(1, async=True)
+
+        pool=instance1.async_request.join(instance2.async_request)
+        pool.waitall()
+        t2=time.time()
+
+        for x in requests:
+            self.assertEquals(x[0].result(), x[1])
+        instance1.stop()
+        instance2.stop()
+        self.assertTrue(t2-t1 < 2.)
+
+    def test8(self):
+        from threading import Thread
+        instance1 = ForTesting(self.exefile)
+        instance2 = ForTesting(self.exefile)
+        t1=time.time()
+
+        requests=[]
+        for x in range(10):
+            requests.append([instance1.echo_int(x, async=True),x])
+        for x in range(10):
+            requests.append([instance2.echo_int(x, async=True),x])
+
+        instance1.do_sleep(1, async=True)
+        instance2.do_sleep(1, async=True)
+
+        pool=instance1.async_request.join(instance2.async_request)
+        
+        thread=Thread(target=pool.waitall)
+        thread.start()
+        time.sleep(1)
+        thread.join()
+        
+        self.assertTrue(pool)
+        
+        t2=time.time()
+
+        for x in requests:
+            self.assertEquals(x[0].result(), x[1])
+        instance1.stop()
+        instance2.stop()
+        self.assertTrue(t2-t1 < 2.)
+


### PR DESCRIPTION
This patch allows for multiple async requests on the same code; see for examples
the new compile_tests/test_async.py

it also allows to specify async call with keyword argument async=True instead of the 
.async(..) method..