### PR TITLE
work on grid for samplePoints with explicit coordinate arrays

### DIFF
--- a/src/amuse/datamodel/grid_attributes.py
+++ b/src/amuse/datamodel/grid_attributes.py
@@ -1,4 +1,4 @@
-from amuse.units.quantities import zero, as_vector_quantity
+from amuse.units.quantities import zero, as_vector_quantity, column_stack
 
 import numpy
 
@@ -205,4 +205,22 @@ def get_overlap_with(grid, grid1,eps=None):
 #    coordinates fully inside the grid """
 #    gridminx,gridminy=sys.grid.get_minimum_position()
 #    gridmaxx,gridmaxy=sys.grid.get_maximum_position()
+
+@grids.BaseGrid.function_for_set
+def get_index(grid, pos=None, **kwargs):
+    raise Exception("not implemented for a {0} grid".format(grid.__class__.__name__))
+
+@grids.RegularBaseGrid.function_for_set
+def get_index(grid, pos=None, **kwargs):
+    pos=grid._get_array_of_positions_from_arguments(pos=pos,**kwargs)
+    offset = pos - grid.get_minimum_position()
+    indices = (offset / grid.cellsize())
+    return numpy.floor(indices).astype(numpy.int)
+
+@grids.BaseGrid.function_for_set
+def _get_array_of_positions_from_arguments(grid, **kwargs):
+    return grids._get_array_of_positions_from_arguments(grid.get_axes_names(), **kwargs)
+
+           
+      
 

--- a/src/amuse/datamodel/grids.py
+++ b/src/amuse/datamodel/grids.py
@@ -1065,4 +1065,8 @@ def _get_array_of_positions_from_arguments(axes_names, **kwargs):
         return kwargs['pos']
     if kwargs.get('position',None):
         return kwargs['position']
-    return column_stack([kwargs[x] for x in axes_names])
+    
+    coordinates=[kwargs[x] for x in axes_names]
+    if numpy.rank(coordinates[0])==0:
+      return coordinates
+    return column_stack(coordinates)

--- a/src/amuse/units/quantities.py
+++ b/src/amuse/units/quantities.py
@@ -1280,6 +1280,13 @@ def concatenate(quantities):
     concatenated = numpy.concatenate(numbers)
     return VectorQuantity(concatenated, unit)
 
+def column_stack( args ):
+    args_=[to_quantity(x) for x in args]
+    units=set([x.unit for x in args_])
+    if len(units)==1:
+      return new_quantity(numpy.column_stack([x.number for x in args_]),args_[0].unit)
+    else:
+      return numpy.column_stack(args)
 
 def arange(start, stop, step):
     if not is_quantity(start):

--- a/test/core_tests/test_grid_attributes.py
+++ b/test/core_tests/test_grid_attributes.py
@@ -65,3 +65,17 @@ class TestGridAttributes(amusetest.TestCase):
     def xtest5(self):
         grid=new_unstructured_grid((10,20),(10,10))
         self.assertEqual(grid.cellsize(),[1.,0.5])
+
+    def test6(self):
+        grid=new_regular_grid((10,10),(10,10))
+        self.assertEquals(grid.get_index((6.2,3.7)), [6,3])
+        self.assertEquals(grid.get_index(x=[6.2],y=[3.7]), [6,3])
+        self.assertEquals(grid.get_index(y=[6.2],x=[3.7]), [3,6])
+        self.assertEquals(grid.get_index(y=6.2,x=3.7), [3,6])
+        
+    def test7(self):
+        grid=new_regular_grid((10,10),[20,10] | units.m,axes_names="ab")
+        self.assertEquals(grid.get_index([16.2,3.7] | units.m), [8,3])
+        self.assertEquals(grid.get_index(a=16.2 | units.m,b=3.7 | units.m), [8,3])
+        self.assertEquals(grid.get_index(a=[16.2, 4.5] | units.m,b=[3.7,4.2] | units.m), [[8,3],[2,4]])
+

--- a/test/core_tests/test_grid_attributes.py
+++ b/test/core_tests/test_grid_attributes.py
@@ -71,7 +71,8 @@ class TestGridAttributes(amusetest.TestCase):
         self.assertEquals(grid.get_index((6.2,3.7)), [6,3])
         self.assertEquals(grid.get_index(x=[6.2],y=[3.7]), [6,3])
         self.assertEquals(grid.get_index(y=[6.2],x=[3.7]), [3,6])
-        self.assertEquals(grid.get_index(y=6.2,x=3.7), [3,6])
+        self.assertEquals(grid.get_index(y=6.2,x=3.7)[0], 3)
+        self.assertEquals(grid.get_index(y=6.2,x=3.7)[1], 6)
         
     def test7(self):
         grid=new_regular_grid((10,10),[20,10] | units.m,axes_names="ab")

--- a/test/core_tests/test_grids.py
+++ b/test/core_tests/test_grids.py
@@ -896,52 +896,52 @@ class TestGridSampling(amusetest.TestCase):
     def test1(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m)
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m,method="interpolation")
         self.assertEquals(sample.index , [1,1,1])
-        sample = grid.samplePoint([2.5,2.5,2.5]| units.m)
+        sample = grid.samplePoint([2.5,2.5,2.5]| units.m,method="interpolation")
         self.assertEquals(sample.index , [1,1,1])
-        sample = grid.samplePoint([3.5,3.5,3.5]| units.m)
+        sample = grid.samplePoint([3.5,3.5,3.5]| units.m,method="interpolation")
         self.assertEquals(sample.index , [1,1,1])
         
         for x in range(0,200):
-            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m)
+            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m,method="interpolation")
             self.assertEquals(sample.index , [0,2,3])
             
         for x in range(200,400):
-            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m)
+            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m,method="interpolation")
             self.assertEquals(sample.index , [1,3,4])
 
     def test2(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m)
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m,method="interpolation")
         self.assertEquals(sample.index_for_000_cell , [1,1,1])
-        sample = grid.samplePoint([2.5,2.5,2.5]| units.m)
+        sample = grid.samplePoint([2.5,2.5,2.5]| units.m,method="interpolation")
         self.assertEquals(sample.index_for_000_cell , [0,0,0])
-        sample = grid.samplePoint([3.5,3.5,3.5]| units.m)
+        sample = grid.samplePoint([3.5,3.5,3.5]| units.m,method="interpolation")
         self.assertEquals(sample.index_for_000_cell , [1,1,1])
-        sample = grid.samplePoint([4.5,4.5,4.5]| units.m)
+        sample = grid.samplePoint([4.5,4.5,4.5]| units.m,method="interpolation")
         self.assertEquals(sample.index_for_000_cell , [1,1,1])
         self.assertEquals(sample.index , [2,2,2])
         
         for x in range(0,100):
             
-            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m)
+            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m,method="interpolation")
             self.assertEquals(sample.index_for_000_cell , [-1,1,2])
         for x in range(100,300):
             
-            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m)
+            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m,method="interpolation")
             self.assertEquals(sample.index_for_000_cell , [0,2,3])
             
         for x in range(300,400):
-            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m)
+            sample = grid.samplePoint([0.0 + (x/100.0),4.0+(x/100.0),6.0+(x/100.0)]| units.m,method="interpolation")
             self.assertEquals(sample.index_for_000_cell , [1,3,4])
             
     
     def test3(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m)
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m,method="interpolation")
         self.assertEquals(sample.index_for_000_cell , [1,1,1])
         self.assertEquals(sample.surrounding_cell_indices , [
             [1,1,1],
@@ -957,7 +957,7 @@ class TestGridSampling(amusetest.TestCase):
     def test4(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m)
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m,method="interpolation")
         self.assertEquals(sample.surrounding_cells[0].position , [3.0,3.0,3.0] | units.m )    
         self.assertEquals(sample.surrounding_cells[1].position , [5.0,3.0,3.0] | units.m )   
         self.assertEquals(sample.surrounding_cells[-1].position , [5.0,5.0,5.0] | units.m )        
@@ -966,7 +966,7 @@ class TestGridSampling(amusetest.TestCase):
     def test5(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m)
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m,method="interpolation")
         masses = sample.get_values_of_attribute("mass")
         self.assertEquals(masses[0] , 3.0 | units.kg ) 
         self.assertEquals(masses[1] , 5.0 | units.kg ) 
@@ -992,50 +992,50 @@ class TestGridSampling(amusetest.TestCase):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
         for xpos in numpy.arange(3.0,5.0,0.1):
-            sample = grid.samplePoint([xpos,3.0,3.0]| units.m)
+            sample = grid.samplePoint([xpos,3.0,3.0]| units.m,method="interpolation")
             self.assertAlmostRelativeEquals(sample.mass , (3.0 | units.kg) + ((2.0 * (xpos - 3.0) / 2.0) | units.kg) ) 
           
-            sample = grid.samplePoint([xpos,3.0,3.0]| units.m)
+            sample = grid.samplePoint([xpos,3.0,3.0]| units.m,method="interpolation")
             self.assertAlmostRelativeEquals(sample.mass , (3.0 | units.kg) + ((2.0 * (xpos - 3.0) / 2.0) | units.kg) ) 
           
-            sample = grid.samplePoint([xpos,5.0,3.0]| units.m)
+            sample = grid.samplePoint([xpos,5.0,3.0]| units.m,method="interpolation")
             self.assertAlmostRelativeEquals(sample.mass , (3.0 | units.kg) + ((2.0 * (xpos - 3.0) / 2.0) | units.kg) ) 
           
-            sample = grid.samplePoint([xpos,3.0,5.0]| units.m)
+            sample = grid.samplePoint([xpos,3.0,5.0]| units.m,method="interpolation")
             self.assertAlmostRelativeEquals(sample.mass , (3.0 | units.kg) + ((2.0 * (xpos - 3.0) / 2.0) | units.kg) ) 
         
 
-            sample = grid.samplePoint([4.0,4.0,4.0]| units.m)
+            sample = grid.samplePoint([4.0,4.0,4.0]| units.m,method="interpolation")
             self.assertAlmostRelativeEquals(sample.mass , (4.0 | units.kg)) 
 
     def test7(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m)
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m,method="interpolation")
         self.assertTrue(sample.isvalid)
-        sample = grid.samplePoint([11.0,3.0,3.0]| units.m)
+        sample = grid.samplePoint([11.0,3.0,3.0]| units.m,method="interpolation")
         self.assertFalse(sample.isvalid)
-        sample = grid.samplePoint([3.0,-1.0,3.0]| units.m)
+        sample = grid.samplePoint([3.0,-1.0,3.0]| units.m,method="interpolation")
         self.assertFalse(sample.isvalid)
         
     
     def test8(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m, must_return_values_on_cell_center = True)    
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m, method="nearest")    
         self.assertEquals(sample.position, [3.0,3.0,3.0]| units.m)    
         self.assertEquals(sample.mass, 3.0 | units.kg)
-        sample = grid.samplePoint([3.5,3.0,3.0]| units.m, must_return_values_on_cell_center = True)    
+        sample = grid.samplePoint([3.5,3.0,3.0]| units.m, method="nearest")    
         self.assertEquals(sample.position, [3.0,3.0,3.0]| units.m)  
         self.assertEquals(sample.mass, 3.0 | units.kg)
         
     def test9(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        sample = grid.samplePoint([3.0,3.0,3.0]| units.m, must_return_values_on_cell_center = False)    
+        sample = grid.samplePoint([3.0,3.0,3.0]| units.m, method="linear")    
         self.assertEquals(sample.position, [3.0,3.0,3.0]| units.m)    
         self.assertEquals(sample.mass, 3.0 | units.kg)
-        sample = grid.samplePoint([3.5,3.0,3.0]| units.m, must_return_values_on_cell_center = False)    
+        sample = grid.samplePoint([3.5,3.0,3.0]| units.m, method="linear")    
         self.assertEquals(sample.position, [3.5,3.0,3.0]| units.m)  
         self.assertEquals(sample.mass, 3.5 | units.kg)
         
@@ -1045,7 +1045,7 @@ class TestGridSamplingMultiplePoints(amusetest.TestCase):
     def test1(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        samples = grid.samplePoints([[3.0,3.0,3.0], [4.0,3.0,3.0]]| units.m)
+        samples = grid.samplePoints([[3.0,3.0,3.0], [4.0,3.0,3.0]]| units.m, method="linear")
         self.assertEquals(len(samples), 2)
         self.assertEquals(samples.position[0] , [3.0,3.0,3.0]| units.m)
         self.assertEquals(samples.position[0] , samples[0].position)
@@ -1055,7 +1055,7 @@ class TestGridSamplingMultiplePoints(amusetest.TestCase):
     def test2(self):
         grid = datamodel.new_regular_grid((5,5,5), [10.0, 10.0, 10.0] | units.m)
         grid.mass = grid.x.value_in(units.m) | units.kg
-        samples = grid.samplePoints([[3.5,3.0,3.0], [4.5,3.0,3.0]]| units.m)
+        samples = grid.samplePoints([[3.5,3.0,3.0], [4.5,3.0,3.0]]| units.m, method="linear")
         self.assertEquals(len(samples), 2)
         self.assertEquals(samples.mass , [3.5, 4.5] | units.kg)
         

--- a/test/core_tests/test_quantities.py
+++ b/test/core_tests/test_quantities.py
@@ -532,5 +532,13 @@ class TestNumpyFunctionWithUnits(amusetest.TestCase):
 
         self.assertAlmostRelativeEquals(y, fit_values, 1)
 
-
+    def test5(self):
+        a=[1,2,3] | units.m
+        b=[4,5,6] | units.m
+        
+        ab1=quantities.column_stack((a,b))
+        ab2=quantities.column_stack((a.number,b.number)) | units.m
+        
+        self.assertEquals(ab1,ab2)
+        
 


### PR DESCRIPTION
eg:
```
sample=grid.samplePoint(x=5, y=3)
```

 adds get_index, get_axes_names and possibility of specifying sample points with explicit coordinate vectors, also adds column-stack on quantities.