### PR TITLE
Explicit module imports within examples/textbook

### DIFF
--- a/examples/textbook/1992AA...260..161H.py
+++ b/examples/textbook/1992AA...260..161H.py
@@ -1,9 +1,19 @@
 import math
 import numpy
-from amuse.lab import *
+# from amuse.lab import *
 from amuse.ext.protodisk import ProtoPlanetaryDisk
 from optparse import OptionParser
 from amuse.couple import bridge
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.ic.gasplummer import new_plummer_gas_model
+from amuse.units import constants
+from amuse.datamodel import Particles
+from amuse.community.fi.interface import Fi
+from amuse.community.hermite0.interface import Hermite
+from amuse.datamodel import ParticlesSuperset
+from amuse.io import write_set_to_file
+
 
 def main(Mstar=1, Ndisk=100, Mdisk= 0.001, Rmin=1, Rmax=100, t_end=10, n_steps=10, filename="nbody.hdf5"):
 #    numpy.random.seed(111)

--- a/examples/textbook/2017arXiv170307029H_Fig3.py
+++ b/examples/textbook/2017arXiv170307029H_Fig3.py
@@ -1,6 +1,10 @@
 import numpy
-from amuse.lab import *
+# from amuse.lab import *
 from matplotlib import pyplot
+from amuse.datamodel import Particles 
+from amuse.io import read_set_from_file
+from amuse.units import units
+from amuse.units import constants
 
 R_young_stars = [ 0.1012221753955787, 0.2968660204589863,
                   0.5017430508551541, 0.7046418772801384, 0.8984687805821738,

--- a/examples/textbook/anim_gravity_old.py
+++ b/examples/textbook/anim_gravity_old.py
@@ -1,7 +1,10 @@
 import os
 from matplotlib import pyplot
 import matplotlib.animation as animation
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.io import read_set_from_file
+from amuse.units import units
+
 
 fig = pyplot.figure(figsize=(8,8))
 ax = fig.add_subplot(1,1,1)

--- a/examples/textbook/compare_disk_size_Trapezium.py
+++ b/examples/textbook/compare_disk_size_Trapezium.py
@@ -3,7 +3,7 @@ import os
 import numpy
 import math
 from matplotlib import pyplot
-from amuse.lab import *
+# from amuse.lab import *
 
 from prepare_figure import single_frame, figure_frame, set_tickmarks
 from distinct_colours import get_distinct

--- a/examples/textbook/core_temperature_density.py
+++ b/examples/textbook/core_temperature_density.py
@@ -1,4 +1,7 @@
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.units import units
+from amuse.community.mesa.interface import MESA
+from amuse.datamodel import Particle
 
 Second_Asymptotic_Giant_Branch = 6 | units.stellar_type
 HeWhiteDwarf = 10 | units.stellar_type

--- a/examples/textbook/earthorbitvariation.py
+++ b/examples/textbook/earthorbitvariation.py
@@ -1,5 +1,9 @@
-from amuse.lab import * 
-
+# from amuse.lab import * 
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.community.huayno.interface import Huayno
+from amuse.datamodel import Particles
+from amuse.community.kepler.interface import Kepler
 from amuse.ext.solarsystem import solar_system_in_time
 from prepare_figure import single_frame, figure_frame, \
     			   set_tickmarks, get_distinct

--- a/examples/textbook/evolve_XiTauPrimary.py
+++ b/examples/textbook/evolve_XiTauPrimary.py
@@ -1,4 +1,12 @@
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.units import units 
+from amuse.community.mesa.interface import MESA
+from amuse.io import write_set_to_file
+from amuse.datamodel import Particle
+from amuse.ext.star_to_sph import convert_stellar_model_to_SPH
+
+
+
 
 def new_option_parser():
     from amuse.units.optparse import OptionParser

--- a/examples/textbook/gravity_collision.py
+++ b/examples/textbook/gravity_collision.py
@@ -1,8 +1,16 @@
 import math, numpy
 from matplotlib import pyplot
-from amuse.lab import *
+# from amuse.lab import *
 from optparse import OptionParser
 from amuse.ext.LagrangianRadii import LagrangianRadii
+from amuse.units import nbody_system
+from amuse.ic.kingmodel import new_king_model
+from amuse.ic.salpeter import new_powerlaw_mass_distribution
+from amuse.units import units
+from amuse.community.ph4.interface import ph4
+from amuse.datamodel import Particles
+from amuse.units.quantities import zero
+
 
 def merge_two_stars(bodies, particles_in_encounter, tcoll):
     com_pos = particles_in_encounter.center_of_mass()
@@ -47,7 +55,7 @@ def main(N=10, W0=7.0, t_end=10, nsteps=10,
 
     time = 0.0 | t_end.unit
     Nenc = 0
-    dEk_enc = zero    
+    dEk_enc = zero  
     dEp_enc = zero
 
     t = []
@@ -156,7 +164,7 @@ def new_option_parser():
     result = OptionParser()
     result.add_option("-f", dest="filename", default = "gravity_stellar.hdf5",
                       help="output filename [gravity_stellar.hdf5]")
-    result.add_option("-N", dest="N", type="int",default = 1000,
+    result.add_option("-N", dest="N", type="int",default = 100,
                       help="number of stars [100]")
     result.add_option("-n", dest="nsteps", type="int",default = 100,
                       help="number of output steps [10]")

--- a/examples/textbook/gravity_drifter.py
+++ b/examples/textbook/gravity_drifter.py
@@ -1,9 +1,10 @@
 import numpy
-from amuse.lab import *
+# from amuse.lab import *
 from amuse.units import units
 from amuse.units import quantities
 from amuse.units import constants
 from amuse.units import nbody_system
+from amuse.datamodel import Particles
 from amuse.ext.bridge import bridge
 from amuse.community.phiGRAPE.interface import PhiGRAPE
 from amuse.community.ph4.interface import ph4

--- a/examples/textbook/gravity_kepler_disks.py
+++ b/examples/textbook/gravity_kepler_disks.py
@@ -1,9 +1,15 @@
-from amuse.lab import *
+# from amuse.lab import *
 #from amuse.io import store
 #from amuse.community.seba.interface import SeBa
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.units import constants
+from amuse.ic.brokenimf import new_kroupa_mass_distribution
 from amuse.ext.orbital_elements import orbital_elements_from_binary
 from amuse.community.fractalcluster.interface import new_fractal_cluster_model
-
+from amuse.community.ph4.interface import ph4
+from amuse.io import write_set_to_file
+from amuse.datamodel import Particles
 ###BOOKLISTSTART3###
 def resolve_close_encounter(time, bodies):
     orbital_elements = orbital_elements_from_binary(bodies, G=constants.G)

--- a/examples/textbook/gravity_stellar_collision.py
+++ b/examples/textbook/gravity_stellar_collision.py
@@ -3,9 +3,19 @@
    function between Mmin and Mmax and with stellar evolution with
    metallicity z.
 """
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.units.quantities import zero
+from amuse.datamodel import Particles
 from amuse.io import store
+from amuse.io import write_set_to_file
 from amuse.community.seba.interface import SeBa
+from amuse.support.console import set_printing_strategy
+from amuse.ic.salpeter import new_salpeter_mass_distribution
+from amuse.ic.kingmodel import new_king_model
+from amuse.community.ph4.interface import ph4
+
 
 ###BOOKLISTSTART1###
 def merge_two_stars(bodies, particles_in_encounter):

--- a/examples/textbook/gravity_stellar_comparison.py
+++ b/examples/textbook/gravity_stellar_comparison.py
@@ -5,8 +5,14 @@
 """
 import numpy
 from matplotlib import pyplot
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.ic.salpeter import new_salpeter_mass_distribution
+from amuse.ic.kingmodel import new_king_model
 from amuse.ext.LagrangianRadii import LagrangianRadii
+from amuse.community.ph4.interface import ph4
+from amuse.community.sse.interface import SSE
 from prepare_figure import single_frame
 from distinct_colours import get_distinct
 

--- a/examples/textbook/gravity_stellar_eventdriven.py
+++ b/examples/textbook/gravity_stellar_eventdriven.py
@@ -1,7 +1,17 @@
 import numpy
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.units.quantities import zero
+from amuse.ic.salpeter import new_salpeter_mass_distribution
+from amuse.ic.kingmodel import new_king_model
 from amuse.io import store
+from amuse.io import write_set_to_file
+from amuse.datamodel import Particles
 from amuse.community.seba.interface import SeBa
+from amuse.community.ph4.interface import ph4
+
+
 
 def merge_two_stars(bodies, particles_in_encounter):
     com_pos = particles_in_encounter.center_of_mass()

--- a/examples/textbook/gravity_stellar_minimal.py
+++ b/examples/textbook/gravity_stellar_minimal.py
@@ -1,6 +1,13 @@
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.ic.salpeter import new_salpeter_mass_distribution
+from amuse.ic.kingmodel import new_king_model
 from amuse.units.optparse import OptionParser
-    
+from amuse.community.sse.interface import SSE
+from amuse.community.ph4.interface import ph4
+from amuse.io import write_set_to_file
+
 def main(N, t_end, W0, Rvir, Mmin, Mmax, z):
 
 ###BOOKLISTSTART1###

--- a/examples/textbook/gravity_to_virial.py
+++ b/examples/textbook/gravity_to_virial.py
@@ -1,7 +1,12 @@
 """
    Simple routine for running a gravity code
 """
-from amuse.lab import *
+# from amuse.lab import *
+from amuse.units import nbody_system
+from amuse.ic.plummer import new_plummer_model
+from amuse.community.ph4.interface import ph4
+from amuse.community.huayno.interface import Huayno
+from amuse.community.bhtree.interface import BHTree
 from matplotlib import pyplot
 from prepare_figure import single_frame, figure_frame, set_tickmarks
 from distinct_colours import get_distinct

--- a/examples/textbook/kira.py
+++ b/examples/textbook/kira.py
@@ -1,7 +1,18 @@
-from amuse.lab import *
+# from amuse.lab import *
 from amuse.units.quantities import as_vector_quantity
 from amuse.couple import encounters
 from amuse.units import quantities
+from amuse.units import units
+from amuse.units import nbody_system
+from amuse.units import constants
+from amuse.datamodel import Particles
+from amuse.support.console import set_printing_strategy
+from amuse.ic.salpeter import new_salpeter_mass_distribution
+from amuse.ic.plummer import new_plummer_model
+from amuse.community.hermite0.interface import Hermite
+from amuse.community.seba.interface import SeBa
+from amuse.community.kepler.interface import Kepler
+from amuse.community.smalln.interface import SmallN
 import numpy
 import logging
 


### PR DESCRIPTION
Commented out the use of "from amuse.lab import *" and added in individual imports of modules. Could only do textbook scripts that are supported on my laptop for testing.