### PR TITLE
Replace easy_install with pip

### DIFF
--- a/doc/install/install-prerequisites-ubuntu.rst
+++ b/doc/install/install-prerequisites-ubuntu.rst
@@ -22,7 +22,10 @@ For openmpi do::
 	  python-nose python-numpy python-setuptools python-docutils \
 	  python-h5py python-setuptools git
 	
-	> sudo easy_install mpi4py
+	>  [sudo] pip install mpi4py
+	or alternatively setuptools easy_install (deprecated):
+	>  [sudo] easy_install mpi4py
+
 
 For mpich do::
 	
@@ -34,7 +37,9 @@ For mpich do::
 	  python-nose python-numpy python-setuptools python-docutils \
 	  python-h5py python-setuptools git
 	
-	> sudo easy_install mpi4py
+	>  [sudo] pip install mpi4py
+	or alternatively setuptools easy_install (deprecated):
+	>  [sudo] easy_install mpi4py
 
 .. note::
 	


### PR DESCRIPTION
easy_install is deprecated and was removed from the python-setuptools package.
https://mpi4py.readthedocs.io/en/stable/install.html
https://setuptools.readthedocs.io/en/latest/easy_install.html