### PR TITLE
Move gencode

### DIFF
--- a/build.py.in
+++ b/build.py.in
@@ -4,7 +4,7 @@ import sys
 import subprocess
 import inspect
 import os.path
-from support import gencode
+from amuse.rfi import gencode
 
 if __name__ == "__main__":
     try:

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ def find_data_files(srcdir, destdir, *wildcards, **kw):
     return file_list
 
 all_data_files = find_data_files('data', 'share/amuse/data', '*', recursive=True)
-#~ all_data_files.extend(find_data_files('support', 'share/amuse/support', '*', recursive=False))
+# all_data_files.extend(find_data_files('support', 'share/amuse/support', '*', recursive=False))
 # all_data_files.extend(find_data_files('support3', 'share/amuse/support3', '*', recursive = False))
 # all_data_files.extend(find_data_files('lib', 'share/amuse/lib', '*.h', '*.a', '*.mod', '*.inc', '*.so', '*.dylib', recursive = True))
 all_data_files.append(('share/amuse', ['./config.mk', './build.py']))

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ def find_data_files(srcdir, destdir, *wildcards, **kw):
     return file_list
 
 all_data_files = find_data_files('data', 'share/amuse/data', '*', recursive=True)
-all_data_files.extend(find_data_files('support', 'share/amuse/support', '*', recursive=False))
+#~ all_data_files.extend(find_data_files('support', 'share/amuse/support', '*', recursive=False))
 # all_data_files.extend(find_data_files('support3', 'share/amuse/support3', '*', recursive = False))
 # all_data_files.extend(find_data_files('lib', 'share/amuse/lib', '*.h', '*.a', '*.mod', '*.inc', '*.so', '*.dylib', recursive = True))
 all_data_files.append(('share/amuse', ['./config.mk', './build.py']))

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -608,17 +608,23 @@ class AbstractMessageChannel(OptionalAttributes):
         return self.amuse_root_dir
     
     @option(type="string", sections=('data',))
-    def amuse_root_dir(self):
+    def amuse_root_dir(self):  # needed for location of data, so same as in support.__init__
         if 'AMUSE_DIR' in os.environ:
             return os.environ['AMUSE_DIR']    
-        previous = None
-        result = os.path.abspath(__file__)
-        while not os.path.exists(os.path.join(result,'build.py')):
-            result = os.path.dirname(result)
-            if result == previous:
-                raise exceptions.AmuseException("Could not locate AMUSE root directory!")
-            previous = result
-        return result
+
+        this = os.path.dirname(os.path.abspath(__file__))
+        
+        # installed
+        result=os.path.abspath(os.path.join(this, "..","..","..","..","..","share", "amuse"))
+        if os.path.exists(os.path.join(result,'build.py')):
+            return result
+        
+        # in-place
+        result=os.path.abspath(os.path.join(this, "..","..",".."))        
+        if os.path.exists(os.path.join(result,'build.py')):
+            return result
+
+        raise exceptions.AmuseException("Could not locate AMUSE root directory! set the AMUSE_DIR variable")
     
     def check_if_worker_is_up_to_date(self, object):
         if not self.must_check_if_worker_is_up_to_date:

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -35,6 +35,7 @@ except ImportError:
 from amuse.support.options import OptionalAttributes, option, GlobalOptions
 from amuse.support.core import late
 from amuse.support import exceptions
+from amuse.support import get_amuse_root_dir
 from amuse.rfi import run_command_redirected
 
 from amuse.rfi import slurm
@@ -609,22 +610,7 @@ class AbstractMessageChannel(OptionalAttributes):
     
     @option(type="string", sections=('data',))
     def amuse_root_dir(self):  # needed for location of data, so same as in support.__init__
-        if 'AMUSE_DIR' in os.environ:
-            return os.environ['AMUSE_DIR']    
-
-        this = os.path.dirname(os.path.abspath(__file__))
-        
-        # installed
-        result=os.path.abspath(os.path.join(this, "..","..","..","..","..","share", "amuse"))
-        if os.path.exists(os.path.join(result,'build.py')):
-            return result
-        
-        # in-place
-        result=os.path.abspath(os.path.join(this, "..","..",".."))        
-        if os.path.exists(os.path.join(result,'build.py')):
-            return result
-
-        raise exceptions.AmuseException("Could not locate AMUSE root directory! set the AMUSE_DIR variable")
+        return get_amuse_root_dir()
     
     def check_if_worker_is_up_to_date(self, object):
         if not self.must_check_if_worker_is_up_to_date:

--- a/src/amuse/rfi/gencode.py
+++ b/src/amuse/rfi/gencode.py
@@ -7,10 +7,10 @@ from optparse import OptionParser
 # Should probably use an absolute import here (support.config), but
 # we're not guaranteed this script will always be in a support
 # subdirectory with an __init__.py file.
-#try:  # running as a module
-#    from . import config
-#except (ImportError, ValueError):  # running as a stand-alone script
-#    import config
+# try:  # running as a module
+#     from . import config
+# except (ImportError, ValueError):  # running as a stand-alone script
+#     import config
 
 
 if sys.hexversion > 0x03000000:
@@ -363,7 +363,7 @@ def make_directory(settings):
     
 if __name__ == '__main__':
     
-    #~ setup_sys_path()
+    # setup_sys_path()
 
     from amuse import config
 

--- a/src/amuse/rfi/gencode.py
+++ b/src/amuse/rfi/gencode.py
@@ -363,9 +363,9 @@ def make_directory(settings):
     
 if __name__ == '__main__':
     
-    setup_sys_path()
+    #~ setup_sys_path()
 
-    import config
+    from amuse import config
 
     from amuse.rfi.tools import create_c
     from amuse.rfi.tools import create_fortran

--- a/src/amuse/support/__init__.py
+++ b/src/amuse/support/__init__.py
@@ -16,14 +16,20 @@ class _Defaults(OptionalAttributes):
     def amuse_root_dir(self):
         if 'AMUSE_DIR' in os.environ:
             return os.environ['AMUSE_DIR']    
-        previous = None
-        result = os.path.abspath(__file__)
-        while not os.path.exists(os.path.join(result,'build.py')):
-            result = os.path.dirname(result)
-            if result == previous:
-                raise exceptions.AmuseException("Could not locate AMUSE root directory!")
-            previous = result
-        return result
+
+        this = os.path.dirname(os.path.abspath(__file__))
+        
+        # installed
+        result=os.path.abspath(os.path.join(this, "..","..","..","..","..","share", "amuse"))
+        if os.path.exists(os.path.join(result,'build.py')):
+            return result
+        
+        # in-place
+        result=os.path.abspath(os.path.join(this, "..","..",".."))        
+        if os.path.exists(os.path.join(result,'build.py')):
+            return result
+
+        raise exceptions.AmuseException("Could not locate AMUSE root directory! set the AMUSE_DIR variable")
 
 def get_amuse_root_dir():
     return _Defaults().amuse_root_dir

--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -298,19 +298,13 @@ class CodeCommand(Command):
         else:
             if self.inplace:
                self.environment['AMUSE_DIR'] = os.path.abspath(os.getcwd())
-               path = os.path.abspath(os.getcwd())
             else:
                self.environment['AMUSE_DIR'] = os.path.abspath(self.build_temp)
-               path=os.path.abspath(self.build_temp)
-            path=os.path.join(path,"src")
-            path=path+":"+self.environment.get('PYTHONPATH','')
-            
-            self.environment['PYTHONPATH'] = path
 
-            #~ if self.inplace:
-               #~ self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(os.getcwd())
-            #~ else:
-               #~ self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(self.build_temp)
+            if self.inplace:
+               self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(os.getcwd())
+            else:
+               self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(self.build_temp)
 
     
     def set_fortran_variables(self):
@@ -695,6 +689,14 @@ class CodeCommand(Command):
         
         stringio.close()
         return result, content
+        
+    def build_environment(self):
+        environment=self.environment.copy()
+        environment.update(os.environ)
+        path=os.path.join(environment["AMUSE_DIR"],"src")
+        path=path+':'+environment.get("PYTHONPATH", "")
+        environment["PYTHONPATH"]=path
+        return environment
     
 class SplitOutput(object) :
     def __init__(self, file1, file2) :
@@ -775,8 +777,7 @@ class BuildCodes(CodeCommand):
         build = list()
         lib_build = list()
         lib_not_build = list()
-        environment = self.environment
-        environment.update(os.environ)
+        environment = self.build_environment()
         
         buildlog = 'build.log'
         
@@ -1030,8 +1031,7 @@ class BuildLibraries(CodeCommand):
         build = list()
         lib_build = list()
         lib_not_build = list()
-        environment = self.environment
-        environment.update(os.environ)
+        environment = self.build_environment()
         
         buildlog = 'build.log'
         
@@ -1176,8 +1176,7 @@ class ConfigureCodes(CodeCommand):
         if os.path.exists('config.mk'):
             self.announce("Already configured, not running configure", level = 2)
             return
-        environment = self.environment
-        environment.update(os.environ)
+        environment = self.build_environment()
         self.announce("Running configure for AMUSE", level = 2)
         self.call(['./configure'], env=environment, shell=True)
         
@@ -1187,8 +1186,7 @@ class CleanCodes(CodeCommand):
 
     def run (self):
             
-        environment = self.environment
-        environment.update(os.environ)
+        environment = self.build_environment()
         self.announce("Cleaning libraries and community codes", level = 2)
         for x in self.makefile_paths(self.lib_dir):
             self.announce("cleaning libary " + x)
@@ -1205,8 +1203,7 @@ class DistCleanCodes(CodeCommand):
     description = "clean for distribution"
 
     def run (self):
-        environment = self.environment
-        environment.update(os.environ)
+        environment = self.build_environment()
         
         self.announce("Cleaning for distribution, libraries and community codes", level = 2)
         for x in self.makefile_paths(self.lib_dir):
@@ -1255,8 +1252,7 @@ class BuildOneCode(CodeCommand):
         if not self.inplace:
             self.run_command("build_py")
 
-        environment = self.environment
-        environment.update(os.environ)
+        environment = self.build_environment()
         
         results = []
         

--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -156,12 +156,14 @@ class GenerateInstallIni(Command):
         outfilename = os.path.join(self.build_dir, 'amuse', 'amuserc')
         
         
-        data_dir = os.path.join(self.install_data,'share','amuse')
-        if not self.root is None:
-            data_dir = os.path.relpath(data_dir,self.root)
-            data_dir =  os.path.join('/',data_dir)
-        else:
-            data_dir = os.path.abspath(data_dir)
+        # this does not work for pip installs
+        #~ data_dir = os.path.join(self.install_data,'share','amuse')
+        #~ if not self.root is None:
+            #~ data_dir = os.path.relpath(data_dir,self.root)
+            #~ data_dir =  os.path.join('/',data_dir)
+        #~ else:
+            #~ data_dir = os.path.abspath(data_dir)
+
         installinilines = []
         installinilines.append('[channel]')
         installinilines.append('must_check_if_worker_is_up_to_date=0')
@@ -169,10 +171,10 @@ class GenerateInstallIni(Command):
         #installinilines.append('worker_code_directory={0}'.format(os.path.join(data_dir, 'bin')))
         if sys.platform == 'win32':
             installinilines.append('worker_code_suffix=".exe"')
-        installinilines.append('[data]')
-        installinilines.append('input_data_root_directory={0}'.format(os.path.join(data_dir, 'data')))
-        installinilines.append('output_data_root_directory=amuse-data')
-        installinilines.append('amuse_root_dir={0}'.format(data_dir))
+        #~ installinilines.append('[data]')
+        #~ installinilines.append('input_data_root_directory={0}'.format(os.path.join(data_dir, 'data')))
+        #~ installinilines.append('output_data_root_directory=amuse-data')
+        #~ installinilines.append('amuse_root_dir={0}'.format(data_dir))
         
         if 'BUILD_BINARY' in os.environ:
             installinilines.append('[test]')

--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -171,9 +171,9 @@ class GenerateInstallIni(Command):
         #installinilines.append('worker_code_directory={0}'.format(os.path.join(data_dir, 'bin')))
         if sys.platform == 'win32':
             installinilines.append('worker_code_suffix=".exe"')
-        #~ installinilines.append('[data]')
+        installinilines.append('[data]')
         #~ installinilines.append('input_data_root_directory={0}'.format(os.path.join(data_dir, 'data')))
-        #~ installinilines.append('output_data_root_directory=amuse-data')
+        installinilines.append('output_data_root_directory=_amuse_output_data')
         #~ installinilines.append('amuse_root_dir={0}'.format(data_dir))
         
         if 'BUILD_BINARY' in os.environ:

--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -297,14 +297,20 @@ class CodeCommand(Command):
             pass
         else:
             if self.inplace:
-               self.environment['AMUSE_DIR'] = os.path.abspath(os.getcwd())
+               #~ self.environment['AMUSE_DIR'] = os.path.abspath(os.getcwd())
+               path = os.path.abspath(os.getcwd())
             else:
-               self.environment['AMUSE_DIR'] = os.path.abspath(self.build_temp)
+               #~ self.environment['AMUSE_DIR'] = os.path.abspath(self.build_temp)
+               path=os.path.abspath(self.build_temp)
+            path=os.path.join(path,"src")
+            path=path+":"+self.environment.get('PYTHONPATH','')
+            
+            self.environment['PYTHONPATH'] = path
 
-            if self.inplace:
-               self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(os.getcwd())
-            else:
-               self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(self.build_temp)
+            #~ if self.inplace:
+               #~ self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(os.getcwd())
+            #~ else:
+               #~ self.environment['MUSE_PACKAGE_DIR'] = os.path.abspath(self.build_temp)
 
     
     def set_fortran_variables(self):

--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -297,10 +297,10 @@ class CodeCommand(Command):
             pass
         else:
             if self.inplace:
-               #~ self.environment['AMUSE_DIR'] = os.path.abspath(os.getcwd())
+               self.environment['AMUSE_DIR'] = os.path.abspath(os.getcwd())
                path = os.path.abspath(os.getcwd())
             else:
-               #~ self.environment['AMUSE_DIR'] = os.path.abspath(self.build_temp)
+               self.environment['AMUSE_DIR'] = os.path.abspath(self.build_temp)
                path=os.path.abspath(self.build_temp)
             path=os.path.join(path,"src")
             path=path+":"+self.environment.get('PYTHONPATH','')


### PR DESCRIPTION
this moves gencode (the generator for interface code) into the amuse module tree, and removes the support directory from the install (I don't think anything there has to be included)