### PR TITLE
Savepoint on incode particles

### DIFF
--- a/src/amuse/datamodel/particles.py
+++ b/src/amuse/datamodel/particles.py
@@ -1221,7 +1221,7 @@ class Particles(AbstractParticleSet):
                 instance = type(self)(is_working_copy = False)
                 instance._private.attribute_storage = self._private.attribute_storage.copy()
             except:
-                instance=self.copy()
+                instance = self.copy()
                 instance._private.is_working_copy = False
                 
             instance.collection_attributes.timestamp = timestamp

--- a/src/amuse/datamodel/particles.py
+++ b/src/amuse/datamodel/particles.py
@@ -1108,6 +1108,8 @@ class AbstractParticleSet(AbstractSet):
 
     def get_containing_set(self):
         return self
+
+
 class Particles(AbstractParticleSet):
     """
     A set of particles. Attributes and values are stored in
@@ -1215,8 +1217,13 @@ class Particles(AbstractParticleSet):
 
     def savepoint(self, timestamp=None, format = 'memory', **attributes):
         if format == 'memory':
-            instance = type(self)(is_working_copy = False)
-            instance._private.attribute_storage = self._private.attribute_storage.copy()
+            try:
+                instance = type(self)(is_working_copy = False)
+                instance._private.attribute_storage = self._private.attribute_storage.copy()
+            except:
+                instance=self.copy()
+                instance._private.is_working_copy = False
+                
             instance.collection_attributes.timestamp = timestamp
 
             for name, value in attributes.iteritems():

--- a/src/amuse/support/parameter_tools.py
+++ b/src/amuse/support/parameter_tools.py
@@ -75,11 +75,16 @@ class CodeWithIniFileParameters(object):
         self._optionxform=str
         
     def define_parameters(self, handler):
+        _tmp=dict()
         for p in self._inifile_parameters.values():
             if p["ptype"] in ["ini", "ini+normal"]:
                 parameter_set_name=p.get("set_name", p["group_name"])
-                if not p["name"] in handler.definitions[parameter_set_name]:
-                    handler.add_interface_parameter( p["name"], p["description"], p["default"], "before_set_interface_parameter", parameter_set=parameter_set_name)
+                if parameter_set_name not in _tmp:
+                    _tmp[parameter_set_name]=[ x.name for x in handler.definitions[parameter_set_name] ]
+                if not p["name"] in _tmp[parameter_set_name]:  
+                    handler.add_interface_parameter( p["name"], p["description"], p["default"], 
+                                      "before_set_interface_parameter", parameter_set=parameter_set_name)
+                    
         self.set_parameters()
 
     def set_parameters(self):


### PR DESCRIPTION
this patch allows code particle sets to have a savepoint.
This savepoint is saved in memory (like ordinary).