### PR TITLE
add option to abort setup (or pip) in case build error detected

### DIFF
--- a/support/__init__.py
+++ b/support/__init__.py
@@ -1,4 +1,4 @@
-supportrc=dict(framework_install=True, package_name="amuse")
+supportrc=dict(framework_install=True, package_name="amuse", abort_on_build_failure=True)
 
 def use(arg):
     if arg == "package":
@@ -10,3 +10,6 @@ def use(arg):
 
 def set_package_name(arg):
     supportrc["package_name"]=arg
+
+def set_abort_on_build_failure(arg):
+    supportrc["abort_on_build_failure"]=arg

--- a/support/__init__.py
+++ b/support/__init__.py
@@ -1,4 +1,4 @@
-supportrc=dict(framework_install=True, package_name="amuse", abort_on_build_failure=True)
+supportrc=dict(framework_install=True, package_name="amuse", allow_build_failures='some')
 
 def use(arg):
     if arg == "package":
@@ -11,5 +11,7 @@ def use(arg):
 def set_package_name(arg):
     supportrc["package_name"]=arg
 
-def set_abort_on_build_failure(arg):
-    supportrc["abort_on_build_failure"]=arg
+def set_allow_build_failures(arg):
+    if arg=="yes" or (arg==True): arg='some'
+    if arg=="no" or (arg==False): arg='none'
+    supportrc["allow_build_failures"]=arg

--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -1058,8 +1058,15 @@ class BuildCodes(CodeCommand):
                 level = level
             )
 
-        if supportrc["abort_on_build_failure"] and not_build:
+        allow_build_failures=environment.get("AMUSE_ALLOW_BUILD_FAILURES", supportrc["allow_build_failures"])
+
+        if allow_build_failures=="none" and len(not_build)>0:
             raise Exception("Unexpected build failure(s) detected. Aborting.")
+        if allow_build_failures=="some" and len(not_build)>0 and len(build)==0:
+            raise Exception("No succesful builds detected. Aborting.")
+        if allow_build_failures=="all" and len(not_build)>0 and len(build)==0:
+            self.announce("Continuing despite apparent build failure", level=level)
+
  
 class BuildLibraries(BuildCodes):
 

--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -1057,7 +1057,9 @@ class BuildCodes(CodeCommand):
                 "Your configuration is out of date, please rerun configure",
                 level = level
             )
-        
+
+        if supportrc["abort_on_build_failure"] and not_build:
+            raise Exception("Unexpected build failure(s) detected. Aborting.")
  
 class BuildLibraries(BuildCodes):
 


### PR DESCRIPTION
add an option to stop build (and hence a pip install) in case of build error.

It may need some refinement (i can see at least 3 reasonable options:
- never abort
- abort if any build failed
- abort only if all builds failed
)