### PR TITLE
Implement opportunistic deadlock avoidance for worker crashes.

### DIFF
--- a/src/amuse/rfi/tools/create_c.py
+++ b/src/amuse/rfi/tools/create_c.py
@@ -429,7 +429,7 @@ void run_mpi(int argc, char *argv[]) {
     handler.sa_flags = 0;
 
     for (int i = 0; i < (sizeof abort_signals) / (sizeof abort_signals[0]); i++) {
-        int result = sigaction(abort_signals[i], &handler, nullptr);
+        int result = sigaction(abort_signals[i], &handler, NULL);
         if (result == -1) {
             perror("Error installing signal handler");
             exit(EXIT_FAILURE);

--- a/src/amuse/rfi/tools/create_c.py
+++ b/src/amuse/rfi/tools/create_c.py
@@ -42,7 +42,9 @@ HEADER_CODE_STRING = """
   #include <arpa/inet.h>
 #endif
 #if _POSIX_VERSION >= 1
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 1
+#endif
 	#include <signal.h>
 #endif
 """


### PR DESCRIPTION
Amuse has a tendency to deadlock when the remote worker crashes, due to the
worker(s) never calling MPI_Finalize or MPI_Abort. This change installs (only
on POSIX platforms and only on thread-safe MPI initialisations) a signal
handler that traps some of the more common "crash" signals (SIGABRT, SIGBUS,
SIGILL, SIGINT, SIGQUIT, SIGSEGV, and SIGTERM) and attempts to call MPI_Abort()
before dying.

This is not sufficient to avoid deadlock, as the MPI_Abort() never notifies
the MPI_Comm_spawn parent that the run is aborted. The parent (i.e., amuse) is
generally blocked in an MPI_Wait, waiting for a return message from a function
call, due to the way mpi4py is implemented amuse becomes (nearly)
uninterruptible by keyboard interrupts (SIGINT), nor does it detect the
MPI_Abort in the worker.

To work around this, the worker sends a non-blocking all 0 message to the
parent (waking it up from the MPI_Wait), this message fails the call and
function id checks on lines 1149 and 1152 of amuse/rfi/channel.py, resulting in
a call to MPI_Comm_disconnect in the parent. The worker also calls
MPI_Comm_disonnect and only then calls MPI_Abort to end the other worker tasks.

This way both the workers and clients abort when an error/crash happens. This
doesn't always work (the disconnect could block, some other MPI error could
happen while trying to send/abort, etc.), but since the current behaviour is to
just deadlock, we're not off any worse than before and when it does work things
are much more pleasant to test with.