### PR TITLE
Allow using AMUSE without configuration

### DIFF
--- a/src/amuse/__init__.py
+++ b/src/amuse/__init__.py
@@ -38,4 +38,4 @@ numpy_fix()
 try:
     from . import config
 except:
-    raise ImportError("amuse is not configured correctly")
+    print("amuse is not configured correctly")  


### PR DESCRIPTION
An exception here is perhaps too harsh...
A core-only installation will not need (and in fact should not have) a config file.
We should think of a better way to handle this.