### PR TITLE
Fix building sapporo2, bonsai1 and pikachu

### DIFF
--- a/lib/sapporo_2/Makefile
+++ b/lib/sapporo_2/Makefile
@@ -17,7 +17,7 @@ OFLAGS = -g -Wall -fopenmp
 CXXFLAGS =  -fPIC $(OFLAGS) -I$(CUDA_TK)/include  -D__INCLUDE_KERNELS__ $(CL_CFLAGS)
 
 NVCC      = $(CUDA_TK)/bin/nvcc  
-NVCCFLAGS ?= -arch=sm_20
+NVCCFLAGS ?= 
 
 export NVCCFLAGS NVCC CXXFLAGS
 

--- a/src/amuse/community/bonsai/libraryInterface.cpp
+++ b/src/amuse/community/bonsai/libraryInterface.cpp
@@ -736,6 +736,7 @@ int get_gravity_at_point(double eps, double x, double y, double z,
   double dx;
   double dy;
   double dz;
+  double F;
   double fx = 0;
   double fy = 0;
   double fz = 0;

--- a/src/amuse/community/pikachu/src/sequoia/Makefile
+++ b/src/amuse/community/pikachu/src/sequoia/Makefile
@@ -25,7 +25,7 @@ CXXFLAGS +=  -fPIC $(OFLAGS) -I$(CUDA_TK)/include
 NVCC ?= $(CUDA_TK)/bin/nvcc  
 #NVCCFLAGS = -arch sm_20 -ftz=true -prec-div=false -prec-sqrt=false 
 #NVCCFLAGS = -arch sm_20 -g -G 
-NVCCFLAGS ?= -arch sm_20 
+#NVCCFLAGS ?= -arch sm_20 
 
 
 # Use with Mac OS X

--- a/src/amuse/community/pikachu/src/sequoia/include/my_cuda.h
+++ b/src/amuse/community/pikachu/src/sequoia/include/my_cuda.h
@@ -249,7 +249,7 @@ namespace my_dev {
     {
       switch(ccMajor)
       {
-        case 1:
+/*        case 1:
           switch(ccMinor)
           {
             case 0:
@@ -277,6 +277,16 @@ namespace my_dev {
               break;            
           }
           break;             
+          */
+      case 3:
+          defaultComputeMode = CU_TARGET_COMPUTE_30;
+          break;
+      case 6:
+          defaultComputeMode = CU_TARGET_COMPUTE_60;
+          break;
+      case 7:
+          defaultComputeMode = CU_TARGET_COMPUTE_70;
+          break;
       }  
    }    
     


### PR DESCRIPTION
This PR fixes some of the compile issues related to depracted CUDA compile options and a bug introduced in 7dc4bfa37f534b8637f42159ff7b4d9f3654a88c that prevented bonsai1 from compiling.
