### PR TITLE
Implemented support for parallel GPU use in ph4

### DIFF
--- a/src/amuse/community/ph4/Makefile
+++ b/src/amuse/community/ph4/Makefile
@@ -15,7 +15,7 @@ OPT	  = -I$(AMUSE_DIR)/lib/stopcond
 
 MPICXX   ?= mpicxx
 
-CFLAGS   += -Wall -g -O2 $(OPT)
+CFLAGS   += -Wall -g -O2 $(OPT) -DSAPPORO_VERSION=$(SAPPORO_VERSION)
 CXXFLAGS += $(CFLAGS) 
 LDFLAGS  += -L$(AMUSE_DIR)/lib/stopcond -lstopcond -lm $(MUSE_LD_FLAGS)
 

--- a/src/amuse/community/ph4/interface.cc
+++ b/src/amuse/community/ph4/interface.cc
@@ -167,6 +167,18 @@ int get_gpu_id(int * gpu_id)
     return 0;
 }
 
+int set_n_gpu(int n_gpu)
+{
+    jd->n_gpu = n_gpu;
+    return 0;
+}
+
+int get_n_gpu(int * n_gpu)
+{
+    *n_gpu = jd->n_gpu;
+    return 0;
+}
+
 int set_manage_encounters(int m)
 {
     jd->set_manage_encounters(m);

--- a/src/amuse/community/ph4/interface.cc
+++ b/src/amuse/community/ph4/interface.cc
@@ -179,6 +179,18 @@ int get_n_gpu(int * n_gpu)
     return 0;
 }
 
+int set_n_node(int n_node)
+{
+    jd->n_node = n_node;
+    return 0;
+}
+
+int get_n_node(int * n_node)
+{
+    *n_node = jd->n_node;
+    return 0;
+}
+
 int set_manage_encounters(int m)
 {
     jd->set_manage_encounters(m);

--- a/src/amuse/community/ph4/interface.py
+++ b/src/amuse/community/ph4/interface.py
@@ -212,6 +212,28 @@ class ph4Interface(CodeInterface,
         return function
 
     @legacy_function
+    def set_n_gpu():
+        """
+        Set n_gpu.
+        """
+        function = LegacyFunctionSpecification()
+        function.addParameter('n_gpu', dtype='int32',
+                              direction=function.IN)
+        function.result_type = 'int32'
+        return function
+
+    @legacy_function
+    def get_n_gpu():
+        """
+        Get n_gpu.
+        """
+        function = LegacyFunctionSpecification()
+        function.addParameter('n_gpu', dtype='int32',
+                              direction=function.OUT)
+        function.result_type = 'int32'
+        return function
+
+    @legacy_function
     def set_manage_encounters():
         """
         Set the value of manage_encounters.
@@ -539,6 +561,14 @@ class ph4(GravitationalDynamics,GravityFieldCode):
             "set_gpu_id",                # setter name in interface.cc
             "gpu_id",                    # python parameter name
             "GPU ID",                    # description
+            default_value = -1
+        )
+        
+        handler.add_method_parameter(
+            "get_n_gpu",                 # getter name in interface.cc
+            "set_n_gpu",                 # setter name in interface.cc
+            "n_gpu",                     # python parameter name
+            "number of GPUs to use",     # description
             default_value = -1
         )
         

--- a/src/amuse/community/ph4/interface.py
+++ b/src/amuse/community/ph4/interface.py
@@ -234,6 +234,28 @@ class ph4Interface(CodeInterface,
         return function
 
     @legacy_function
+    def set_n_node():
+        """
+        Set n_node.
+        """
+        function = LegacyFunctionSpecification()
+        function.addParameter('n_node', dtype='int32',
+                              direction=function.IN)
+        function.result_type = 'int32'
+        return function
+
+    @legacy_function
+    def get_n_node():
+        """
+        Get n_node.
+        """
+        function = LegacyFunctionSpecification()
+        function.addParameter('n_node', dtype='int32',
+                              direction=function.OUT)
+        function.result_type = 'int32'
+        return function
+
+    @legacy_function
     def set_manage_encounters():
         """
         Set the value of manage_encounters.
@@ -570,6 +592,14 @@ class ph4(GravitationalDynamics,GravityFieldCode):
             "n_gpu",                     # python parameter name
             "number of GPUs to use",     # description
             default_value = -1
+        )
+        
+        handler.add_method_parameter(
+            "get_n_node",                 # getter name in interface.cc
+            "set_n_node",                 # setter name in interface.cc
+            "n_node",                     # python parameter name
+            "number of nodes to use",     # description
+            default_value = 1
         )
         
         handler.add_method_parameter(

--- a/src/amuse/community/ph4/src/gpu.cc
+++ b/src/amuse/community/ph4/src/gpu.cc
@@ -20,10 +20,14 @@
 #include <mpi.h>
 #endif
 
+#ifdef SAPPORO_VERSION
+#if SAPPORO_VERSION==2
 extern "C" {
     int g6_open_special(int, int*);	// *** sapporo_2 function ***
     					// configure --enable-sapporo2
 }
+#endif
+#endif
 
 #include "debug.h"
 extern real TDEBUG;	// in debug.cc
@@ -33,6 +37,98 @@ extern real TDEBUG;	// in debug.cc
 
 // Maybe some of the n, j_start, j_end, etc. below should be promoted
 // to member data to avoid replicated code...?
+
+void jdata::startup_gpu(int clusterid)
+{
+#ifdef GPU
+
+    // g6_open() logic in sapporo_light is for a single GPU.  The
+    // code below expects to use sapporo_2, and will not work
+    // properly with sapporo_light in parallel.  It should work
+    // properly within a single node or across multiple nodes, but
+    // is currently inadequately tested in the latter case. (Steve, 4/20)
+
+    // The GPUs to use in sapporo_2 may be specified using a
+    // configuration file, but that doesn't generalize well to
+    // parallel operation.  Instead, we use the following simple
+    // allocation scheme.
+
+    PRL(clusterid);
+    PRL(gpu_id);
+    PRL(n_gpu);
+    PRL(n_node);
+
+    int light = 1, sapporo_version = light;
+#ifdef SAPPORO_VERSION
+    sapporo_version = SAPPORO_VERSION;
+    if (sapporo_version != 2) sapporo_version = 1;
+#endif
+    PRL(sapporo_version);
+	
+    if (sapporo_version == 1 || (mpi_size == 1 && gpu_id < 0 && n_gpu <= 0)) {
+
+	// Single process or sapporo_light: use g6open().  Both
+	// sapporo_light and sapporo_2 ignore the argument
+	// provided to g6_open().  Sapporo_light will use a single
+	// GPU; sapporo_2 will allocate all available GPUs.
+
+	int gpu_to_use = gpu_id;
+	cout << "AMUSE worker " << clusterid << " (PID " << getpid()
+	     << ") calling g6_open..." << endl << flush;
+	g6_open(gpu_to_use);
+
+    } else {
+
+#ifdef SAPPORO_VERSION
+#if SAPPORO_VERSION==2
+	
+	// Parallel process or gpu_id or n_gpu set: create a list
+	// of GPUs and use g6_open_special() in sapporo_2 to open
+	// them.
+
+	// If gpu_id is >= 0, start at that GPU.  Otherwise start
+	// at GPU 0 for a single-process run, MPI rank (clusterid)
+	// * n_gpu for a multi-process run.  Allocate n_gpu
+	// devices.  Note that no check is made for invalid or
+	// overlapping GPU IDs.
+
+	// We extend this scheme to multiple nodes by using n_node
+	// to determine the local rank of this process.  (Not
+	// clear why we are calling mpi_rank clusterid -- they are
+	// the same thing.)  Implemented but not tested yet on
+	// multiple nodes.
+
+	int cores_per_node = mpi_size/n_node;	// cores used in each node
+	int which_node = clusterid/cores_per_node;	// node I am running on
+	int local_rank = clusterid - which_node*cores_per_node;
+	    
+	if (n_gpu <= 0) n_gpu = 1;
+	int *ilist = new int[n_gpu];
+	for (int i = 0; i < n_gpu; i++) {
+	    ilist[i] = n_gpu*local_rank + i;
+	    if (gpu_id > 0) ilist[i] += gpu_id;
+	}
+	char hostname[1024];
+	int resultlen;
+	MPI_Get_processor_name(hostname, &resultlen);
+	if (resultlen > 1024) hostname[1023] = '\0';
+	cout << "AMUSE worker " << clusterid << " (PID " << getpid()
+	     << ") on logical node " << which_node << " (" << hostname
+	     << ") opening GPU(s)";
+	for (int i = 0; i < n_gpu; i++) cout << " " << ilist[i];
+	cout << endl << flush;
+	cout << "calling g6_open_special..." << endl << flush;
+	g6_open_special(n_gpu, ilist);
+	delete ilist;
+
+	cout << "done" << endl << flush;
+	// g6_set_tunit(new_tunit);
+	// g6_set_xunit(new_xunit);
+#endif
+#endif
+    }
+#endif
+}
 
 #ifdef GPU
 static int clusterid = 0;
@@ -49,89 +145,7 @@ void jdata::initialize_gpu(bool reinitialize)	// default = false
 
     // (Re)initialize the local GPU(s): reload all particles.
 
-    if (!reinitialize) {
-
-	// g6_open() logic in sapporo_light is for a single GPU.  The
-	// code below expects to use sapporo_2, and will not work
-	// properly with sapporo_light in parallel.  It also will not
-	// work properly as currently written across multiple nodes
-	// (OK within a single node, though).
-
-	// The GPUs to use in sapporo_2 may be specified using a
-	// configuration file, but that doesn't generalize well to
-	// parallel operation.  Instead, we use the following simple
-	// allocation scheme.
-
-	PRL(clusterid);
-	PRL(gpu_id);
-	PRL(n_gpu);
-	PRL(n_node);
-
-	int light = 1, sapporo_version = light;
-#ifdef SAPPORO_VERSION
-	sapporo_version = SAPPORO_VERSION;
-	if (sapporo_version != 2) sapporo_version = 1;
-#endif
-	PRL(sapporo_version);
-	
-        if (sapporo_version == 1 || (mpi_size == 1 && gpu_id < 0 && n_gpu <= 0)) {
-
-	    // Single process or sapporo_light: use g6open().  Both
-	    // sapporo_light and sapporo_2 ignore the argument
-	    // provided to g6_open().  Sapporo_light will use a single
-	    // GPU; sapporo_2 will allocate all available GPUs.
-
-	    int gpu_to_use = gpu_id;
-	    cout << "AMUSE worker " << clusterid << " (PID " << getpid()
-		 << ") calling g6_open..." << endl << flush;
-	    g6_open(gpu_to_use);
-
-	} else {
-
-	    // Parallel process or gpu_id or n_gpu set: create a list
-	    // of GPUs and use g6_open_special() in sapporo_2 to open
-	    // them.
-
-	    // If gpu_id is >= 0, start at that GPU.  Otherwise start
-	    // at GPU 0 for a single-process run, MPI rank (clusterid)
-	    // * n_gpu for a multi-process run.  Allocate n_gpu
-	    // devices.  Note that no check is made for invalid or
-	    // overlapping GPU IDs.
-
-	    // We could extend this scheme to multiple nodes by using
-	    // n_node to determine the local rank of this process.
-	    // (Not clear why we are calling mpi_rank clusterid --
-	    // they are the same thing.)  Implemented but not tested
-	    // yet on multiple nodes.
-
-	    int cores_per_node = mpi_size/n_node;	// cores used in each node
-	    int which_node = clusterid/cores_per_node;	// node I am running on
-	    int local_rank = clusterid - which_node*cores_per_node;
-	    
-	    if (n_gpu <= 0) n_gpu = 1;
-	    int *ilist = new int[n_gpu];
-	    for (int i = 0; i < n_gpu; i++) {
-                ilist[i] = n_gpu*local_rank + i;
-		if (gpu_id > 0) ilist[i] += gpu_id;
-	    }
-	    char hostname[1024];
-	    int resultlen;
-	    MPI_Get_processor_name(hostname, &resultlen);
-	    if (resultlen > 1024) hostname[1023] = '\0';
-	    cout << "AMUSE worker " << clusterid << " (PID " << getpid()
-		 << ") on logical node " << which_node << " (" << hostname
-		 << ") opening GPU(s)";
-	    for (int i = 0; i < n_gpu; i++) cout << " " << ilist[i];
-	    cout << endl << flush;
-	    cout << "calling g6_open_special..." << endl << flush;
-	    g6_open_special(n_gpu, ilist);
-	    delete ilist;
-	}
-
-	cout << "done" << endl << flush;
-	// g6_set_tunit(new_tunit);
-	// g6_set_xunit(new_xunit);
-    }
+    if (!reinitialize) startup_gpu(clusterid);
 
     static int n = 0;
     static int j_start, j_end;
@@ -159,7 +173,6 @@ void jdata::initialize_gpu(bool reinitialize)	// default = false
 			  time[j], timestep[j],		// as GRAPE index
 			  mass[j], k18, j6, a2, vel[j], pos[j]);
     }
-
 #endif
 }
 

--- a/src/amuse/community/ph4/src/jdata.h
+++ b/src/amuse/community/ph4/src/jdata.h
@@ -88,6 +88,7 @@ class jdata {
     bool use_gpu;			// true if actually using GPU
     int gpu_id;				// >= 0 if we have specified a GPU ID
     int n_gpu;				// number of GPUs to use
+    int n_node;				// number of nodes to use
 
     real eps2, eta;
     real rmin;				// 90 degree turnaround distance

--- a/src/amuse/community/ph4/src/jdata.h
+++ b/src/amuse/community/ph4/src/jdata.h
@@ -217,6 +217,7 @@ class jdata {
 
     // In gpu.cc:
 
+    void startup_gpu(int clusterid);
     void initialize_gpu(bool reinitialize = false);
     void update_gpu(int jlist[], int njlist);
     void sync_gpu();

--- a/src/amuse/community/ph4/src/jdata.h
+++ b/src/amuse/community/ph4/src/jdata.h
@@ -87,6 +87,7 @@ class jdata {
     bool have_gpu;			// will be true if -DGPU is compiled in
     bool use_gpu;			// true if actually using GPU
     int gpu_id;				// >= 0 if we have specified a GPU ID
+    int n_gpu;				// number of GPUs to use
 
     real eps2, eta;
     real rmin;				// 90 degree turnaround distance

--- a/src/amuse/community/ph4/test_ph4.py
+++ b/src/amuse/community/ph4/test_ph4.py
@@ -80,7 +80,8 @@ def print_log(pre, time, gravity, E0 = 0.0 | nbody_system.energy,
 def run_ph4(infile = None, number_of_stars = 40,
              end_time = 10 | nbody_system.time,
              delta_t = 1 | nbody_system.time,
-             n_workers = 1, use_gpu = 1, gpu_worker = 1, gpu_id = -1, n_gpu = 0,
+             n_workers = 1, use_gpu = 1, gpu_worker = 1, gpu_id = -1,
+             n_gpu = 0, n_node = 1,
              accuracy_parameter = 0.1,
              softening_length = -1 | nbody_system.length,
              manage_encounters = 1):
@@ -126,6 +127,7 @@ def run_ph4(infile = None, number_of_stars = 40,
 
     gravity.parameters.gpu_id = gpu_id	# (first) GPU to use
     gravity.parameters.n_gpu = n_gpu	# number of GPUs to use
+    gravity.parameters.n_node = n_node	# number of nodes to use
 
     #-----------------------------------------------------------------
 
@@ -301,13 +303,14 @@ if __name__ == '__main__':
     gpu_worker = 1
     gpu_id = -1
     n_gpu = 0
+    n_node = 1
     accuracy_parameter = 0.1
     softening_length = -1  | nbody_system.length
     random_seed = -1
     manage_encounters = 1
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "a:c:d:e:f:gGi:n:s:t:w:W:")
+        opts, args = getopt.getopt(sys.argv[1:], "a:c:d:e:f:gGi:n:N:s:t:w:W:")
     except getopt.GetoptError as err:
         print(str(err))
         sys.exit(1)
@@ -332,6 +335,8 @@ if __name__ == '__main__':
             gpu_id = int(a)
         elif o == "-n":
             N = int(a)
+        elif o == "-N":
+            n_node = int(a)
         elif o == "-s":
             random_seed = int(a)
         elif o == "-t":
@@ -355,6 +360,6 @@ if __name__ == '__main__':
 
     assert is_mpd_running()
     run_ph4(infile, N, t_end, delta_t, n_workers,
-             use_gpu, gpu_worker, gpu_id, n_gpu,
+             use_gpu, gpu_worker, gpu_id, n_gpu, n_node,
              accuracy_parameter, softening_length,
              manage_encounters)

--- a/src/amuse/community/ph4/test_ph4.py
+++ b/src/amuse/community/ph4/test_ph4.py
@@ -150,7 +150,7 @@ def run_ph4(infile = None, number_of_stars = 40,
 
         print("centering stars")
         stars.move_to_center()
-        if 0:
+        if 1:
             print("scaling stars to virial equilibrium")
             stars.scale_to_standard(smoothing_length_squared
                                     = gravity.parameters.epsilon_squared)
@@ -206,6 +206,7 @@ def run_ph4(infile = None, number_of_stars = 40,
                 | nbody_system.length**2
     else:
         eps2 = softening_length*softening_length
+    print('softening_length =', eps2.sqrt())
 
     #print "6"; sys.stdout.flush()
     gravity.parameters.timestep_parameter = accuracy_parameter

--- a/src/amuse/community/ph4/test_ph4.py
+++ b/src/amuse/community/ph4/test_ph4.py
@@ -80,7 +80,7 @@ def print_log(pre, time, gravity, E0 = 0.0 | nbody_system.energy,
 def run_ph4(infile = None, number_of_stars = 40,
              end_time = 10 | nbody_system.time,
              delta_t = 1 | nbody_system.time,
-             n_workers = 1, use_gpu = 1, gpu_worker = 1, gpu_id = -1,
+             n_workers = 1, use_gpu = 1, gpu_worker = 1, gpu_id = -1, n_gpu = 0,
              accuracy_parameter = 0.1,
              softening_length = -1 | nbody_system.length,
              manage_encounters = 1):
@@ -124,7 +124,8 @@ def run_ph4(infile = None, number_of_stars = 40,
     #print "3"; sys.stdout.flush()
     gravity.parameters.set_defaults()
 
-    gravity.parameters.gpu_id = gpu_id
+    gravity.parameters.gpu_id = gpu_id	# (first) GPU to use
+    gravity.parameters.n_gpu = n_gpu	# number of GPUs to use
 
     #-----------------------------------------------------------------
 
@@ -299,13 +300,14 @@ if __name__ == '__main__':
     use_gpu = 1
     gpu_worker = 1
     gpu_id = -1
+    n_gpu = 0
     accuracy_parameter = 0.1
     softening_length = -1  | nbody_system.length
     random_seed = -1
     manage_encounters = 1
 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "a:c:d:e:f:gGi:n:s:t:w:")
+        opts, args = getopt.getopt(sys.argv[1:], "a:c:d:e:f:gGi:n:s:t:w:W:")
     except getopt.GetoptError as err:
         print(str(err))
         sys.exit(1)
@@ -336,6 +338,8 @@ if __name__ == '__main__':
             t_end = float(a) | nbody_system.time
         elif o == "-w":
             n_workers = int(a)
+        elif o == "-W":
+            n_gpu = int(a)
         else:
             print("unexpected argument", o)
 
@@ -351,6 +355,6 @@ if __name__ == '__main__':
 
     assert is_mpd_running()
     run_ph4(infile, N, t_end, delta_t, n_workers,
-             use_gpu, gpu_worker, gpu_id,
+             use_gpu, gpu_worker, gpu_id, n_gpu,
              accuracy_parameter, softening_length,
              manage_encounters)


### PR DESCRIPTION
Default is 1 GPU per worker.  Specify more GPUs with the n_gpu parameter.  No checks for
overlapping GPU requests or enough GPUs.  Code uses sapporo_2, but reverts to sapporo_light if sapporo_2 is not enabled.  Tested only on a fairly old system.