### PR TITLE
fix the defaults of hdf5 store to make them less dangerous 

### DIFF
--- a/src/amuse/io/store_v2.py
+++ b/src/amuse/io/store_v2.py
@@ -27,6 +27,9 @@ from amuse.io import store_v1
 
 import warnings
 
+import logging
+logger = logging.getLogger(__name__)
+
 def pickle_to_string(value):
     return numpy.void(pickle.dumps(value, protocol=0))
         
@@ -625,29 +628,29 @@ class StoreHDF(object):
     INFO_GROUP_NAME = 'AMUSE_INF'
     DATA_GROUP_NAME = 'data'
     
-    def __init__(self, filename, append_to_file=True, open_for_writing = True, copy_history = False, return_working_copy = False):
+    def __init__(self, filename, append_to_file=True, open_for_writing = True, copy_history = False, overwrite_file=False):
         if h5py is None:
             raise AmuseException("h5py module not available, cannot use hdf5 files")
+        
+        logger.info("opening {0} with options {1} {2} {3} {4} {5}".format(filename, append_to_file, open_for_writing, copy_history,overwrite_file))
             
-        if not append_to_file and open_for_writing and os.path.exists(filename):
-            os.remove(filename)
-            
-        if append_to_file:
-            if open_for_writing:
-                self.hdf5file = h5py.File(filename,'a')
-            else:
-                if os.access(filename, os.W_OK):
-                    self.hdf5file = h5py.File(filename,'a')
+        if not append_to_file and open_for_writing:
+            if os.path.exists(filename):
+                if overwrite_file:
+                    os.remove(filename)
                 else:
-                    self.hdf5file = h5py.File(filename,'r')
+                    raise Exception("Opening file for write with overwrite_file is False but file {0} exists".format(filename))
+
+        if append_to_file:
+            if os.access(filename, os.F_OK) and not os.access(filename, os.W_OK):
+                   raise Exception("Opening file for append but file {0} is not writeable".format(filename))
+            self.hdf5file = h5py.File(filename,'a')
+        elif open_for_writing:
+            self.hdf5file = h5py.File(filename,'w')
         else:
-            if open_for_writing:
-                self.hdf5file = h5py.File(filename,'w')
-            else:
-                self.hdf5file = h5py.File(filename,'r')
+            self.hdf5file = h5py.File(filename,'r')
         
         self.copy_history = copy_history
-        self.return_working_copy = return_working_copy
         self.mapping_from_groupid_to_set = {}
         
         #warnings.warn("amuse hdf storage version 2.0 is still in development, do not use it for production scripts")
@@ -959,8 +962,6 @@ class StoreHDF(object):
                 result[x] = self.load_container(self.named_group(x))
             return result
                 
-
-
     def load_sets(self, names):
         result = []
         for x in names:
@@ -990,7 +991,6 @@ class StoreHDF(object):
         
         
         return particles
-        
         
     def load_grid_from_group(self, group):
         try:
@@ -1088,12 +1088,13 @@ class StoreHDF(object):
         else:
             return self.hdf5file.require_group(name)
         
-
     def close(self):
         if not self.hdf5file is None:
             self.hdf5file.flush()
             self.hdf5file.close()
             self.hdf5file = None
+
+
 class HDF5UnicodeAttribute(HDF5UnitlessAttribute):
     
     def __init__(self, name, dataset):
@@ -1108,11 +1109,9 @@ class HDF5UnicodeAttribute(HDF5UnitlessAttribute):
             encoded = self.dataset[:][indices]
         return numpy.char.decode(encoded, 'UTF-32BE')
 
-
     def set_values(self, indices, values):
         self.dataset[indices] = numpy.char.encode(values, 'UTF-32LE')
     
-
     def get_value(self, index):
         return self.dataset[index].decode('UTF-32BE')
 

--- a/src/amuse/io/store_v2.py
+++ b/src/amuse/io/store_v2.py
@@ -632,7 +632,7 @@ class StoreHDF(object):
         if h5py is None:
             raise AmuseException("h5py module not available, cannot use hdf5 files")
         
-        logger.info("opening {0} with options {1} {2} {3} {4} {5}".format(filename, append_to_file, open_for_writing, copy_history,overwrite_file))
+        logger.info("opening {0} with options {1} {2} {3} {4}".format(filename, append_to_file, open_for_writing, copy_history,overwrite_file))
             
         if not append_to_file and open_for_writing:
             if os.path.exists(filename):

--- a/test/core_tests/test_io.py
+++ b/test/core_tests/test_io.py
@@ -196,15 +196,15 @@ class FormatTests(amusetest.TestCase):
         x.mass = [10.0, 20.0] | units.kg
         io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=True, version="1.0")
         x.mass = [100.0, 200.0] | units.kg
-        io.write_set_to_file(x, "test_unit.hdf5","hdf5", version="1.0")
-        y = io.read_set_from_file("test_unit.hdf5","hdf5")
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", version="1.0", append_to_file=True)
+        y = io.read_set_from_file("test_unit.hdf5","hdf5", copy_history=False, close_file=False)
         y = y.previous_state() # weirdness for version="1.0"
         self.assertAlmostEqual(x.mass, y.mass, 8)
         self.assertAlmostEqual([10.0, 20.0] | units.kg, y.previous_state().mass, 8)
         self.assertAlmostEqual([1.0, 2.0] | units.kg, y.previous_state().previous_state().mass, 8)
         self.assertEqual(y.previous_state().previous_state().previous_state(), None)
         
-        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=False, version="1.0")
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=False, overwrite_file=True,version="1.0")
         y = io.read_set_from_file("test_unit.hdf5","hdf5")
         self.assertAlmostEqual(x.mass, y.mass, 8)
         self.assertEqual(y.previous_state().previous_state(), None)
@@ -212,6 +212,31 @@ class FormatTests(amusetest.TestCase):
         os.remove("test_unit.hdf5")
 
     def test6b(self):
+        print("Testing HDF5 io, with options")
+        if os.path.exists("test_unit.hdf5"):
+            os.remove("test_unit.hdf5")
+        x = datamodel.Particles(2)
+        x.mass = [1.0, 2.0] | units.kg
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", version="1.0")
+        x.mass = [10.0, 20.0] | units.kg
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=True, version="1.0")
+        x.mass = [100.0, 200.0] | units.kg
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", version="1.0", append_to_file=True)
+        y = io.read_set_from_file("test_unit.hdf5","hdf5", copy_history=True, )
+        y = y.previous_state() # weirdness for version="1.0"
+        self.assertAlmostEqual(x.mass, y.mass, 8)
+        self.assertAlmostEqual([10.0, 20.0] | units.kg, y.previous_state().mass, 8)
+        self.assertAlmostEqual([1.0, 2.0] | units.kg, y.previous_state().previous_state().mass, 8)
+        self.assertEqual(y.previous_state().previous_state().previous_state(), None)
+        
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=False, overwrite_file=True,version="1.0")
+        y = io.read_set_from_file("test_unit.hdf5","hdf5")
+        self.assertAlmostEqual(x.mass, y.mass, 8)
+        self.assertEqual(y.previous_state().previous_state(), None)
+        
+        os.remove("test_unit.hdf5")
+
+    def test6c(self):
         print("Testing HDF5 io, with options, version=2.0")
         if os.path.exists("test_unit.hdf5"):
             os.remove("test_unit.hdf5")
@@ -221,19 +246,45 @@ class FormatTests(amusetest.TestCase):
         x.mass = [10.0, 20.0] | units.kg
         io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=True, version="2.0")
         x.mass = [100.0, 200.0] | units.kg
-        io.write_set_to_file(x, "test_unit.hdf5","hdf5", version="2.0")
-        y = io.read_set_from_file("test_unit.hdf5","hdf5")
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=True, version="2.0")
+        y = io.read_set_from_file("test_unit.hdf5","hdf5", close_file=False, copy_history=False)
         self.assertAlmostEqual(x.mass, y.mass, 8)
         self.assertAlmostEqual([10.0, 20.0] | units.kg, y.previous_state().mass, 8)
         self.assertAlmostEqual([1.0, 2.0] | units.kg, y.previous_state().previous_state().mass, 8)
         self.assertEqual(y.previous_state().previous_state().previous_state(), None)
         
-        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=False, version="2.0")
-        y = io.read_set_from_file("test_unit.hdf5","hdf5")
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=False, overwrite_file=True, version="2.0")
+        y = io.read_set_from_file("test_unit.hdf5","hdf5", copy_history=False)
         self.assertAlmostEqual(x.mass, y.mass, 8)
         self.assertEqual(y.previous_state(), None)
         
         os.remove("test_unit.hdf5")
+
+    def test6d(self):
+        print("Testing HDF5 io, with options, version=2.0")
+        if os.path.exists("test_unit.hdf5"):
+            os.remove("test_unit.hdf5")
+        x = datamodel.Particles(2)
+        x.mass = [1.0, 2.0] | units.kg
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", version="2.0")
+        x.mass = [10.0, 20.0] | units.kg
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=True, version="2.0")
+        x.mass = [100.0, 200.0] | units.kg
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=True, version="2.0")
+        y = io.read_set_from_file("test_unit.hdf5","hdf5", close_file=True, copy_history=True)
+        y = y.previous_state() # weirdness for version="1.0"
+        self.assertAlmostEqual(x.mass, y.mass, 8)
+        self.assertAlmostEqual([10.0, 20.0] | units.kg, y.previous_state().mass, 8)
+        self.assertAlmostEqual([1.0, 2.0] | units.kg, y.previous_state().previous_state().mass, 8)
+        self.assertEqual(y.previous_state().previous_state().previous_state(), None)
+        
+        io.write_set_to_file(x, "test_unit.hdf5","hdf5", append_to_file=False, overwrite_file=True, version="2.0")
+        y = io.read_set_from_file("test_unit.hdf5","hdf5", copy_history=False)
+        self.assertAlmostEqual(x.mass, y.mass, 8)
+        self.assertEqual(y.previous_state(), None)
+        
+        os.remove("test_unit.hdf5")
+
 
     def test7(self):
         print("Testing HDF5 io with a ParticlesSuperset")
@@ -275,7 +326,7 @@ class FormatTests(amusetest.TestCase):
         self.assertEqual(name, 'append_to_file')
         self.assertTrue(description.find('If set to True, new data is appended to HDF5 files.') >= 0)
         self.assertTrue(description.find('If set to False, the existing file is removed and overwritten.') >= 0)
-        self.assertEqual(default, True)
+        self.assertEqual(default, False)
     
     def test9(self):
         x = datamodel.Particles(2)

--- a/test/core_tests/test_store.py
+++ b/test/core_tests/test_store.py
@@ -554,7 +554,7 @@ class _AbstractTestStoreHDF(amusetest.TestCase):
 
         io.write_set_to_file(stars, output_file, "hdf5", version = self.store_version())
        
-        loaded = io.read_set_from_file(output_file, "hdf5", close_file = True, version = self.store_version())
+        loaded = io.read_set_from_file(output_file, "hdf5", close_file = True, version = self.store_version(), copy_history=False)
         
         self.assertEqual(loaded[0].md, [[1,3],[2,4],[3,5]])
         self.assertEqual(loaded[1].md, [[4,6],[5,7],[6,8]])
@@ -612,7 +612,7 @@ class _AbstractTestStoreHDF(amusetest.TestCase):
         
         for i in range(10):
             particles.position += [1.0, 2.0, 3.0] | units.m
-            io.write_set_to_file(particles, output_file, format='amuse', version = self.store_version())
+            io.write_set_to_file(particles, output_file, format='amuse', version = self.store_version(), append_to_file=True)
         
         particles_from_file = io.read_set_from_file(output_file, format='amuse', version = self.store_version())
         os.remove(output_file)
@@ -634,7 +634,7 @@ class _AbstractTestStoreHDF(amusetest.TestCase):
         
         for i in range(10):
             particles.position += [1.0, 2.0, 3.0] | units.m
-            io.write_set_to_file(particles, output_file, format='amuse', version = self.store_version())
+            io.write_set_to_file(particles, output_file, format='amuse', version = self.store_version(), append_to_file=True)
         
         particles_from_file = io.read_set_from_file(output_file, format='amuse', version = self.store_version(), copy_history = True, close_file = True)
         
@@ -969,7 +969,7 @@ class TestStoreHDFV2(_AbstractTestStoreHDF):
         loaded_particles = io.read_set_from_file(
             output_file, 
             "hdf5",
-            version = self.store_version()
+            version = self.store_version(), copy_history=False, close_file=False
         )
         
         attributes = loaded_particles.collection_attributes


### PR DESCRIPTION
this PR makes hdf5 stores (used by read_set_from_file and write_set_to_file) less dangerous
and hopefully a bit more intuitive to use. 

 - Instead of appending by by default, it simply refuses to (over)write an existing file. unless either
  append_to_file=True is passed (the old behaviour) or overwrite_file=True (the old behaviour if
 append_to_file=False)
 - when reading, the defaults have changed and both close_file and copy_history are true by default: this reads in all information into memory and closes file. 
 - The file are also opened read-only by read_set_from_file unless append_to_file=True or allow_write=True (these two options do the same)
 - return_working_copy had no effect and is removed