### PR TITLE
Travis alternate configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,17 @@ matrix:
       addons:
         apt:
           packages:
+            - build-essential
+            - python3-dev
+            - gfortran
+            - libgsl0-dev
+            - cmake
+            - libfftw3-3
+            - libfftw3-dev
+            - libmpfr6
+            - libmpfr-dev
+            - libhdf5-serial-dev
+            - hdf5-tools
             - libopenmpi-dev
             - openmpi-bin
 
@@ -27,30 +38,19 @@ matrix:
       addons:
         apt:
           packages:
+            - build-essential
+            - python3-dev
+            - gfortran
+            - libgsl0-dev
+            - cmake
+            - libfftw3-3
+            - libfftw3-dev
+            - libmpfr6
+            - libmpfr-dev
+            - libhdf5-serial-dev
+            - hdf5-tools
             - libmpich-dev
             - mpich
-
-addons:
-  apt:
-    packages:
-      - build-essential
-      - python3-dev
-      - gfortran
-      - libgsl0-dev
-      - cmake
-      - libfftw3-3
-      - libfftw3-dev
-      - libmpfr6
-      - libmpfr-dev
-      - libhdf5-serial-dev
-      - hdf5-tools
-      # - libmpich-dev
-      # - mpich
-      # - libopenmpi-dev
-      # - openmpi-bin
-  homebrew:
-    packages:
-      - openmpi
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 codecov: true
-language: python
-dist: bionic
-compiler:
-  - gcc
-os:
-  - linux
-  # - osx
+compiler: gcc
 env:
   global:
     - OMPI_MCA_rmaps_base_oversubscribe=true
@@ -14,9 +8,14 @@ env:
     # - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7
 
+dist: bionic
 matrix:
+  os:
+    - linux
+    # - osx
   include:
-    - mpi: "openmpi"
+    - name: "openmpi"
+      language: python
       addons:
         apt:
           packages:
@@ -34,7 +33,8 @@ matrix:
             - libopenmpi-dev
             - openmpi-bin
 
-    - mpi: "mpich"
+    - name: "mpich"
+      language: python
       addons:
         apt:
           packages:
@@ -73,7 +73,7 @@ virtualenv:
 script:
   - mpiexec -n 1 py.test --timeout=10 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.reports.test_speed
   - mpiexec -n 1 py.test --timeout=30 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.core_tests
-  - mpiexec -n 1 py.test --timeout=10 --timeout_method=thread --cov-report=xml --cov=amuse --pyargs amuse.test.suite.compile_tests
+  - mpiexec -n 1 py.test -v --timeout=10 --timeout_method=thread --cov-report=xml --cov=amuse --pyargs amuse.test.suite.compile_tests
   
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,43 +14,45 @@ matrix:
     - linux
     # - osx
   include:
-    - name: "openmpi"
-      language: python
-      addons:
-        apt:
-          packages:
-            - build-essential
-            - python3-dev
-            - gfortran
-            - libgsl0-dev
-            - cmake
-            - libfftw3-3
-            - libfftw3-dev
-            - libmpfr6
-            - libmpfr-dev
-            - libhdf5-serial-dev
-            - hdf5-tools
-            - libopenmpi-dev
-            - openmpi-bin
-
-    - name: "mpich"
-      language: python
-      addons:
-        apt:
-          packages:
-            - build-essential
-            - python3-dev
-            - gfortran
-            - libgsl0-dev
-            - cmake
-            - libfftw3-3
-            - libfftw3-dev
-            - libmpfr6
-            - libmpfr-dev
-            - libhdf5-serial-dev
-            - hdf5-tools
-            - libmpich-dev
-            - mpich
+    - python: 3.7
+      env: TOXENV=py37
+      - name: "openmpi py37 linux"
+        language: python
+        addons:
+          apt:
+            packages:
+              - build-essential
+              - python3-dev
+              - gfortran
+              - libgsl0-dev
+              - cmake
+              - libfftw3-3
+              - libfftw3-dev
+              - libmpfr6
+              - libmpfr-dev
+              - libhdf5-serial-dev
+              - hdf5-tools
+              - libopenmpi-dev
+              - openmpi-bin
+  
+      - name: "mpich py37 linux"
+        language: python
+        addons:
+          apt:
+            packages:
+              - build-essential
+              - python3-dev
+              - gfortran
+              - libgsl0-dev
+              - cmake
+              - libfftw3-3
+              - libfftw3-dev
+              - libmpfr6
+              - libmpfr-dev
+              - libhdf5-serial-dev
+              - hdf5-tools
+              - libmpich-dev
+              - mpich
 
 
 before_install:
@@ -59,21 +61,17 @@ before_install:
   #     something;
   #   fi
   # - pip install --upgrade pip
-  - pip install numpy scipy matplotlib pytest docutils mpi4py h5py Cython
-  - pip install pytest-cov codecov pytest-timeout
 
 install:
-  - pip install -e .
-  - ./configure
-  - make framework
+  - pip install numpy scipy matplotlib docutils mpi4py pytest
+  # - pip install pytest-cov codecov pytest-timeout
+  - pip install tox
 
 virtualenv:
   system_site_packages: false
 
 script:
-  - mpiexec -n 1 py.test --timeout=10 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.reports.test_speed
-  - mpiexec -n 1 py.test --timeout=30 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.core_tests
-  - mpiexec -n 1 py.test -v --timeout=10 --timeout_method=thread --cov-report=xml --cov=amuse --pyargs amuse.test.suite.compile_tests
+  - tox
   
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
             - mpich
     - name: "openmpi py37 macos"
       os: osx
-      osx_image: xcode11.5
+      osx_image: xcode10.3
       env:
         - TOXENV=py37
         - MINICONDA_OSX="MacOSX-x86_64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ virtualenv:
 script:
   - mpiexec -n 1 py.test --timeout=10 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.reports.test_speed
   - mpiexec -n 1 py.test --timeout=30 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.core_tests
-  - mpiexec -n 1 py.test --timeout=10 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.compile_tests
+  - mpiexec -n 1 py.test --timeout=10 --timeout_method=thread --cov-report=xml --cov=amuse --pyargs amuse.test.suite.compile_tests
   
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ env:
   global:
     - OMPI_MCA_rmaps_base_oversubscribe=true
 
-dist: bionic
 matrix:
-  os:
-    - linux
-    # - osx
+  allow_failures:
+    - name: "openmpi py37 linux"
   include:
     - name: "openmpi py37 linux"
-      python: 3.7
+      os: linux
+      dist: bionic
       language: python
+      python: 3.7
       env: TOXENV=py37
       addons:
         apt:
@@ -31,9 +31,11 @@ matrix:
             - libopenmpi-dev
             - openmpi-bin
     - name: "mpich py37 linux"
+      os: linux
+      dist: bionic
+      language: python
       python: 3.7
       env: TOXENV=py37
-      language: python
       addons:
         apt:
           packages:
@@ -61,7 +63,6 @@ before_install:
   - pip install numpy scipy matplotlib docutils mpi4py pytest
 
 install:
-  # - pip install pytest-cov codecov pytest-timeout
   - pip install tox
 
 virtualenv:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
         - TOXENV=py37
         - MINICONDA_OSX="MacOSX-x86_64"
         - MINICONDA_PYTHON_MAJOR=3
-        - MINICONDA_VERSION="$TOXENV"
+        - MINICONDA_VERSION="py37_4.8.2"
         - CXX=clang++
         - CC=clang
         - LDFLAGS="-Wl,-rpath,$CONDA_PREFIX/lib"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ compiler: gcc
 env:
   global:
     - OMPI_MCA_rmaps_base_oversubscribe=true
-  matrix:
-    # - PYTHON_VERSION=3.5
-    # - PYTHON_VERSION=3.6
-    - PYTHON_VERSION=3.7
 
 dist: bionic
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,23 +67,18 @@ matrix:
         - CONDA_OPTIONS="-c conda-forge -c anaconda"
         - CONDA_PACKAGES="gfortran_osx-64"
         - CONDA_PACKAGES="${CONDA_PACKAGES} openmpi"
-
-
-before_install:
-  - if [[ $TRAVIS_OS_NAME == osx ]]; then
-      export MINICONDA_OS=$MINICONDA_OSX
-      wget "http://repo.continuum.io/miniconda/Miniconda$MINICONDA_PYTHON_MAJOR-$MINICONDA_VERSION-$MINICONDA_OS.sh" -O miniconda.sh;
-      bash miniconda.sh -b -p $HOME/miniconda;
-      export CONDA_PREFIX=$HOME/miniconda;
-      export PATH="$CONDA_PREFIX/bin:$PATH";
-      hash -r;
-      conda update -yq conda;
-      conda install -y ${CONDA_OPTIONS} ${CONDA_PACKAGES};
-    fi
-  # - pip install --upgrade pip
-  - pip install numpy scipy matplotlib docutils mpi4py pytest
+      before_install:
+        - export MINICONDA_OS=$MINICONDA_OSX
+        - wget "http://repo.continuum.io/miniconda/Miniconda$MINICONDA_PYTHON_MAJOR-$MINICONDA_VERSION-$MINICONDA_OS.sh" -O miniconda.sh;
+        - bash miniconda.sh -b -p $HOME/miniconda;
+        - export CONDA_PREFIX=$HOME/miniconda;
+        - export PATH="$CONDA_PREFIX/bin:$PATH";
+        - hash -r;
+        - conda update -yq conda;
+        - conda install -y ${CONDA_OPTIONS} ${CONDA_PACKAGES};
 
 install:
+  - pip install numpy scipy matplotlib docutils mpi4py pytest
   - pip install tox
 
 virtualenv:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,33 @@ matrix:
             - hdf5-tools
             - libmpich-dev
             - mpich
+    - name: "openmpi py37 macos"
+      os: osx
+      osx_image: xcode11.5
+      env:
+        - TOXENV=py37
+        - MINICONDA_OSX="MacOSX-x86_64"
+        - MINICONDA_PYTHON_MAJOR=3
+        - MINICONDA_VERSION="$TOXENV"
+        - CXX=clang++
+        - CC=clang
+        - LDFLAGS="-Wl,-rpath,$CONDA_PREFIX/lib"
+        - CONDA_OPTIONS="-c conda-forge -c anaconda"
+        - CONDA_PACKAGES="gfortran_osx-64"
+        - CONDA_PACKAGES="${CONDA_PACKAGES} openmpi"
 
 
 before_install:
-  # - if [[ $TRAVIS_OS_NAME == linux ]]; then ; fi
-  # - if [[ $TRAVIS_OS_NAME == osx ]]; then
-  #     something;
-  #   fi
+  - if [[ $TRAVIS_OS_NAME == osx ]]; then
+      export MINICONDA_OS=$MINICONDA_OSX
+      wget "http://repo.continuum.io/miniconda/Miniconda$MINICONDA_PYTHON_MAJOR-$MINICONDA_VERSION-$MINICONDA_OS.sh" -O miniconda.sh;
+      bash miniconda.sh -b -p $HOME/miniconda
+      export CONDA_PREFIX=$HOME/miniconda
+      export PATH="$CONDA_PREFIX/bin:$PATH"
+      hash -r
+      conda update -yq conda
+      conda install -y ${CONDA_OPTIONS} ${CONDA_PACKAGES}
+    fi
   # - pip install --upgrade pip
   - pip install numpy scipy matplotlib docutils mpi4py pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
 matrix:
   allow_failures:
     - name: "openmpi py37 linux"
+    - name: "openmpi py37 macos"
   include:
     - name: "openmpi py37 linux"
       os: linux
@@ -72,12 +73,12 @@ before_install:
   - if [[ $TRAVIS_OS_NAME == osx ]]; then
       export MINICONDA_OS=$MINICONDA_OSX
       wget "http://repo.continuum.io/miniconda/Miniconda$MINICONDA_PYTHON_MAJOR-$MINICONDA_VERSION-$MINICONDA_OS.sh" -O miniconda.sh;
-      bash miniconda.sh -b -p $HOME/miniconda
-      export CONDA_PREFIX=$HOME/miniconda
-      export PATH="$CONDA_PREFIX/bin:$PATH"
-      hash -r
-      conda update -yq conda
-      conda install -y ${CONDA_OPTIONS} ${CONDA_PACKAGES}
+      bash miniconda.sh -b -p $HOME/miniconda;
+      export CONDA_PREFIX=$HOME/miniconda;
+      export PATH="$CONDA_PREFIX/bin:$PATH";
+      hash -r;
+      conda update -yq conda;
+      conda install -y ${CONDA_OPTIONS} ${CONDA_PACKAGES};
     fi
   # - pip install --upgrade pip
   - pip install numpy scipy matplotlib docutils mpi4py pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ before_install:
   #     something;
   #   fi
   # - pip install --upgrade pip
+  - pip install numpy scipy matplotlib docutils mpi4py pytest
 
 install:
-  - pip install numpy scipy matplotlib docutils mpi4py pytest
   # - pip install pytest-cov codecov pytest-timeout
   - pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,22 @@ env:
     # - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7
 
+matrix:
+  include:
+    - mpi: "openmpi"
+      addons:
+        apt:
+          packages:
+            - libopenmpi-dev
+            - openmpi-bin
+
+    - mpi: "mpich"
+      addons:
+        apt:
+          packages:
+            - libmpich-dev
+            - mpich
+
 addons:
   apt:
     packages:
@@ -28,8 +44,8 @@ addons:
       - libmpfr-dev
       - libhdf5-serial-dev
       - hdf5-tools
-      - libmpich-dev
-      - mpich
+      # - libmpich-dev
+      # - mpich
       # - libopenmpi-dev
       # - openmpi-bin
   homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,47 +10,46 @@ matrix:
     - linux
     # - osx
   include:
-    - python: 3.7
+    - name: "openmpi py37 linux"
+      python: 3.7
+      language: python
       env: TOXENV=py37
-      - name: "openmpi py37 linux"
-        language: python
-        addons:
-          apt:
-            packages:
-              - build-essential
-              - python3-dev
-              - gfortran
-              - libgsl0-dev
-              - cmake
-              - libfftw3-3
-              - libfftw3-dev
-              - libmpfr6
-              - libmpfr-dev
-              - libhdf5-serial-dev
-              - hdf5-tools
-              - libopenmpi-dev
-              - openmpi-bin
-  
-    - python: 3.7
+      addons:
+        apt:
+          packages:
+            - build-essential
+            - python3-dev
+            - gfortran
+            - libgsl0-dev
+            - cmake
+            - libfftw3-3
+            - libfftw3-dev
+            - libmpfr6
+            - libmpfr-dev
+            - libhdf5-serial-dev
+            - hdf5-tools
+            - libopenmpi-dev
+            - openmpi-bin
+    - name: "mpich py37 linux"
+      python: 3.7
       env: TOXENV=py37
-      - name: "mpich py37 linux"
-        language: python
-        addons:
-          apt:
-            packages:
-              - build-essential
-              - python3-dev
-              - gfortran
-              - libgsl0-dev
-              - cmake
-              - libfftw3-3
-              - libfftw3-dev
-              - libmpfr6
-              - libmpfr-dev
-              - libhdf5-serial-dev
-              - hdf5-tools
-              - libmpich-dev
-              - mpich
+      language: python
+      addons:
+        apt:
+          packages:
+            - build-essential
+            - python3-dev
+            - gfortran
+            - libgsl0-dev
+            - cmake
+            - libfftw3-3
+            - libfftw3-dev
+            - libmpfr6
+            - libmpfr-dev
+            - libhdf5-serial-dev
+            - hdf5-tools
+            - libmpich-dev
+            - mpich
 
 
 before_install:
@@ -70,6 +69,6 @@ virtualenv:
 
 script:
   - tox
-  
+
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
               - libopenmpi-dev
               - openmpi-bin
   
+    - python: 3.7
+      env: TOXENV=py37
       - name: "mpich py37 linux"
         language: python
         addons:

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ whitelist_externals =
     coverage
 
 commands =
-    ./configure
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure --with-hdf5=$CONDA_PREFIX --with-gmp=$CONDA_PREFIX --with-mpfr=$CONDA_PREFIX --with-fftw=$CONDA_PREFIX --with-gsl-prefix=$CONDA_PREFIX; else ./configure; fi
     make framework
     mpiexec -n 1 pytest --timeout=10 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.reports.test_speed
     mpiexec -n 1 pytest --timeout=30 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.core_tests

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,15 @@ deps =
     coverage
 usedevelop = true
 
-whitelist_externals = 
+whitelist_externals =
+    bash
     mpiexec
     make
     configure
     coverage
 
 commands =
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure --with-hdf5=$CONDA_PREFIX --with-gmp=$CONDA_PREFIX --with-mpfr=$CONDA_PREFIX --with-fftw=$CONDA_PREFIX --with-gsl-prefix=$CONDA_PREFIX; else ./configure; fi
+    bash -ec 'if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./configure --with-hdf5=$CONDA_PREFIX --with-gmp=$CONDA_PREFIX --with-mpfr=$CONDA_PREFIX --with-fftw=$CONDA_PREFIX --with-gsl-prefix=$CONDA_PREFIX; else ./configure; fi'
     make framework
     mpiexec -n 1 pytest --timeout=10 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.reports.test_speed
     mpiexec -n 1 pytest --timeout=30 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.core_tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,28 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    pytest-timeout
+    coverage
+usedevelop = true
+
+whitelist_externals = 
+    mpiexec
+    make
+    configure
+    coverage
+
+commands =
+    ./configure
+    make framework
+    mpiexec -n 1 pytest --timeout=10 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.reports.test_speed
+    mpiexec -n 1 pytest --timeout=30 --cov-report=xml --cov=amuse --pyargs amuse.test.suite.core_tests
+    mpiexec -n 1 pytest -v --timeout=10 --timeout_method=thread --cov-report=xml --cov=amuse --pyargs amuse.test.suite.compile_tests
+


### PR DESCRIPTION
- Add linux/openmpi alternative configuration
- Use tox for automated setup/install/testing (described in tox.ini)
- Allow failing of linux/openmpi testing for now since specific tests hang on Travis (but not locally on a comparable installation, which is weird)