### PR TITLE
Also fix hasing for gas_interface.py in GalactICs

### DIFF
--- a/src/amuse/community/galactics/gas_interface.py
+++ b/src/amuse/community/galactics/gas_interface.py
@@ -4,6 +4,7 @@ import os.path
 import pickle
 import random
 import numpy
+import hashlib
 from subprocess import Popen, PIPE
 
 from amuse.units.core import *
@@ -223,7 +224,8 @@ class GaslactICsImplementation(object):
             pass
 
     def _data_directory(self,in_dbh,in_diskdf):
-        return os.path.join(self._output_directory, "model"+str(hash(in_dbh+in_diskdf)))
+        modelhash=hashlib.sha1((in_dbh+in_diskdf).encode()).hexdigest()
+        return os.path.join(self._output_directory, "model_"+modelhash)
         
     def model_present(self,model_present):
         in_dbh = self.generate_in_dbh_string()


### PR DESCRIPTION
Same change Inti made to in 2b632905775c67f04f369b8183a12b0b8dae30f9 for GalactICs interface.py to fix hashing in Python 3, now also in gas_interface.py.