### PR TITLE
Add $(NVCC_FLAGS) to a bunch of Makefiles

### DIFF
--- a/lib/sapporo_2/Makefile
+++ b/lib/sapporo_2/Makefile
@@ -17,7 +17,7 @@ OFLAGS = -g -Wall -fopenmp
 CXXFLAGS =  -fPIC $(OFLAGS) -I$(CUDA_TK)/include  -D__INCLUDE_KERNELS__ $(CL_CFLAGS)
 
 NVCC      = $(CUDA_TK)/bin/nvcc  
-NVCCFLAGS ?= 
+NVCCFLAGS ?= $(NVCC_FLAGS)
 
 export NVCCFLAGS NVCC CXXFLAGS
 

--- a/src/amuse/community/fastkick/Makefile
+++ b/src/amuse/community/fastkick/Makefile
@@ -12,6 +12,8 @@ GPU_OBJ = interface.gpuo cuda_fastkick.o
 
 CODE_GENERATOR ?= $(PYTHON) $(AMUSE_DIR)/build.py
 
+NVCCFLAGS ?= $(NVCC_FLAGS)
+
 all: fastkick_worker
 
 worker_code.cc: interface.py

--- a/src/amuse/community/hacs64/Makefile
+++ b/src/amuse/community/hacs64/Makefile
@@ -36,6 +36,8 @@ SRCDIR = src
 BUILDDIRCPU = build_cpu
 CXXFLAGS += -I../src -I../src/ON_neib
 
+NVCCFLAGS ?= $(NVCC_FLAGS)
+
 CODELIB = src/libhacs64gpu.a
 CODELIBCPU = $(BUILDDIRCPU)/libhacs64cpu.a
 

--- a/src/amuse/community/hacs64/src/Makefile
+++ b/src/amuse/community/hacs64/src/Makefile
@@ -18,6 +18,7 @@ NVCCFLAGS += -Xcompiler="-Wall"
 #NVCCFLAGS += -G
 #NVCCFLAGS := -O0 -g -D_DEBUG -deviceemu -maxrregcount=32 $(CUDAINCLUDE)
 NVCCFLAGS += -D_FORCE_INLINES
+NVCCFLAGS += $(NVCC_FLAGS)
 CUDA_LIBS = -lcudart  -L $(CUDAPATH)/lib -L $(CUDAPATH)/lib64
 
 OPENMP_CFLAGS ?= -fopenmp

--- a/src/amuse/community/higpus/Makefile
+++ b/src/amuse/community/higpus/Makefile
@@ -47,7 +47,7 @@ MYINCLUDE := -I./lib/
 LIBS := -lm $(OPENMP_CFLAGS) $(MPI_CXXLIBS) $(CUDALIB)
 
 GXXOPTS := -O3 -fopenmp -Wall -W
-NVCCFLAGS := -O3 --compiler-bindir=/usr/bin/$(CXX) -Xcompiler "$(GXXOPTS) $(MYOPTS)" $(CUDAINCLUDE) $(MPI_CXXFLAGS) $(MYINCLUDE)
+NVCCFLAGS := -O3 --compiler-bindir=/usr/bin/$(CXX) -Xcompiler "$(GXXOPTS) $(MYOPTS)" $(CUDAINCLUDE) $(MPI_CXXFLAGS) $(MYINCLUDE) $(NVCC_FLAGS)
 CXXFLAGS += $(GXXOPTS) $(MYOPTS) $(CUDAINCLUDE) $(MPI_CXXFLAGS) $(MYINCLUDE)
 
 LDFLAGS = $(LIBS) $(CUDALIB) 

--- a/src/amuse/community/higpus/src/Makefile
+++ b/src/amuse/community/higpus/src/Makefile
@@ -23,8 +23,8 @@ MYINCLUDE := -I./lib/
 LIBS := -lm -fopenmp
 
 GXXOPTS := -O3 -fopenmp -Wall -W
-NVCCFLAGS := -O3 --compiler-bindir=/usr/bin/$(CXX) -Xcompiler "$(GXXOPTS) $(MYOPTS) $(MPI_FCFLAGS)" $(CUDAINCLUDE) $(MYINCLUDE) $(NVCC_FLAGS)
-CXXFLAGS += $(GXXOPTS) $(MYOPTS) $(CUDAINCLUDE) $(MYINCLUDE) $(MPI_CLIBS)
+NVCCFLAGS := -O3 -Xcompiler "$(GXXOPTS) $(MYOPTS) $(MPI_FCFLAGS) $(MPI_CFLAGS)" $(CUDAINCLUDE) $(MYINCLUDE) $(NVCC_FLAGS)
+CXXFLAGS += $(GXXOPTS) $(MYOPTS) $(CUDAINCLUDE) $(MYINCLUDE) $(MPI_CLIBS) $(MPI_CFLAGS)
 
 CUDAOBJS = 	./src/cuda/main.cu.o \
                 ./src/cuda/cpu_func.cu.o \

--- a/src/amuse/community/higpus/src/Makefile
+++ b/src/amuse/community/higpus/src/Makefile
@@ -23,7 +23,7 @@ MYINCLUDE := -I./lib/
 LIBS := -lm -fopenmp
 
 GXXOPTS := -O3 -fopenmp -Wall -W
-NVCCFLAGS := -O3 --compiler-bindir=/usr/bin/$(CXX) -Xcompiler "$(GXXOPTS) $(MYOPTS) $(MPI_FCFLAGS)" $(CUDAINCLUDE) $(MYINCLUDE)
+NVCCFLAGS := -O3 --compiler-bindir=/usr/bin/$(CXX) -Xcompiler "$(GXXOPTS) $(MYOPTS) $(MPI_FCFLAGS)" $(CUDAINCLUDE) $(MYINCLUDE) $(NVCC_FLAGS)
 CXXFLAGS += $(GXXOPTS) $(MYOPTS) $(CUDAINCLUDE) $(MYINCLUDE) $(MPI_CLIBS)
 
 CUDAOBJS = 	./src/cuda/main.cu.o \

--- a/src/amuse/community/octgrav/src/octgrav_v1.7d/Makefile
+++ b/src/amuse/community/octgrav/src/octgrav_v1.7d/Makefile
@@ -12,7 +12,7 @@ CXXFLAGS ?= $(CFLAGS)
 
 NVCC      ?= $(CUDA_TK)/bin/nvcc
 
-NVCCFLAGS ?= -D_DEBUG --compiler-options -fno-inline \
+NVCCFLAGS ?= -D_DEBUG --compiler-options -fno-inline $(NVCC_FLAGS) \
 		--maxrregcount=32 -O0 -g 
 
 


### PR DESCRIPTION
Several of the Makefiles on the community codes weren't passing $(NVCC_FLAGS) along to the nvcc compiler.  I've added this to those Makefiles.