### PR TITLE
fixed stellar_wind.py evolving past time argument

### DIFF
--- a/src/amuse/ext/stellar_wind.py
+++ b/src/amuse/ext/stellar_wind.py
@@ -411,7 +411,7 @@ class SimpleWind(PositionGenerator):
 
     def evolve_model(self, time):
         if self.has_target():
-            while self.model_time <= time:
+            while self.model_time < time:
                 self.evolve_particles()
                 if self.has_new_wind_particles():
                     wind_gas = self.create_wind_particles()


### PR DESCRIPTION
stellar_wind.py's evolve_model would evolve past the time argument, if the internal model_time was exactly the endtime. This was because of a while model_time <= end_time: do a step; logic, thus making a step if the end time was already reached.