### PR TITLE
Update values in SeBa test

### DIFF
--- a/src/amuse/test/suite/codes_tests/test_seba.py
+++ b/src/amuse/test/suite/codes_tests/test_seba.py
@@ -494,15 +494,15 @@ class TestSeBa(TestWithMPI):
         instance.parameters.supernova_kick_velocity = 0 | units.kms
         instance.commit_parameters()
         print("v_kick=", instance.parameters.supernova_kick_velocity)
-        stars =  Particles(2)
+        stars = Particles(2)
         stars[0].mass = 10.0 | units.MSun
         stars[1].mass = 9 | units.MSun
 
-        semi_major_axis = 10000|units.AU
+        semi_major_axis = 10000 | units.AU
 
         instance.particles.add_particles(stars)
 
-        binaries =  Particles(1)
+        binaries = Particles(1)
 
         binary = binaries[0]
         binary.semi_major_axis = semi_major_axis
@@ -511,15 +511,15 @@ class TestSeBa(TestWithMPI):
         binary.child2 = stars[1]
 
         instance.binaries.add_particles(binaries)
-        instance.evolve_model(30|units.Myr)
+        instance.evolve_model(30 | units.Myr)
         print(instance.particles)
         print(instance.binaries)
 
-        self.assertAlmostRelativeEquals(instance.binaries[0].eccentricity, 0.7872, 4)
+        self.assertAlmostRelativeEquals(instance.binaries[0].eccentricity, 1, 4)
 
     def test9(self):
         instance = self.new_instance_of_an_optional_code(SeBa)
-        stars =  Particles(2)
+        stars = Particles(2)
         stars[0].mass = 10.0 | units.MSun
         stars[1].mass = 9 | units.MSun
 
@@ -528,19 +528,19 @@ class TestSeBa(TestWithMPI):
 
         self.assertAlmostRelativeEquals(instance.particles.age, [30,30] |units.Myr)
         self.assertAlmostRelativeEquals(instance.model_time, 30 | units.Myr)
-        self.assertAlmostRelativeEquals(instance.particles[0].mass, 1.2263 | units.MSun, 4)
+        self.assertAlmostRelativeEquals(instance.particles[0].mass, 1.2476 | units.MSun, 4)
         self.assertAlmostRelativeEquals(instance.particles[1].mass, 8.8682 | units.MSun, 4)
-        stars =  Particles(2)
+        stars = Particles(2)
         stars[0].mass = 10.0 | units.MSun
         stars[1].mass = 9 | units.MSun
 
         instance.particles.add_particles(stars)
-        instance.evolve_model(60|units.Myr)
+        instance.evolve_model(60 | units.Myr)
         print(instance.particles.age)
         print(instance.particles.mass)
         self.assertAlmostRelativeEquals(instance.model_time, 60 | units.Myr)
-        self.assertAlmostRelativeEquals(instance.particles.age, [60,60,30,30] |units.Myr)
-        self.assertAlmostRelativeEquals(instance.particles[2].mass, 1.2263 | units.MSun, 4)
+        self.assertAlmostRelativeEquals(instance.particles.age, [60,60,30,30] | units.Myr)
+        self.assertAlmostRelativeEquals(instance.particles[2].mass, 1.2476 | units.MSun, 4)
         self.assertAlmostRelativeEquals(instance.particles[3].mass, 8.8682 | units.MSun, 4)
 
     def test10(self):
@@ -560,8 +560,8 @@ class TestSeBa(TestWithMPI):
 
         self.assertAlmostRelativeEqual(p.age, 27.35866 | units.Myr, 4)
 
-        self.assertAlmostRelativeEqual(p.mass, 1.22632 | units.MSun, 4)
-        self.assertAlmostRelativeEqual(p.natal_kick_velocity, [0,0,0] | units.kms, 4)
+        self.assertAlmostRelativeEqual(p.mass, 1.2476 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(p.natal_kick_velocity, [-54.070,12.818,42.583] | units.kms, 4)
 
 
     def test11(self):
@@ -590,13 +590,13 @@ class TestSeBa(TestWithMPI):
         print(instance.parameters)
         self.assertAlmostRelativeEqual(instance.particles[0].age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[1].age, 27.35866 | units.Myr, 4)
-        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.22632 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.2476 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.particles[1].mass, 5.0 | units.MSun, 4)
 #        self.assertAlmostRelativeEqual(instance.particles[0].natal_kick_velocity, [0,0,0] | units.kms, 4)
 
         self.assertAlmostRelativeEqual(instance.binaries[0].child1.age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.binaries[0].child2.age, 27.35866 | units.Myr, 4)
-        self.assertAlmostRelativeEqual(instance.binaries[0].child1.mass, 1.22632 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.binaries[0].child1.mass, 1.2476 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.binaries[0].child2.mass, 5.0 | units.MSun, 4)
 #        self.assertAlmostRelativeEqual(instance.binaries[0].child1.natal_kick_velocity, [0,0,0] | units.kms, 4)
 
@@ -619,7 +619,7 @@ class TestSeBa(TestWithMPI):
         self.assertAlmostRelativeEqual(instance.particles[0].age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[1].age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].age, 27.35866 | units.Myr, 4)
-        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.22632 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.2476 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.particles[1].mass, 5.0 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].mass, 0.5 | units.MSun, 4)
 #        self.assertAlmostRelativeEqual(instance.particles[0].natal_kick_velocity, [0,0,0] | units.kms, 4)
@@ -644,7 +644,7 @@ class TestSeBa(TestWithMPI):
         self.assertAlmostRelativeEqual(instance.particles[1].age, 23.08688 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].age, 23.08688 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[0].mass, 9.92275 | units.MSun, 4)
-        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.23645 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.28809 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].mass, 0.5 | units.MSun, 4)
 #        self.assertAlmostRelativeEqual(instance.particles[0].natal_kick_velocity, [0,0,0] | units.kms, 4)
 
@@ -655,8 +655,8 @@ class TestSeBa(TestWithMPI):
         self.assertAlmostRelativeEqual(instance.particles[0].age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[1].age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].age, 27.35866 | units.Myr, 4)
-        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.22632 | units.MSun, 4)
-        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.23645 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.24766 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.28809 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].mass, 0.5 | units.MSun, 4)
 #        self.assertAlmostRelativeEqual(instance.particles[0].natal_kick_velocity, [0,0,0] | units.kms, 4)
 
@@ -681,8 +681,8 @@ class TestSeBa(TestWithMPI):
         self.assertAlmostRelativeEqual(instance.particles[0].age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[1].age, 27.35866 | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].age, 27.35866 | units.Myr, 4)
-        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.22632 | units.MSun, 4)
-        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.22632 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.2476 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.2476 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].mass, 0.5 | units.MSun, 4)
 
 #        self.assertAlmostRelativeEqual(instance.particles[0].natal_kick_velocity, [0,0,0] | units.kms, 4)
@@ -694,7 +694,7 @@ class TestSeBa(TestWithMPI):
         self.assertAlmostRelativeEqual(instance.particles[0].age, 30. | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[1].age, 30. | units.Myr, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].age, 30. | units.Myr, 4)
-        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.22632 | units.MSun, 4)
-        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.22632 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[0].mass, 1.2476 | units.MSun, 4)
+        self.assertAlmostRelativeEqual(instance.particles[1].mass, 1.2476 | units.MSun, 4)
         self.assertAlmostRelativeEqual(instance.particles[2].mass, 0.5 | units.MSun, 4)
 

--- a/src/amuse/test/suite/codes_tests/test_seba.py
+++ b/src/amuse/test/suite/codes_tests/test_seba.py
@@ -490,12 +490,15 @@ class TestSeBa(TestWithMPI):
         self.assertAlmostRelativeEqual(p.mass, 0.9906 | units.MSun, 4)
 
     def test8(self):
+        """
+        Test to check setting/getting the semi-major axis of a binary
+        """
         instance = self.new_instance_of_an_optional_code(SeBa)
         instance.parameters.supernova_kick_velocity = 0 | units.kms
         instance.commit_parameters()
         print("v_kick=", instance.parameters.supernova_kick_velocity)
         stars = Particles(2)
-        stars[0].mass = 10.0 | units.MSun
+        stars[0].mass = 10 | units.MSun
         stars[1].mass = 9 | units.MSun
 
         semi_major_axis = 10000 | units.AU


### PR DESCRIPTION
The SeBa test was giving errors due to masses/velocities not matching the output anymore. I think this is due to updates to SeBa related to massive stars, so I have updated the values. Please check if this is correct (@silviatoonen, @spzwart).