### PR TITLE
Allow negative weight in FiMap (e.g. velocities)

### DIFF
--- a/src/amuse/community/fi/src/makemapmod.f90
+++ b/src/amuse/community/fi/src/makemapmod.f90
@@ -226,10 +226,10 @@ end subroutine
    endif   
   endif
   if(extinction.EQ.1) then
-   if(pmass.GT.0.OR.popac.gt.0) call projectopacity(low,up,pic,opdepth, &
+   if(pmass.NE.0.OR.popac.gt.0) call projectopacity(low,up,pic,opdepth, &
                                   scratch,ppos,psize,pmass,popac,magic_number)
   else 
-   if(pmass.gt.0) call projectparticle(low,up,pic,scratch,ppos,psize,pmass)
+   if(pmass.ne.0) call projectparticle(low,up,pic,scratch,ppos,psize,pmass)
   endif
  enddo
 
@@ -322,13 +322,13 @@ end subroutine
 ! if(opac.gt.0) tau(i+n1:i+n2,j+m1:j+m2)=tau(i+n1:i+n2,j+m1:j+m2)*exp(-opac/2*pimage(n1:n2,m1:m2))
 ! if(opac.gt.0) tau(i+n1:i+n2,j+m1:j+m2)=tau(i+n1:i+n2,j+m1:j+m2)*exp(-opac/2*pimage(n1:n2,m1:m2))
 
-  if(mass.gt.0.and.opac.gt.0) then
+  if(mass.ne.0.and.opac.gt.0) then
 !   tau(i+n1:i+n2,j+m1:j+m2)=tau(i+n1:i+n2,j+m1:j+m2)*(1.-min(1.,opac/2*pimage(n1:n2,m1:m2)))
    img(i+n1:i+n2,j+m1:j+m2)=img(i+n1:i+n2,j+m1:j+m2)+mass*pimage(n1:n2,m1:m2)*tau(i+n1:i+n2,j+m1:j+m2)
    tau(i+n1:i+n2,j+m1:j+m2)=tau(i+n1:i+n2,j+m1:j+m2)*(1.-min(1.,opac*pimage(n1:n2,m1:m2)))
    return
   endif
-  if(mass.gt.0) img(i+n1:i+n2,j+m1:j+m2)=img(i+n1:i+n2,j+m1:j+m2)+mass*pimage(n1:n2,m1:m2)*tau(i+n1:i+n2,j+m1:j+m2)
+  if(mass.ne.0) img(i+n1:i+n2,j+m1:j+m2)=img(i+n1:i+n2,j+m1:j+m2)+mass*pimage(n1:n2,m1:m2)*tau(i+n1:i+n2,j+m1:j+m2)
   if(opac.gt.0) tau(i+n1:i+n2,j+m1:j+m2)=tau(i+n1:i+n2,j+m1:j+m2)*(1.-min(1.,opac*pimage(n1:n2,m1:m2)))
   
  end subroutine

--- a/src/amuse/community/fi/src/map_helpers.f90
+++ b/src/amuse/community/fi/src/map_helpers.f90
@@ -276,6 +276,7 @@ function map_remove_particle(id) result(ret)
     return
   endif  
 
+  mass(index)=0
   pindex(index)=-1
   nbod=nbod-1
 

--- a/src/amuse/community/fi/src/map_helpers.f90
+++ b/src/amuse/community/fi/src/map_helpers.f90
@@ -149,7 +149,7 @@ subroutine clean_array()
   i=0
   do while(n.LT.nbod)
     i=i+1
-    if(mass(i).GE.0) then
+    if(pindex(i).GE.0) then
       n=n+1
       mass(n)=mass(i)
       gpos(n,1:3)=gpos(i,1:3)
@@ -276,7 +276,7 @@ function map_remove_particle(id) result(ret)
     return
   endif  
 
-  mass(index)=-1
+  pindex(index)=-1
   nbod=nbod-1
 
   ret=0


### PR DESCRIPTION
Fix to allow the weight (mass) of a particle in FiMap to be negative (e.g. for using a velocity as weight)