### PR TITLE
Add opt-in support for ccache while installing via pip.

### DIFF
--- a/support/setup_codes.py
+++ b/support/setup_codes.py
@@ -7,6 +7,8 @@ import sys, os, re, subprocess
 import os.path
 import datetime
 import stat
+from copy import deepcopy
+from os.path import abspath
 
 from . import supportrc
 
@@ -847,11 +849,17 @@ class BuildCodes(CodeCommand):
             output.write('\n')
             output.flush()
         
+        if environment.get('AMUSE_USE_CCACHE', 0) != "1" or "CCACHE_BASEDIR" in environment:
+            build_environment = environment
+        else:
+            build_environment = deepcopy(environment)
+            build_environment["CCACHE_BASEDIR"] = abspath(directory)
+
         with open(buildlog, "ab") as output:
             result, resultcontent = self.call(
                 ['make','-C', directory, target], 
                 output,
-                env = environment
+                env = build_environment
             )
         
         with open(buildlog, "a") as output:


### PR DESCRIPTION
This PR is to keep the AMUSE and OMUSE `setup_codes.py`. In OMUSE I currently run tests against the tarballs created by `python setup.py sdist` instead of in place (like AMUSE), to ensure the generated sdists actually work. Unfortunately, `pip` will run the install in a randomized temporary directory, which breaks the ccache caching and makes the OMUSE CI really slow.

To workaround this, I changed `setup_codes.py` to look for `AMUSE_USE_CCACHE` in the environment and, if it is set, adding an appropriate `CCACHE_BASEDIR` before compiling the embedded code. This dramatically increases the cache hit rate of ccache on the CI.

The change only affects users who: 1) use ccache and 2) explicitly opt-in by setting `AMUSE_USE_CCACHE` in their environment (and even then only when there is no explicit `CCACHE_BASEDIR` is set), so it should be safe to merge.