### PR TITLE
add mpi_info_options keyword for code instantiation.

### DIFF
--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -912,7 +912,11 @@ class MpiChannel(AbstractMessageChannel):
             if self.job_scheduler:
                 self.info = self.get_info_from_job_scheduler(self.job_scheduler)
             else:
-                self.info = MPI.INFO_NULL
+                self.info = MPI.Info.Create()
+                
+        for key,value in self.mpi_info_options.items():     
+            print(key,value)
+            self.info[key]=value
             
         self.cached = None
         self.intercomm = None
@@ -981,7 +985,10 @@ class MpiChannel(AbstractMessageChannel):
     def debugger(self):
         """Name of the debugger to use when starting the code"""
         return "none"
-        
+
+    @option(type="dict", sections=("channel",))
+    def mpi_info_options(self):
+        return dict()
     
     @option(type="int", sections=("channel",))
     def max_message_length(self):

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -915,7 +915,6 @@ class MpiChannel(AbstractMessageChannel):
                 self.info = MPI.Info.Create()
                 
         for key,value in self.mpi_info_options.items():     
-            print(key,value)
             self.info[key]=value
             
         self.cached = None

--- a/src/amuse/support/options.py
+++ b/src/amuse/support/options.py
@@ -211,6 +211,14 @@ class option(object):
     def STRING(self, section, options):
         return options.get(section, self.name)
 
+    def DICT(self, section, options):
+        opts=options.get(section, self.name).split(",")
+        result=dict()
+        for o in opts:
+          key,value=o.split("=")
+          result[key.strip()]=value.strip()
+        return result
+
     def default_validator(self, value):
         return value
 


### PR DESCRIPTION
proposed solution for #760 and related. This allows setting mpi options for spawned processes.

This allows mpi_info key/value pairs to be passed on to the code. This can be used to for example specify processor binding on a per code basis. you still need to look up the right (and probably mpi implementation specific) mpi_info keywords though.

