### PR TITLE
fix MultiprocessingMPIChannel/ fix channel attributes

### DIFF
--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -568,6 +568,11 @@ class AbstractMessageChannel(OptionalAttributes):
     @classmethod
     def is_multithreading_supported(cls):
         return True
+
+    @option(type="boolean", sections=("channel",))
+    def initialize_mpi(self):
+        """Is MPI initialized in the code or not. Defaults to True if MPI is available"""
+        return config.mpi.is_enabled
             
     @option(type='string', sections=("channel",))
     def worker_code_suffix(self):
@@ -1429,7 +1434,7 @@ m.run_mpi_channel('{2}')"""
             block = client_socket.recv(block_size)
             blocks.append(block)
             bytes_left -= len(block)
-        return ''.join(blocks)
+        return bytearray().join(blocks)
         
             
     def _createAServerUNIXSocket(self, name_of_the_directory, name_of_the_socket=None):

--- a/src/amuse/rfi/core.py
+++ b/src/amuse/rfi/core.py
@@ -775,7 +775,7 @@ class CodeInterface(OptionalAttributes):
         self.channel.redirect_stdout_file = self.redirection_filenames[0]
         self.channel.redirect_stderr_file = self.redirection_filenames[1]
         self.channel.polling_interval_in_milliseconds = self.polling_interval_in_milliseconds
-        self.channel.initialize_mpi = self.initialize_mpi
+        #~ self.channel.initialize_mpi = self.initialize_mpi
         
         self.channel.start()
         
@@ -912,8 +912,6 @@ class CodeInterface(OptionalAttributes):
     def channel_type(self):
         return 'mpi'
     
-
-
     @option(type="boolean", sections=("channel",))
     def initialize_mpi(self):
         """Is MPI initialized in the code or not. Defaults to True if MPI is available"""


### PR DESCRIPTION
by itself not erribly important, but note that the direct setting of
channel attributes should move to __init__ or start() arguments