### PR TITLE
Make community codes slightly easier to import

### DIFF
--- a/src/amuse/community/aarsethzare/__init__.py
+++ b/src/amuse/community/aarsethzare/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Aarsethzare

--- a/src/amuse/community/adaptb/__init__.py
+++ b/src/amuse/community/adaptb/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Adaptb

--- a/src/amuse/community/asterisk/__init__.py
+++ b/src/amuse/community/asterisk/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Asterisk

--- a/src/amuse/community/athena/__init__.py
+++ b/src/amuse/community/athena/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Athena

--- a/src/amuse/community/bhtree/__init__.py
+++ b/src/amuse/community/bhtree/__init__.py
@@ -5,3 +5,4 @@ __author_email__ = '<spz@science.uva.nl>'
 __date__         = '2006-11-11 15:32:00 CEST'
 
 # Dummy file to indicate that this directory is a package.
+from .interface import Bhtree

--- a/src/amuse/community/bonsai/__init__.py
+++ b/src/amuse/community/bonsai/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Bonsai

--- a/src/amuse/community/bonsai2/__init__.py
+++ b/src/amuse/community/bonsai2/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Bonsai2

--- a/src/amuse/community/brutus/__init__.py
+++ b/src/amuse/community/brutus/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Brutus

--- a/src/amuse/community/bse/__init__.py
+++ b/src/amuse/community/bse/__init__.py
@@ -1,8 +1,1 @@
-"""
-The Astrophysical Multipurpose Software Environment
-
-AMUSE contains a lot of functionality to execute astrophysical experiments.
-Look into the interface packages for the interfacing to physical model simulation software.
-You can also use AMUSE to convert common data formats.
-
-"""
+from .interface import Bse

--- a/src/amuse/community/cachedse/__init__.py
+++ b/src/amuse/community/cachedse/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Cachedse

--- a/src/amuse/community/capreole/__init__.py
+++ b/src/amuse/community/capreole/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Capreole

--- a/src/amuse/community/distributed/__init__.py
+++ b/src/amuse/community/distributed/__init__.py
@@ -1,3 +1,4 @@
 # relative import hack
 # https://stackoverflow.com/questions/16981921/relative-imports-in-python-3
 import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+from .interface import Distributed

--- a/src/amuse/community/etics/__init__.py
+++ b/src/amuse/community/etics/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Etics

--- a/src/amuse/community/evtwin/__init__.py
+++ b/src/amuse/community/evtwin/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Evtwin

--- a/src/amuse/community/evtwin2sse/__init__.py
+++ b/src/amuse/community/evtwin2sse/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Evtwin2sse

--- a/src/amuse/community/fastkick/__init__.py
+++ b/src/amuse/community/fastkick/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Fastkick

--- a/src/amuse/community/fi/__init__.py
+++ b/src/amuse/community/fi/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Fi

--- a/src/amuse/community/flash/__init__.py
+++ b/src/amuse/community/flash/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Flash

--- a/src/amuse/community/fractalcluster/__init__.py
+++ b/src/amuse/community/fractalcluster/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Fractalcluster

--- a/src/amuse/community/gadget2/__init__.py
+++ b/src/amuse/community/gadget2/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Gadget2

--- a/src/amuse/community/galactics/__init__.py
+++ b/src/amuse/community/galactics/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Galactics

--- a/src/amuse/community/galaxia/__init__.py
+++ b/src/amuse/community/galaxia/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Galaxia

--- a/src/amuse/community/hacs64/__init__.py
+++ b/src/amuse/community/hacs64/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Hacs64

--- a/src/amuse/community/halogen/__init__.py
+++ b/src/amuse/community/halogen/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Halogen

--- a/src/amuse/community/hermite/__init__.py
+++ b/src/amuse/community/hermite/__init__.py
@@ -1,1 +1,1 @@
-
+from .interface import Hermite

--- a/src/amuse/community/higpus/__init__.py
+++ b/src/amuse/community/higpus/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Higpus

--- a/src/amuse/community/hop/__init__.py
+++ b/src/amuse/community/hop/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Hop

--- a/src/amuse/community/huayno/__init__.py
+++ b/src/amuse/community/huayno/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Huayno

--- a/src/amuse/community/kepler/__init__.py
+++ b/src/amuse/community/kepler/__init__.py
@@ -1,1 +1,1 @@
-
+from .interface import Kepler

--- a/src/amuse/community/kepler_orbiters/__init__.py
+++ b/src/amuse/community/kepler_orbiters/__init__.py
@@ -1,1 +1,1 @@
-
+from .interface import Kepler_orbiters

--- a/src/amuse/community/krome/__init__.py
+++ b/src/amuse/community/krome/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Krome

--- a/src/amuse/community/mameclot/__init__.py
+++ b/src/amuse/community/mameclot/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Mameclot

--- a/src/amuse/community/mercury/__init__.py
+++ b/src/amuse/community/mercury/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Mercury

--- a/src/amuse/community/mesa/__init__.py
+++ b/src/amuse/community/mesa/__init__.py
@@ -1,8 +1,1 @@
-"""
-The Astrophysical Multipurpose Software Environment
-
-AMUSE contains a lot of functionality to execute astrophysical experiments.
-Look into the interface packages for the interfacing to physical model simulation software.
-You can also use AMUSE to convert common data formats.
-
-"""
+from .interface import Mesa

--- a/src/amuse/community/mi6/__init__.py
+++ b/src/amuse/community/mi6/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Mi6

--- a/src/amuse/community/mikkola/__init__.py
+++ b/src/amuse/community/mikkola/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Mikkola

--- a/src/amuse/community/mmams/__init__.py
+++ b/src/amuse/community/mmams/__init__.py
@@ -1,1 +1,1 @@
-
+from .interface import Mmams

--- a/src/amuse/community/mmc/__init__.py
+++ b/src/amuse/community/mmc/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Mmc

--- a/src/amuse/community/mobse/__init__.py
+++ b/src/amuse/community/mobse/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Mobse

--- a/src/amuse/community/mocassin/__init__.py
+++ b/src/amuse/community/mocassin/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Mocassin

--- a/src/amuse/community/mosse/__init__.py
+++ b/src/amuse/community/mosse/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Mosse

--- a/src/amuse/community/mpiamrvac/__init__.py
+++ b/src/amuse/community/mpiamrvac/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Mpiamrvac

--- a/src/amuse/community/nbody6xx/__init__.py
+++ b/src/amuse/community/nbody6xx/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Nbody6xx

--- a/src/amuse/community/octgrav/__init__.py
+++ b/src/amuse/community/octgrav/__init__.py
@@ -5,3 +5,4 @@ __author_email__ = '<egaburov@science.uva.nl>,<djgroen@science.uva.nl>'
 __date__         = '2008-04-14 15:42:00 CEST'
 
 # Dummy file to indicate that this directory is a package.
+from .interface import Octgrav

--- a/src/amuse/community/petar/__init__.py
+++ b/src/amuse/community/petar/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Petar

--- a/src/amuse/community/ph4/__init__.py
+++ b/src/amuse/community/ph4/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Ph4

--- a/src/amuse/community/phantom/__init__.py
+++ b/src/amuse/community/phantom/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Phantom

--- a/src/amuse/community/phigrape/__init__.py
+++ b/src/amuse/community/phigrape/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Phigrape

--- a/src/amuse/community/pikachu/__init__.py
+++ b/src/amuse/community/pikachu/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Pikachu

--- a/src/amuse/community/rebound/__init__.py
+++ b/src/amuse/community/rebound/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Rebound

--- a/src/amuse/community/sakura/__init__.py
+++ b/src/amuse/community/sakura/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Sakura

--- a/src/amuse/community/seba/__init__.py
+++ b/src/amuse/community/seba/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Seba

--- a/src/amuse/community/secularmultiple/__init__.py
+++ b/src/amuse/community/secularmultiple/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Secularmultiple

--- a/src/amuse/community/sei/__init__.py
+++ b/src/amuse/community/sei/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Sei

--- a/src/amuse/community/simplex/__init__.py
+++ b/src/amuse/community/simplex/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Simplex

--- a/src/amuse/community/smalln/__init__.py
+++ b/src/amuse/community/smalln/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Smalln

--- a/src/amuse/community/sphray/__init__.py
+++ b/src/amuse/community/sphray/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Sphray

--- a/src/amuse/community/sse/__init__.py
+++ b/src/amuse/community/sse/__init__.py
@@ -5,3 +5,4 @@ __author_email__ = '<Steve@physics.drexel.edu>'
 __date__         = '2007-12-06'
 
 # Dummy file to indicate that this directory is a package.
+from .interface import Sse

--- a/src/amuse/community/symple/__init__.py
+++ b/src/amuse/community/symple/__init__.py
@@ -1,1 +1,2 @@
 # generated file
+from .interface import Symple

--- a/src/amuse/community/tupan/__init__.py
+++ b/src/amuse/community/tupan/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Tupan

--- a/src/amuse/community/twobody/__init__.py
+++ b/src/amuse/community/twobody/__init__.py
@@ -1,0 +1,1 @@
+from .interface import Twobody


### PR DESCRIPTION
Removes the need for `.interface` in the import line: a community code can now be imported as `from amuse.community.codename import Codename`
Relates to #132 