### PR TITLE
Expose setting the location of MESA_DIR/data

### DIFF
--- a/src/amuse/community/mesa_r15140/interface.f90
+++ b/src/amuse/community/mesa_r15140/interface.f90
@@ -1,7 +1,7 @@
 module amuse_support
    implicit none
    character (len=4096) :: AMUSE_inlist_path
-   character (len=4096) :: AMUSE_mesa_dir
+   character (len=4096) :: AMUSE_mesa_dir,AMUSE_mesa_data_dir ! Normally $MESA_DIR and $MESA_DIR/data
    character (len=4096) :: AMUSE_local_data_dir ! Used for output starting_models
    character (len=4096) :: AMUSE_gyre_in_file 
    character (len=4096) :: AMUSE_temp_dir ! Used for mesa_temp_caches support
@@ -40,15 +40,17 @@ module amuse_mesa
 
 ! Set the paths to the inlist and the data directory
    integer function set_MESA_paths(AMUSE_inlist_path_in, &
-         AMUSE_mesa_dir_in, AMUSE_local_data_dir_in, AMUSE_gyre_in_file_in,&
+         AMUSE_mesa_dir_in, AMUSE_mesa_data_dir_in, &
+         AMUSE_local_data_dir_in, AMUSE_gyre_in_file_in,&
          AMUSE_temp_dir_in)
       
       character(*), intent(in) :: AMUSE_inlist_path_in, &
          AMUSE_mesa_dir_in, AMUSE_local_data_dir_in,  AMUSE_gyre_in_file_in, &
-         AMUSE_temp_dir_in
+         AMUSE_temp_dir_in, AMUSE_mesa_data_dir_in
 
       AMUSE_inlist_path = AMUSE_inlist_path_in
       AMUSE_mesa_dir = AMUSE_mesa_dir_in
+      AMUSE_mesa_data_dir = AMUSE_mesa_data_dir_in
       AMUSE_local_data_dir = AMUSE_local_data_dir_in
       AMUSE_gyre_in_file =  AMUSE_gyre_in_file_in
       AMUSE_temp_dir = AMUSE_temp_dir_in
@@ -228,6 +230,7 @@ module amuse_mesa
       call set_init_options(AMUSE_id, &
                            AMUSE_mass, &
                            AMUSE_mesa_dir, &
+                           AMUSE_mesa_data_dir, &
                            AMUSE_local_data_dir, &
                            AMUSE_inlist_path, &
                            AMUSE_metallicity,&

--- a/src/amuse/community/mesa_r15140/interface.py
+++ b/src/amuse/community/mesa_r15140/interface.py
@@ -97,6 +97,9 @@ class MESAInterface(
             'mesa_dir', dtype='string', direction=function.IN,
             description="Path to the MESA directory.")
         function.addParameter(
+            'mesa_data_dir', dtype='string', direction=function.IN,
+            description="Path to the MESA data directory. Normally this would be mesa_dir/data")
+        function.addParameter(
             'local_data_path', dtype='string', direction=function.IN,
             description="Path to the data directory.")
         function.addParameter(
@@ -1130,6 +1133,7 @@ class MESA(StellarEvolution, InternalStellarStructure):
         self.set_MESA_paths(
             inlist,
             self.default_path_to_MESA,
+            self.default_path_to_MESA_data,
             output_dir,
             gyre_in,
             self.default_tmp_dir
@@ -1726,7 +1730,7 @@ class MESA(StellarEvolution, InternalStellarStructure):
 
         handler.add_method(
             "set_MESA_paths",
-            (handler.NO_UNIT,handler.NO_UNIT,handler.NO_UNIT,handler.NO_UNIT,handler.NO_UNIT),
+            (handler.NO_UNIT,handler.NO_UNIT,handler.NO_UNIT,handler.NO_UNIT,handler.NO_UNIT,handler.NO_UNIT),
             (handler.ERROR_CODE,)
         )
 

--- a/src/amuse/community/mesa_r15140/mesa_interface.f90
+++ b/src/amuse/community/mesa_r15140/mesa_interface.f90
@@ -295,6 +295,7 @@ module mesa_interface
     subroutine  set_init_options(id, &
                                 mass, &
                                 mesa_dir_in, &
+                                mesa_data_dir_in, &
                                 output_folder, &
                                 inlist, &
                                 metallicity,&
@@ -305,7 +306,7 @@ module mesa_interface
                                 temp_dir &
                                 )
         integer, intent(in) :: id
-        character(len=*), intent(in) :: mesa_dir_in, output_folder, inlist, gyre_in, temp_dir
+        character(len=*), intent(in) :: mesa_dir_in, mesa_data_dir_in, output_folder, inlist, gyre_in, temp_dir
         real(dp), intent(in) :: mass, metallicity,&
                                 max_age_stop_condition, &
                                 min_timestep_stop_condition
@@ -324,6 +325,8 @@ module mesa_interface
 
         call const_init(mesa_dir_in, ierr)
         if (failed('const_init',ierr)) return 
+
+        mesa_data_dir = mesa_data_dir_in
 
         s% inlist_fname = inlist
 


### PR DESCRIPTION
Exposes the ability to change where MESA read/writes data files from/to.

Works on #872 