### PR TITLE
Add SYCLIST 

### DIFF
--- a/src/amuse/community/syclist/Makefile
+++ b/src/amuse/community/syclist/Makefile
@@ -1,0 +1,44 @@
+# standard amuse configuration include
+# config.mk will be made after ./configure has run
+ifeq ($(origin AMUSE_DIR), undefined)
+  AMUSE_DIR := $(shell amusifier --get-amuse-dir)
+endif
+-include $(AMUSE_DIR)/config.mk
+
+MPIFC ?= mpif90
+FC      = $(MPIFC)
+AR = ar ruv
+RANLIB = ranlib
+RM = rm
+
+FCFLAGS+= -Isrc/SYCLIST
+LDFLAGS  += -lm $(MUSE_LD_FLAGS)
+
+OBJS = interface.o
+
+CODEDIR = src/SYCLIST
+CODELIB = $(CODEDIR)/libsyclist.a
+
+
+all: syclist_worker 
+
+clean:
+	$(RM) -rf __pycache__
+	$(RM) -f *.so *.o *.pyc worker_code.cc worker_code.h 
+	$(RM) *~ worker_code worker_code.f90
+	make -C $(CODEDIR) clean
+
+distclean: clean
+	make -C $(CODEDIR) distclean
+
+$(CODELIB):
+	make -C $(CODEDIR) libsyclist.a
+
+worker_code.f90: interface.py
+	$(CODE_GENERATOR) --type=f90 interface.py SyclistInterface -o $@
+
+syclist_worker: worker_code.f90 $(CODELIB) $(OBJS)
+	$(MPIFC) $(FCFLAGS) $(FS_FLAGS) $< $(OBJS) $(CODELIB) $(FS_LIBS) -o $@
+
+%.o: %.f90
+	$(FC) $(FCFLAGS) -c -o $@ $<

--- a/src/amuse/community/syclist/Makefile
+++ b/src/amuse/community/syclist/Makefile
@@ -7,9 +7,6 @@ endif
 
 MPIFC ?= mpif90
 FC      = $(MPIFC)
-AR = ar ruv
-RANLIB = ranlib
-RM = rm
 
 FCFLAGS+= -Isrc/SYCLIST
 LDFLAGS  += -lm $(MUSE_LD_FLAGS)
@@ -20,7 +17,13 @@ CODEDIR = src/SYCLIST
 CODELIB = $(CODEDIR)/libsyclist.a
 
 
+DOWNLOAD_FROM_WEB = $(PYTHON) ./download.py
+
+
 all: syclist_worker 
+
+download:
+	$(DOWNLOAD_FROM_WEB)
 
 clean:
 	$(RM) -rf __pycache__
@@ -31,7 +34,7 @@ clean:
 distclean: clean
 	make -C $(CODEDIR) distclean
 
-$(CODELIB):
+$(CODELIB): #download
 	make -C $(CODEDIR) libsyclist.a
 
 worker_code.f90: interface.py

--- a/src/amuse/community/syclist/__init__.py
+++ b/src/amuse/community/syclist/__init__.py
@@ -1,0 +1,1 @@
+# generated file

--- a/src/amuse/community/syclist/download.py
+++ b/src/amuse/community/syclist/download.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+import subprocess
+import os
+import urllib.request
+import urllib.parse
+import urllib.error
+from shutil import which
+from optparse import OptionParser
+
+
+class GetCodeFromHttp:
+    filename_template = "{version}.tar.gz"
+    name = "SYCLIST"
+    url_template = "https://github.com/GESEG/SYCLIST/archive/{version}.tar.gz"
+    version = ""
+
+    def directory(self):
+        return os.path.abspath(os.path.dirname(__file__))
+
+    def src_directory(self):
+        return os.path.join(self.directory(), 'src')
+
+    def unpack_downloaded_file(self, filename, name, version):
+        print("unpacking", filename)
+        arguments = ['tar', '-xf']
+        arguments.append(filename)
+        subprocess.call(
+            arguments,
+            cwd=os.path.join(self.src_directory())
+        )
+        subprocess.call(
+            [
+                'mv', f'{name}-{version}',
+                name
+            ],
+            cwd=os.path.join(self.src_directory())
+        )
+        print("done")
+
+    def start(self):
+        if os.path.exists('src'):
+            counter = 0
+            while os.path.exists(f'src.{counter}'):
+                counter += 1
+                if counter > 100:
+                    print("too many backup directories")
+                    break
+            os.rename('src', f'src.{counter}')
+
+        os.mkdir('src')
+
+        url = self.url_template.format(version=self.version)
+        filename = self.filename_template.format(version=self.version)
+        filepath = os.path.join(self.src_directory(), filename)
+        print(
+            f"downloading version {self.version}"
+            f"from {url} to {filename}"
+        )
+        if which('wget') is not None:
+            arguments = ['wget', url]
+            subprocess.call(
+                arguments,
+                cwd=os.path.join(self.src_directory())
+            )
+        elif which('curl') is not None:
+            arguments = ['curl', '-L', '-O', url]
+            subprocess.call(
+                arguments,
+                cwd=os.path.join(self.src_directory())
+            )
+        else:
+            urllib.request.urlretrieve(url, filepath)
+        print("downloading finished")
+        self.unpack_downloaded_file(
+            filename, self.name, self.version
+        )
+
+
+def main(version=''):
+    instance = GetCodeFromHttp()
+    instance.version = version
+    instance.start()
+
+
+def new_option_parser():
+    result = OptionParser()
+    result.add_option(
+        "--version",
+        default='a38f080e50f157b92684df61e678f97faf24d68e',
+        dest="version",
+        help="SYCLIST commit hash to download",
+        type="string"
+    )
+    return result
+
+
+if __name__ == "__main__":
+    options, arguments = new_option_parser().parse_args()
+    main(**options.__dict__)

--- a/src/amuse/community/syclist/interface.f90
+++ b/src/amuse/community/syclist/interface.f90
@@ -1,0 +1,310 @@
+function initialize_code()
+  use DataStructure, only: verbose
+  use VariousParameters, only: Std_Path,Std_Path_tables
+  use VariousParameters, only: grid, table_format, PMS, star_number, i_metallicity, &
+          fixed_metallicity, IMF_type, m_IMF_inf, m_IMF_sup, ivdist, om_ivdist, &
+          iangle, Fixed_AoV_latitude, inoise, sigma_mv, sigma_bv, binary_prob, &
+          Colour_Calibration_mode, grav_dark, limb_dark
+  use Population_Mode, only: Pop_Mass_Beam_Number, Pop_Omega_Beam_Number, N_Time_step
+  implicit none
+  integer :: initialize_code
+
+  ! Set default values.
+  ! Not all of these are used in AMUSE but we set them just in case for now.
+  verbose = .true.  ! Control output with 'redirection' option in AMUSE
+  ! Root path for Syclist data. Should move to AMUSE data dir at some point.
+  Std_Path = './src/SYCLIST'  
+  Std_Path_tables = trim(Std_Path)//'/tables/'
+  Std_Path = trim(Std_Path)//'/inputs/'
+
+  !grid = 'BeGrids'
+  grid = 'Grids2012'
+  table_format = 1
+  PMS = .false.
+  star_number = 1
+  i_metallicity = 0
+  fixed_metallicity = 0.014d0
+  IMF_type = 1
+  m_IMF_inf = 0.8d0
+  m_IMF_sup = 120.d0
+  ivdist = 2
+  om_ivdist = 0.4d0
+  iangle = 0
+  Fixed_AoV_latitude = 22.d0
+  inoise = 0
+  sigma_mv = 0.01d0
+  sigma_bv = 0.0025d0
+  binary_prob = 0.d0
+  Colour_Calibration_mode = 2
+  grav_dark = 2
+  limb_dark = 0
+
+  Pop_Mass_Beam_Number = 2000
+  Pop_Omega_Beam_Number = 100
+  N_Time_step = 500
+
+  initialize_code = 0
+end function
+
+function set_models_path(path)
+  use VariousParameters, only: Std_Path
+  implicit none
+  character(256) :: path
+  integer :: set_models_path
+  Std_Path = path
+  set_models_path = 0
+end function
+
+function get_models_path(path)
+  use VariousParameters, only: Std_Path
+  implicit none
+  character(256) :: path
+  integer :: get_models_path
+  path = Std_Path
+  get_models_path = 0
+end function
+
+function evolve_star(&
+                age, initial_mass, metallicity, omega,&
+                mass, luminosity, temperature,&
+                ab_surf_H1, ab_surf_He4, ab_surf_C12, ab_surf_C13, ab_surf_N14,&
+                ab_surf_O16, ab_surf_O17, ab_surf_O18, ab_surf_Ne20, ab_surf_Ne22,&
+                ab_surf_Al26, MccMt, temperature_wr, Md, rhoc, ab_core_H1, ab_core_He4,&
+                ab_core_C12, ab_core_C13, ab_core_N14, ab_core_O16, ab_core_O17, ab_core_Ne20,&
+                ab_core_Ne22, ab_core_Al26, omega_surf, omega_core, RpReq, MdMd0,&
+                v_crit1, v_crit2, v_eq, OmOmcr, Gamma_Ed, MdotMech, Ltot,&
+                !StarType, &
+                n&
+                )
+  use DataStructure, only: Table_Line_Number
+  use DataStructure, only: &
+      i_mass,i_logL,i_logTeff_corr,i_H1_Surf,i_He4_surf,i_C12_surf,i_C13_surf,i_N14_surf, &
+      i_O16_surf,i_O17_surf,i_O18_surf,i_Ne20_surf,i_Ne22_surf,i_Al26_surf,i_logTeff,i_Mdot, &
+      i_Omega_surf,i_oblat,i_v_crit1,i_v_crit2,i_v_equa,i_Omega_Omcrit,i_Gamma_Ed,i_Mdot_mec, &
+      i_PolarRadius,i_polar_gravity,Table_Line_Number,Data_Number,i_MV_noisy,i_BV_noisy,&
+      i_MBol,i_MV,i_UB,i_BV,i_B2V1,i_VK,i_VR,i_VI,i_JK,i_HK,i_BC,i_logL_gd,i_logTeff_gd,i_logL_lgd, &
+      i_logTeff_lgd,i_mean_gravity,i_GV,i_GbpV,i_GrpV,i_Gflag,i_crossing_nb_F,i_crossing_nb_1O,i_P_F, &
+      i_Pdot_P_F,i_omi_omr_F,i_P_1O,i_Pdot_P_1O,i_omi_omr_1O, &
+      i_al26_cen, i_c12_cen, i_c13_cen, i_h1_cen, i_he4_cen, i_l_tot, i_mcc, i_mdot_enhencement, &
+      i_n14_cen, i_ne20_cen, i_ne22_cen, i_o16_cen, i_o17_cen, i_omega_cen, i_rhoc
+  use InterpolationLoop, only:Initialise_Position_and_factor
+  use interpolmod, only: All_Positions_and_factors,Make_InterpolatedModel,Make_TimeModel
+  use Additional_Data, only: Compute_Additional,Compute_Additional_Single
+  use VariousParameters, only:&
+          Comp_Mode,age_log,init_AoV,&
+          Star_Z,Star_mass,Star_omega,Star_AoV,Fixed_AoV,Current_Number,&
+          Z_Number, Z_List
+  use VariousParameters, only: inoise,iangle,star_number
+  use LoopVariables, only:&
+          Z_Position,Z_factor,omega_Position,omega_factor,&
+          mass_Position,mass_factor,Interpolated_Model,CurrentTime_Model
+  implicit none
+  integer :: n, i
+  double precision :: age(n), initial_mass(n), metallicity(n), omega(n) !in
+  double precision :: mass(n), luminosity(n), temperature(n),&
+          ab_surf_H1(n), ab_surf_He4(n), ab_surf_C12(n), ab_surf_C13(n), ab_surf_N14(n),&
+          ab_surf_O16(n), ab_surf_O17(n), ab_surf_O18(n), ab_surf_Ne20(n), ab_surf_Ne22(n),&
+          ab_surf_Al26(n), MccMt(n), temperature_wr(n), Md(n), rhoc(n), ab_core_H1(n), ab_core_He4(n),&
+          ab_core_C12(n), ab_core_C13(n), ab_core_N14(n), ab_core_O16(n), ab_core_O17(n), ab_core_Ne20(n),&
+          ab_core_Ne22(n), ab_core_Al26(n), omega_surf(n), omega_core(n), RpReq(n), MdMd0(n),&
+          v_crit1(n), v_crit2(n), v_eq(n), OmOmcr(n), Gamma_Ed(n), MdotMech(n), Ltot(n)
+  integer :: evolve_star
+  !integer :: StarType(n)
+
+  ! StarTypes:
+  ! positives:
+  ! stars that can be calculated with Syclist
+  ! negatives:
+  ! stars that fall outside the scope
+  ! Numbers are from AMUSE
+  !  "deeply or fully convective low mass MS star",  # 0
+  !  "Main Sequence star",  # 1
+  !  "Hertzsprung Gap",  # 2
+  !  "First Giant Branch",  # 3
+  !  "Core Helium Burning",  # 4
+  !  "First Asymptotic Giant Branch",  # 5
+  !  "Second Asymptotic Giant Branch",  # 6
+  !  "Main Sequence Naked Helium star",  # 7
+  !  "Hertzsprung Gap Naked Helium star",  # 8
+  !  "Giant Branch Naked Helium star",  # 9
+  !  "Helium White Dwarf",  # 10
+  !  "Carbon/Oxygen White Dwarf",  # 11
+  !  "Oxygen/Neon White Dwarf",  # 12
+  !  "Neutron Star",  # 13
+  !  "Black Hole",  # 14
+  !  "Massless Supernova",  # 15
+  !  "Unknown stellar type",  # 16
+  !  "Pre-main-sequence Star",  # 17
+  !  "Planet",  # 18
+  !  "Brown Dwarf",  # 19
+
+  !Comp_Mode = 1  ! stellar cluster
+  !Comp_Mode = 2  ! isochrones
+  !Comp_Mode = 3  ! population as a function of time
+  Comp_Mode = 4  ! single star
+  
+  i = 1  
+  Current_Number = 1
+
+  !write(*,*) metallicity(i), initial_mass(i), omega(i), log10(age(i)), n
+
+  do while (i <= n)
+  !StarType = 1  ! Main sequence star as default
+
+  ! Make sure metallicity is in the range of models, and adjust if needed.
+  Star_Z = metallicity(i)
+  if (Star_Z < Z_List(1)) then
+          Star_Z = Z_List(1)
+  else if (Star_Z > Z_List(Z_Number)) then
+          Star_Z = Z_List(Z_Number)
+  end if
+  metallicity(i) = Star_Z
+
+  Star_mass = initial_mass(i)
+  Star_omega = omega(i)
+  Star_AoV = Fixed_AoV
+  age_log = log10(age(i))  ! age in (julian)year?
+
+  !write(*,*) Star_mass, Star_Z, Star_omega, age_log
+
+  !call Amuse_SingleModelMode
+  inoise = 0
+  if (iangle /= 3) then
+          iangle = 0
+  endif
+
+  ! Number of stars to compute
+  star_number = Table_Line_Number
+  
+  call init_AoV
+  ! if (iangle == 4) then
+  !   call init_angle_external
+  ! endif
+
+  call Initialise_Position_and_factor(&
+          Z_Position,Z_factor,mass_Position,mass_factor,omega_Position, &
+          omega_factor)
+
+  call All_Positions_and_factors(&
+          Star_Z,Z_Position,Z_factor,Star_mass,mass_Position(:),mass_factor(:), &
+          Star_omega,omega_Position(:,:),omega_factor(:,:))
+
+  ! Perform the interpolation
+  call Make_InterpolatedModel(&
+          Z_Position,Z_factor,mass_Position,mass_factor,omega_Position, &
+          omega_factor,Interpolated_Model)
+
+  call Make_TimeModel(Interpolated_Model,age_log,CurrentTime_Model(Current_Number))
+  call Compute_Additional(CurrentTime_Model(Current_Number))
+  
+  !! Computation of the additional quantities.
+  !Call Compute_Additional_Single(&
+  !        Interpolated_Model,Star_AoV,CurrentTime_Model,Table_Line_Number)
+
+  !call WriteResults(table_format)
+  mass(i) = CurrentTime_Model(Current_Number)%Data_Line(i_mass)
+  luminosity(i) = 10**(CurrentTime_Model(Current_Number)%Data_Line(i_logL))
+  temperature(i) = 10**(CurrentTime_Model(Current_Number)%Data_Line(i_logTeff))
+  ab_surf_H1(i) = CurrentTime_Model(Current_Number)%Data_Line(i_H1_Surf)
+  ab_surf_He4(i) = CurrentTime_Model(Current_Number)%Data_Line(i_He4_Surf)
+  ab_surf_C12(i) = CurrentTime_Model(Current_Number)%Data_Line(i_C12_Surf)
+  ab_surf_C13(i) = CurrentTime_Model(Current_Number)%Data_Line(i_C13_Surf)
+  ab_surf_N14(i) = CurrentTime_Model(Current_Number)%Data_Line(i_N14_Surf)
+  ab_surf_O16(i) = CurrentTime_Model(Current_Number)%Data_Line(i_O16_Surf)
+  ab_surf_O17(i) = CurrentTime_Model(Current_Number)%Data_Line(i_O17_Surf)
+  ab_surf_O18(i) = CurrentTime_Model(Current_Number)%Data_Line(i_O18_Surf)
+  ab_surf_Ne20(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Ne20_Surf)
+  ab_surf_Ne22(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Ne22_Surf)
+  ab_surf_Al26(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Al26_Surf)
+  MccMt(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Mcc)
+  temperature_wr(i) = CurrentTime_Model(Current_Number)%Data_Line(i_logTeff_corr)
+  Md(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Mdot)
+  rhoc(i) = CurrentTime_Model(Current_Number)%Data_Line(i_rhoc)
+  ab_core_H1(i) = CurrentTime_Model(Current_Number)%Data_Line(i_H1_cen)
+  ab_core_He4(i) = CurrentTime_Model(Current_Number)%Data_Line(i_He4_cen)
+  ab_core_C12(i) = CurrentTime_Model(Current_Number)%Data_Line(i_C12_cen)
+  ab_core_C13(i) = CurrentTime_Model(Current_Number)%Data_Line(i_C13_cen)
+  ab_core_N14(i) = CurrentTime_Model(Current_Number)%Data_Line(i_N14_cen)
+  ab_core_O16(i) = CurrentTime_Model(Current_Number)%Data_Line(i_O16_cen)
+  ab_core_O17(i) = CurrentTime_Model(Current_Number)%Data_Line(i_O17_cen)
+  ab_core_Ne20(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Ne20_cen)
+  ab_core_Ne22(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Ne22_cen)
+  ab_core_Al26(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Al26_cen)
+  omega_surf(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Omega_surf)
+  omega_core(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Omega_cen)
+  RpReq(i) = CurrentTime_Model(Current_Number)%Data_Line(i_oblat) ! ?
+  MdMd0(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Mdot_enhencement) ! ?
+  v_crit1(i) = CurrentTime_Model(Current_Number)%Data_Line(i_v_crit1)
+  v_crit2(i) = CurrentTime_Model(Current_Number)%Data_Line(i_v_crit2)
+  v_eq(i) = CurrentTime_Model(Current_Number)%Data_Line(i_v_equa)
+  OmOmcr(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Omega_Omcrit)
+  Gamma_Ed(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Gamma_Ed)
+  MdotMech(i) = CurrentTime_Model(Current_Number)%Data_Line(i_Mdot_mec)
+  Ltot(i) = CurrentTime_Model(Current_Number)%Data_Line(i_L_tot)
+  i = i + 1
+  end do
+  evolve_star=0
+end function
+
+function evolve_for(index_of_the_star, delta_t)
+  implicit none
+  integer :: index_of_the_star
+  double precision :: delta_t
+  integer :: evolve_for
+  evolve_for=0
+end function
+
+function recommit_particles()
+  implicit none
+  integer :: recommit_particles
+  recommit_particles=0
+end function
+
+function cleanup_code()
+  implicit none
+  integer :: cleanup_code
+  cleanup_code=0
+end function
+
+function recommit_parameters()
+  implicit none
+  integer :: recommit_parameters
+  recommit_parameters=0
+end function
+
+function evolve_one_step(index_of_the_star)
+  implicit none
+  integer :: index_of_the_star
+  integer :: evolve_one_step
+  evolve_one_step=0
+end function
+
+function commit_parameters()
+  use ReadData, only: &
+          init_Huang,init_HG,init_Correction,init_VcritOmega, init_SurfaceOmega, init_Correct_fact
+  use InOut, only: InitialiseData
+  use InterpolationLoop, only: Initialise
+  use VariousParameters, only: Comp_Mode
+
+  implicit none
+  integer :: commit_parameters
+
+  call init_Huang
+  call init_HG
+  call init_Correction
+  call init_VcritOmega
+  call init_SurfaceOmega
+  call init_Correct_fact
+  Comp_Mode = 4
+
+  ! Various initialisations
+  call Initialise
+
+  ! Searching, opening, sorting and reading evolution files. These files must be listed (with the whole
+  ! access path) in a file called "ListFile.txt".
+  call InitialiseData
+
+  commit_parameters=0
+end function
+
+

--- a/src/amuse/community/syclist/interface.py
+++ b/src/amuse/community/syclist/interface.py
@@ -1,0 +1,422 @@
+from amuse.units import units
+from amuse.community import (
+    CodeInterface,
+    LegacyFunctionSpecification,
+    legacy_function,
+    LiteratureReferencesMixIn, CodeWithDataDirectories,
+    InCodeComponentImplementation,
+    NO_UNIT,
+)
+from amuse.community.interface.common import (
+    CommonCodeInterface,
+    CommonCode,
+)
+# from amuse.community.interface.se import (
+#     StellarEvolutionInterface,
+#     StellarEvolution
+# )
+from amuse.datamodel import Particles, ParticlesSubset
+
+
+class SyclistInterface(
+    CodeInterface,
+    CommonCodeInterface,
+    CodeWithDataDirectories,
+    LiteratureReferencesMixIn,
+):
+    """
+    You have used the SYCLIST population synthesis code.
+        .. [#] [2014A&A...566A..21G] Georgy et al., 2014
+
+    Isochrones are calculated on the basis of the following grids of stellar
+    models:
+
+    B-type stars grids:
+    - M = 1.7 - 15 M⊙
+    - Ω/Ωcrit = 0.0, 0.1, 0.3, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95
+    - Z = 0.014 (=Z⊙), 0.006, 0.002
+
+        .. [#] Georgy et al. (2013), A&A 553 A24
+
+    large grids:
+    - M = 0.8 - 120 M⊙
+    - V/Vcrit = 0.0, 0.4 (i.e. Ω/Ωcrit = 0.0, 0.568)
+    - Z = 0.020, 0.014 (=Z⊙), 0.006, 0.002, 0.0004
+
+    published in:
+        .. [#] Yusof et al. (2022), MNRAS 511 2814 (Z=0.020)
+        .. [#] Ekström et al. (2012), A&A 537 A146 (Z=0.014=Z⊙)
+        .. [#] Eggenberger et al. (2021) A&A 652 A137 (Z=0.006)
+        .. [#] Georgy et al. (2013) A&A 558 A103 (Z=0.002)
+        .. [#] Groh et al. (2019) A&A 627 A24 (Z=0.0004)
+        .. [#] Yusof et al. (2013) MNRAS 433 1114 (M≥150 M⊙)
+    NB: the most massive models (150-500 M⊙) have been evolved without the
+        insurance of angular momentum conservation.
+
+    low-mass stars dense grids:
+    - M = 0.5 - 3.5 M⊙
+    - Z = 0.006, 0.010, 0.014 (=Z⊙), 0.020, 0.030, 0.040
+    - no rotation
+
+    published in:
+        .. [#] Mowlavi et al. (2012), A&A 541 A41
+
+    very low-mass stars grids:
+    - M = 0.2 - 1.5 M⊙
+    - [Fe/H] = -1.0, -0.5, -0.3, -0.15, 0, 0.15, 0.3
+    - no rotation, slow-, medium-, fast-rotation
+     
+    published in:
+        .. [#] Amard et al. (2019), A&A 631 A77
+    """
+
+    def __init__(self, **keyword_arguments):
+        CodeInterface.__init__(
+            self, name_of_the_worker="syclist_worker",
+            **keyword_arguments
+        )
+        LiteratureReferencesMixIn.__init__(self)
+
+    @legacy_function
+    def set_models_path():
+        function = LegacyFunctionSpecification()
+        function.addParameter(
+            'modelpath', dtype='string', direction=function.IN,
+            description="Path from which the models are read",
+        )
+        function.result_type = 'int32'
+        function.result_doc = ''
+        return function
+
+    @legacy_function
+    def get_models_path():
+        function = LegacyFunctionSpecification()
+        function.addParameter(
+            'modelpath', dtype='string', direction=function.OUT,
+            description="Path from which the models are read",
+        )
+        function.result_type = 'int32'
+        function.result_doc = ''
+        return function
+
+    @legacy_function
+    def evolve_star():
+        function = LegacyFunctionSpecification()
+        # function.name = 'evolve_star'
+        # function.can_handle_array = True
+        function.must_handle_array = True
+        stellar_properties = {
+            'age': [0., units.julianyr],
+            'initial_mass': [0., units.MSun],
+            'metallicity': [0.014, NO_UNIT],
+            'omega': [0., NO_UNIT],
+            'mass': [0., units.MSun],
+            'luminosity': [0., units.LSun],
+            'temperature': [0., units.K],
+            'abundance_1H': [0., NO_UNIT],
+            'abundance_4He': [0., NO_UNIT],
+            'abundance_12C': [0., NO_UNIT],
+            'abundance_13C': [0., NO_UNIT],
+            'abundance_14N': [0., NO_UNIT],
+            'abundance_16O': [0., NO_UNIT],
+            'abundance_17O': [0., NO_UNIT],
+            'abundance_18O': [0., NO_UNIT],
+            'abundance_20Ne': [0., NO_UNIT],
+            'abundance_22Ne': [0., NO_UNIT],
+            'abundance_26Al': [0., NO_UNIT],
+            'MccMt': [0., NO_UNIT],
+            'temperature_wr': [0., units.K],
+            'Md': [0., NO_UNIT],
+            'rhoc': [0., NO_UNIT],
+            'abundance_core_1H': [0., NO_UNIT],
+            'abundance_core_4He': [0., NO_UNIT],
+            'abundance_core_12C': [0., NO_UNIT],
+            'abundance_core_13C': [0., NO_UNIT],
+            'abundance_core_14N': [0., NO_UNIT],
+            'abundance_core_16O': [0., NO_UNIT],
+            'abundance_core_17O': [0., NO_UNIT],
+            'abundance_core_20Ne': [0., NO_UNIT],
+            'abundance_core_22Ne': [0., NO_UNIT],
+            'abundance_core_26Al': [0., NO_UNIT],
+            'omega_surface': [0., units.s**-1],
+            'omega_core': [0., units.s**-1],
+            'RpReq': [0., NO_UNIT],
+            'MdMd0': [0., NO_UNIT],
+            'v_crit1': [0., units.kms],
+            'v_crit2': [0., units.kms],
+            'v_equator': [0., units.kms],
+            'OmOmcr': [0., NO_UNIT],
+            'Gamma_Ed': [0., NO_UNIT],
+            'MdotMech': [0., units.MSun/units.yr],
+            'Ltot': [0., 10**53*units.g*units.cm**2/units.s],
+        }
+        for stellar_property in stellar_properties.items():
+            function.addParameter(
+                stellar_property[0],
+                dtype='float64',
+                direction=function.INOUT,
+                unit=stellar_property[1][1],
+            )
+        function.addParameter(
+            'n',
+            dtype='int64',
+            direction=function.LENGTH,
+        )
+
+        return function
+
+    def recommit_particles(self):
+        return 0
+
+    def commit_particles(self):
+        return 0
+
+
+class SyclistParticles(
+    Particles
+):
+    def __init__(self, code_interface, storage=None):
+        Particles.__init__(self, storage=storage)
+        self._private.code_interface = code_interface
+        self.add_function_attribute(
+            "evolve_for",
+            self.particleset_evolve_for,
+            self.evolve_for,
+        )
+    def evolve_one_step(self, particles, subset):
+        self._private.code_interface._evolve_particles(
+            subset.as_set(),
+            subset.age + subset.time_step,
+        )
+
+    def add_particles_to_store(self, keys, attributes=[], values=[]):
+        if len(keys) == 0:
+            return
+
+        all_attributes = []
+        all_attributes.extend(attributes)
+        all_values = []
+        all_values.extend(values)
+
+        mapping_from_attribute_to_default_value = {
+            'age': 0. | units.julianyr,
+            'metallicity': 0.014,
+            'omega': 0. | units.none,
+            'luminosity': 0. | units.LSun,
+            'temperature': 0. | units.K,
+            'abundance_1H': 0. | units.none,
+            'abundance_4He': 0. | units.none,
+            'abundance_12C': 0. | units.none,
+            'abundance_13C': 0. | units.none,
+            'abundance_14N': 0. | units.none,
+            'abundance_16O': 0. | units.none,
+            'abundance_17O': 0. | units.none,
+            'abundance_18O': 0. | units.none,
+            'abundance_20Ne': 0. | units.none,
+            'abundance_22Ne': 0. | units.none,
+            'abundance_26Al': 0. | units.none,
+            'MccMt': 0. | units.none,
+            'temperature_wr': 0. | units.K,
+            'Md': 0. | units.none,
+            'rhoc': 0. | units.none,
+            'abundance_core_1H': 0. | units.none,
+            'abundance_core_4He': 0. | units.none,
+            'abundance_core_12C': 0. | units.none,
+            'abundance_core_13C': 0. | units.none,
+            'abundance_core_14N': 0. | units.none,
+            'abundance_core_16O': 0. | units.none,
+            'abundance_core_17O': 0. | units.none,
+            'abundance_core_20Ne': 0. | units.none,
+            'abundance_core_22Ne': 0. | units.none,
+            'abundance_core_26Al': 0. | units.none,
+            'omega_surface': 0. | units.s**-1,
+            'omega_core': 0. | units.s**-1,
+            'RpReq': 0. | units.none,
+            'MdMd0': 0. | units.none,
+            'v_crit1': 0. | units.kms,
+            'v_crit2': 0. | units.kms,
+            'v_equator': 0. | units.kms,
+            'OmOmcr': 0. | units.none,
+            'Gamma_Ed': 0. | units.none,
+            'MdotMech': 0. | units.MSun/units.yr,
+            'Ltot': 0. | 10**53*units.g*units.cm**2/units.s,
+        }
+        given_attributes = set(attributes)
+
+        if "initial_mass" not in given_attributes:
+            index_of_mass_attribute = attributes.index("mass")
+            all_attributes.append("initial_mass")
+            all_values.append(values[index_of_mass_attribute].in_(units.MSun))
+
+        for attribute, default_value in (
+                mapping_from_attribute_to_default_value.items()
+        ):
+            if attribute not in given_attributes:
+                all_attributes.append(attribute)
+                all_values.append(
+                    default_value.as_vector_with_length(len(keys))
+                )
+
+        super(SyclistParticles, self).add_particles_to_store(
+            keys, all_attributes, all_values
+        )
+
+        added_particles = ParticlesSubset(self, keys)
+        # self._private.code_interface.evolve_star((
+        #     added_particles, 0 | units.yr
+        # )
+
+    def particleset_evolve_one_step(self, particles):
+        self._private.code_interface._evolve_particles(
+            particles,
+            particles.age + particles.time_step,
+        )
+
+    def evolve_for(self, particles, subset, delta_time):
+        self._private.code_interface._evolve_particles(
+            subset.as_set(),
+            subset.age + delta_time,
+        )
+    
+    def particleset_evolve_for(self, particles, delta_time):
+        self._private.code_interface._evolve_particles(
+            particles,
+            particles.age + delta_time,
+        )
+
+
+class Syclist(
+    CommonCode,
+    # StellarEvolution,
+    InCodeComponentImplementation
+):
+
+    def __init__(self, **options):
+        InCodeComponentImplementation.__init__(
+            self, SyclistInterface(**options), **options)
+        self.model_time = 0.0 | units.yr
+
+    def define_parameters(self, handler):
+        handler.add_method_parameter(
+            "get_models_path",
+            "set_models_path",
+            "models_path",
+            "Path where the models are stored",
+            "./src/SYCLIST/inputs/"
+        )
+        # set defaults for metallicity, rotation etc
+
+    def define_state(self, handler):
+        CommonCode.define_state(self, handler)
+        handler.add_transition(
+            'INITIALIZED', 'RUN', 'commit_parameters'
+        )
+        handler.add_method('RUN', 'evolve_star')
+
+        # Only allow changing of models path before they are read
+        handler.add_method('INITIALIZED', 'set_models_path')
+
+    def define_particle_sets(self, handler):
+        handler.define_inmemory_set(
+            'particles',
+            SyclistParticles,
+        )
+
+    def evolve_model(
+        self,
+        end_time=None,
+    ):
+        if end_time is None:
+            end_time = self.model_time
+        self.particles.age = self.particles.age + end_time - self.model_time
+
+        result = self.evolve_star(
+            self.particles.age,  # 0
+            self.particles.initial_mass,  # 1
+            self.particles.metallicity,  # 2
+            self.particles.omega,  # 3
+            self.particles.mass,  # 4
+            self.particles.luminosity,  # 5
+            self.particles.temperature,  # 6
+            self.particles.abundance_1H,  # 7
+            self.particles.abundance_4He,  # 8
+            self.particles.abundance_12C,  # 9
+            self.particles.abundance_13C,  # 10
+            self.particles.abundance_14N,  # 11
+            self.particles.abundance_16O,  # 12
+            self.particles.abundance_17O,  # 13
+            self.particles.abundance_18O,  # 14
+            self.particles.abundance_20Ne,  # 15
+            self.particles.abundance_22Ne,  # 16
+            self.particles.abundance_26Al,  # 17
+            self.particles.MccMt,  # 18
+            self.particles.temperature_wr,  # 19
+            self.particles.Md,  # 20
+            self.particles.rhoc,  # 21
+            self.particles.abundance_core_1H,  # 22
+            self.particles.abundance_core_4He,  # 23
+            self.particles.abundance_core_12C,  # 24
+            self.particles.abundance_core_13C,  # 25
+            self.particles.abundance_core_14N,  # 26
+            self.particles.abundance_core_16O,  # 27
+            self.particles.abundance_core_17O,  # 28
+            self.particles.abundance_core_20Ne,  # 29
+            self.particles.abundance_core_22Ne,  # 30
+            self.particles.abundance_core_26Al,  # 31
+            self.particles.omega_surface,  # 32
+            self.particles.omega_core,  # 33
+            self.particles.RpReq,  # 34
+            self.particles.MdMd0,  # 35
+            self.particles.v_crit1,  # 36
+            self.particles.v_crit2,  # 37
+            self.particles.v_equator,  # 38
+            self.particles.OmOmcr,  # 39
+            self.particles.Gamma_Ed,  # 40
+            self.particles.MdotMech,  # 41
+            self.particles.Ltot,  # 42
+            # ...
+        )
+        self.particles.age = result[0]
+        self.particles.initial_mass = result[1]
+        self.particles.metallicity = result[2]
+        self.particles.omega = result[3]
+        self.particles.mass = result[4]
+        self.particles.luminosity = result[5]
+        self.particles.temperature = result[6]
+        self.particles.abundance_1H = result[7]
+        self.particles.abundance_4He = result[8]
+        self.particles.abundance_12C = result[9]
+        self.particles.abundance_13C = result[10]
+        self.particles.abundance_14N = result[11]
+        self.particles.abundance_16O = result[12]
+        self.particles.abundance_17O = result[13]
+        self.particles.abundance_18O = result[14]
+        self.particles.abundance_20Ne = result[15]
+        self.particles.abundance_22Ne = result[16]
+        self.particles.abundance_26Al = result[17]
+        self.particles.MccMt = result[18]
+        self.particles.temperature_wr = result[19]
+        self.particles.Md = result[20]
+        self.particles.rhoc = result[21]
+        self.particles.abundance_core_1H = result[22]
+        self.particles.abundance_core_4He = result[23]
+        self.particles.abundance_core_12C = result[24]
+        self.particles.abundance_core_13C = result[25]
+        self.particles.abundance_core_14N = result[26]
+        self.particles.abundance_core_16O = result[27]
+        self.particles.abundance_core_17O = result[28]
+        self.particles.abundance_core_20Ne = result[29]
+        self.particles.abundance_core_22Ne = result[30]
+        self.particles.abundance_core_26Al = result[31]
+        self.particles.omega_surface = result[32]
+        self.particles.omega_core = result[33]
+        self.particles.RpReq = result[34]
+        self.particles.MdMd0 = result[35]
+        self.particles.v_crit1 = result[36]
+        self.particles.v_crit2 = result[37]
+        self.particles.v_equator = result[38]
+        self.particles.OmOmcr = result[39]
+        self.particles.Gamma_Ed = result[40]
+        self.particles.MdotMech = result[41]
+        self.particles.Ltot = result[42]
+        self.model_time = end_time

--- a/src/amuse/community/syclist/interface.py
+++ b/src/amuse/community/syclist/interface.py
@@ -100,6 +100,28 @@ class SyclistInterface(
         return function
 
     @legacy_function
+    def set_grid_name():
+        function = LegacyFunctionSpecification()
+        function.addParameter(
+            'gridname', dtype='string', direction=function.IN,
+            description="Grids name",
+        )
+        function.result_type = 'int32'
+        function.result_doc = ''
+        return function
+
+    @legacy_function
+    def get_grid_name():
+        function = LegacyFunctionSpecification()
+        function.addParameter(
+            'gridname', dtype='string', direction=function.OUT,
+            description="Grids name",
+        )
+        function.result_type = 'int32'
+        function.result_doc = ''
+        return function
+
+    @legacy_function
     def evolve_star():
         function = LegacyFunctionSpecification()
         # function.name = 'evolve_star'
@@ -303,6 +325,13 @@ class Syclist(
             "models_path",
             "Path where the models are stored",
             "./src/SYCLIST/inputs/"
+        )
+        handler.add_method_parameter(
+            "get_grid_name",
+            "set_grid_name",
+            "grid",
+            "Grids name",
+            "Grids2012"
         )
         # set defaults for metallicity, rotation etc
 


### PR DESCRIPTION
This PR adds SYCLIST (https://www.unige.ch/sciences/astro/evolution/en/database/syclist/, https://github.com/GESEG/SYCLIST).
SYCLIST interpolates pre-calculated stellar evolution models.
The interface works similar to that of other stellar evolution codes.

Not yet finished.