### PR TITLE
Fix timesteps issues with evolve_model and MESA

### DIFF
--- a/src/amuse/community/mesa_r15140/interface.py
+++ b/src/amuse/community/mesa_r15140/interface.py
@@ -206,8 +206,22 @@ class MESAInterface(
 
 
     @remote_function
-    def set_time_step(index_of_the_star='i', time_step='d' | units.julianyr):
+    def set_time_step(index_of_the_star='i', time_step='d' | units.s):
         returns ()
+
+    @legacy_function
+    def get_time_step():
+        """
+        Retrieve the current time step
+        """
+        function = LegacyFunctionSpecification()
+        function.can_handle_array = True
+        function.addParameter('index_of_the_star', dtype='int32', direction=function.IN
+            , description="The index of the star to get the value of")
+        function.addParameter('time_step', dtype='float64', direction=function.OUT
+            , description="Current timestep")
+        function.result_type = 'int32'
+        return function
 
     @legacy_function
     def get_core_mass():

--- a/src/amuse/community/mesa_r15140/mesa_interface.f90
+++ b/src/amuse/community/mesa_r15140/mesa_interface.f90
@@ -582,7 +582,6 @@ module mesa_interface
         s% max_age = s% star_age + delta_t
         s% num_adjusted_dt_steps_before_max_age =  -1
 
-        s%dt_next = delta_t * secyer
         evolve_loop: do 
             call do_evolve_one_step(id, result, ierr)
             if (result /= keep_going) then
@@ -598,6 +597,7 @@ module mesa_interface
 
         ! In case you want to evolve further
         s% max_age = old_age
+        if(s% dt_next==0) s% dt_next = s% dt
 
         s% doing_first_model_of_run = .false.
 


### PR DESCRIPTION
We would after a few steps end up taking timesteps of 0 seconds as dt_next was being set to 0.