### PR TITLE
Update SeBa version in AMUSE

### DIFF
--- a/src/amuse/community/seba/download.py
+++ b/src/amuse/community/seba/download.py
@@ -96,7 +96,7 @@ def new_option_parser():
     result = OptionParser()
     result.add_option(
         "--seba-version",
-        default='2fd73b4012999cd5fc1eb242de815586b297a7ee',
+        default='2f6e7f37a53167b4b0dcd6c723dff7b5ee1aecba',
         dest="seba_version",
         help="SeBa commit hash to download",
         type="string"


### PR DESCRIPTION
this bugfix makes sure that when one of the stars in a binary merges with another star, that the right stars are merged.  Note, other types of mergers and mergers within SeBa were already performed correctly