### PR TITLE
Tweak mesa2208 inlist loading

### DIFF
--- a/src/amuse/community/mesa_r2208/data/input/AMUSE_inlist
+++ b/src/amuse/community/mesa_r2208/data/input/AMUSE_inlist
@@ -338,8 +338,8 @@
       ! can you split your star_job inlist into pieces using the following controls.
       ! BTW: it works recursively, so the extras can read extras too.
 
-         read_extra_star_job_inlist1 = .false.
-         extra_star_job_inlist1_name = 'undefined'
+         read_extra_star_job_inlist1 = .true.
+         extra_star_job_inlist1_name = 'inlist'
             ! if read_extra_star_job_inlist1 is true, then read &star_job from this namelist file
 
             ! if you try one of the following prebuilt extras,
@@ -2116,8 +2116,8 @@
       ! can you split your controls inlist into pieces using the following parameters.
       ! BTW: it works recursively, so the extras can read extras too.
 
-         read_extra_controls_inlist1 = .false.
-         extra_controls_inlist1_name = 'undefined'
+         read_extra_controls_inlist1 = .true.
+         extra_controls_inlist1_name = 'inlist'
             ! if read_extra_controls_inlist1 is true, then read &controls from this namelist file
          
             ! if you try one of the following prebuilt extras,

--- a/src/amuse/community/mesa_r2208/patches/inlisterror
+++ b/src/amuse/community/mesa_r2208/patches/inlisterror
@@ -1,0 +1,32 @@
+Index: mesa/star/private/ctrls_io.f
+===================================================================
+--- mesa.orig/star/private/ctrls_io.f	2023-02-21 10:41:58.643935871 +0100
++++ mesa/star/private/ctrls_io.f	2023-02-21 10:42:43.572324304 +0100
+@@ -1746,6 +1746,10 @@
+             unit=alloc_iounit(ierr); if (ierr /= 0) return
+             open(unit=unit, file=trim(filename), action='read', delim='quote', status='old', iostat=ierr)
+             if (ierr /= 0) then
++               if(level>1) then
++                  ierr=0
++                  return ! Dont error if we dont find the file beyond the first level
++               end if
+                write(message, *) 'Failed to open control namelist file ', trim(filename)
+                call alert(ierr, message)
+                write(*, '(a)') trim(message)
+
+
+Index: mesa/star/test/src/run_star_support.f
+===================================================================
+--- mesa.orig/star/test/src/run_star_support.f	2023-02-21 10:41:58.625936116 +0100
++++ mesa/star/test/src/run_star_support.f	2023-02-21 10:42:22.691608537 +0100
+@@ -900,6 +900,10 @@
+          
+          open(unit=unit, file=trim(filename), action='read', delim='quote', iostat=ierr)
+          if (ierr /= 0) then
++            if(level>1) then
++               ierr=0
++               return ! Dont error if we dont find the file beyond the first level
++            end if
+             write(message, *) 'Failed to open control namelist file ', trim(filename)
+             call alert(ierr, message)
+             write(*,*) trim(message)

--- a/src/amuse/community/mesa_r2208/patches/series
+++ b/src/amuse/community/mesa_r2208/patches/series
@@ -6,3 +6,4 @@ filelen
 kaptestinit
 openmp
 warningisnoterror
+inlisterror


### PR DESCRIPTION
The AMUSE_inlist is tweaked to look for a local file called "inlist" (we also patch out the error so it's not an error if this local inlist does not exist). This makes it easier to provide the additional input parameters that amuse does not expose in its interface available to users, without needing to edit the main AMUSE_inlist file.