### PR TITLE
Fix time logic for evovle_for in mesa 2208

### DIFF
--- a/src/amuse/community/mesa_r2208/.gitignore
+++ b/src/amuse/community/mesa_r2208/.gitignore
@@ -1,1 +1,2 @@
 src*
+data/data/

--- a/src/amuse/community/mesa_r2208/interface.f
+++ b/src/amuse/community/mesa_r2208/interface.f
@@ -1777,17 +1777,22 @@
       type (star_info), pointer :: s
       integer :: ierr
       integer :: do_evolve_one_step
+      double precision :: end_time
 
       evolve_for = 0
       call get_star_ptr(AMUSE_id, s, ierr)
       if (evolve_failed('get_star_ptr', ierr, evolve_for, -1)) return
 
-      target_times(AMUSE_id) = target_times(AMUSE_id) + AMUSE_delta_t * secyer
+      end_time = s% time + AMUSE_delta_t * secyer
 
       evolve_loop: do while(evolve_for == 0 .and. &
-            (s% time + s% min_timestep_limit < target_times(AMUSE_id))) ! evolve one step per loop
+            (s% time  < end_time)) ! evolve one step per loop
+            if((s% time + s% dt_next) > end_time) then ! Handle final step
+               s% dt_next = end_time - s% time
+            end if
          evolve_for = do_evolve_one_step(AMUSE_id)
       end do evolve_loop
+
    end function evolve_for
 
 ! Return the maximum age stop condition

--- a/src/amuse/community/mesa_r2208/interface.py
+++ b/src/amuse/community/mesa_r2208/interface.py
@@ -1170,6 +1170,12 @@ class MESA(StellarEvolution, InternalStellarStructure):
         InternalStellarStructure.define_methods(self, handler)
         StellarEvolution.define_methods(self, handler)
         handler.add_method(
+            "evolve_for",
+            (handler.INDEX, units.julianyr),
+            (handler.ERROR_CODE,)
+        )
+
+        handler.add_method(
             "new_pre_ms_particle",
             (units.MSun),
             (handler.INDEX, handler.ERROR_CODE)


### PR DESCRIPTION
Now the evolution will stop exactly at the time requested instead of a bit afterwards.

Note evovle_for doesn't need to set target_times and evolve_one_step is doing that for us.