### PR TITLE
Adds ability to change the number of pre-MS steps taken

### DIFF
--- a/src/amuse/community/mesa_r15140/interface.f90
+++ b/src/amuse/community/mesa_r15140/interface.f90
@@ -140,8 +140,9 @@ module amuse_mesa
    end function load_model
 
 ! Create a new pre-main-sequence star
-   integer function new_pre_ms_particle(AMUSE_id, AMUSE_value)
+   integer function new_pre_ms_particle(AMUSE_id, AMUSE_value, num_steps)
       integer, intent(out) :: AMUSE_id
+      integer :: num_steps
       double precision :: AMUSE_value
       integer ::  ierr, id
 
@@ -155,7 +156,7 @@ module amuse_mesa
       AMUSE_id = id
       number_of_particles = AMUSE_id
 
-      call create_pre_main_sequence(AMUSE_id, ierr)
+      call create_pre_main_sequence(AMUSE_id, num_steps, ierr)
       if(ierr/=MESA_SUCESS) return
 
       call finish_init_star(AMUSE_id, set_amuse_options, ierr)

--- a/src/amuse/community/mesa_r15140/interface.py
+++ b/src/amuse/community/mesa_r15140/interface.py
@@ -136,6 +136,8 @@ class MESAInterface(
             , description="The new index for the star. This index can be used to refer to this star in other functions")
         function.addParameter('mass', dtype='float64', direction=function.IN
             , description="The initial mass of the star")
+        function.addParameter('num_steps', dtype='int32', direction=function.IN, default=-1
+            , description="Number of steps to take during pre-MS relaxation process. If negative uses MESA's default choice")
         function.result_type = 'int32'
         return function
 
@@ -1355,7 +1357,7 @@ class MESA(StellarEvolution, InternalStellarStructure):
         StellarEvolution.define_methods(self, handler)
         handler.add_method(
             "new_pre_ms_particle",
-            (units.MSun),
+            (units.MSun, units.none),
             (handler.INDEX, handler.ERROR_CODE)
         )
         handler.add_method(

--- a/src/amuse/community/mesa_r15140/mesa_interface.f90
+++ b/src/amuse/community/mesa_r15140/mesa_interface.f90
@@ -205,7 +205,7 @@ module mesa_interface
         integer, intent(out) :: ierr
         logical :: restart
         type (star_info), pointer :: s
-        logical, parameter :: dbg=.true.
+        logical, parameter :: dbg=.false.
 
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
@@ -506,7 +506,7 @@ module mesa_interface
 
         integer :: model_number
         logical :: continue_evolve_loop, first_try
-        logical,parameter :: dbg=.true.
+        logical,parameter :: dbg=.false.
 
         ierr = MESA_SUCESS
 

--- a/src/amuse/community/mesa_r15140/mesa_interface.f90
+++ b/src/amuse/community/mesa_r15140/mesa_interface.f90
@@ -84,8 +84,8 @@ module mesa_interface
     end subroutine load_inlist
 
 
-    subroutine create_pre_main_sequence(id, ierr)
-        integer, intent(in) :: id
+    subroutine create_pre_main_sequence(id, num_steps, ierr)
+        integer, intent(in) :: id, num_steps
         integer, intent(out) :: ierr
 
         type (star_info), pointer :: s
@@ -95,6 +95,10 @@ module mesa_interface
 
         s% job% create_pre_main_sequence_model = .true.
         s% job% load_saved_model = .false.
+        if (num_steps>0) then
+            s% job% pre_ms_relax_num_steps = num_steps
+            s% job% pre_ms_relax_to_start_radiative_core = .false.
+        end if
 
     end subroutine create_pre_main_sequence
 


### PR DESCRIPTION
Should speed the early evolution up alot. The MESA default is 300, but 50 works well for low mass stars.