### PR TITLE
Remote workers for socket channel

### DIFF
--- a/src/amuse/config.py
+++ b/src/amuse/config.py
@@ -6,15 +6,11 @@ configuration from config.mk
 import os
 import warnings
 
-
-def parse_configmk(filename):
-    configfile = open(filename, "r")
-    lines = configfile.readlines()
-    configfile.close()
+def parse_configmk_lines(lines,label):
     cfgvars = dict()
     if "amuse configuration" not in lines[0]:
         raise Exception(
-            "file: {0} is not an amuse configuration file".format(filename)
+            "{0} is not an amuse configuration file".format(label)
         )
     for line in lines:
         if "=" in line:
@@ -22,11 +18,16 @@ def parse_configmk(filename):
             if value.startswith("@") and value.endswith("@"):
                 warnings.warn(
                     "possible configuration error/ unconfigured variable in"
-                    " {0}".format(filename)
+                    " {0}".format(label)
                 )
             cfgvars[var] = value.strip()
     return cfgvars
 
+def parse_configmk(filename):
+    configfile = open(filename, "r")
+    lines = configfile.readlines()
+    configfile.close()
+    return parse_configmk_lines(lines, "file " + filename)
 
 try:
     configmk = parse_configmk("config.mk")

--- a/src/amuse/config.py
+++ b/src/amuse/config.py
@@ -10,15 +10,15 @@ def parse_configmk_lines(lines,label):
     cfgvars = dict()
     if "amuse configuration" not in lines[0]:
         raise Exception(
-            "{0} is not an amuse configuration file".format(label)
+            f"{label} is not an amuse configuration file"
         )
     for line in lines:
         if "=" in line:
             var, value = line.split("=", 1)
             if value.startswith("@") and value.endswith("@"):
                 warnings.warn(
-                    "possible configuration error/ unconfigured variable in"
-                    " {0}".format(label)
+                    f"possible configuration error/ unconfigured variable in"
+                    f" {label}"
                 )
             cfgvars[var] = value.strip()
     return cfgvars

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -1955,7 +1955,7 @@ class SocketChannel(AbstractMessageChannel):
           self.process.stdin.close()
         else:
           logger.debug("starting process with command `%s`, arguments `%s` and environment '%s'", command, arguments, os.environ)
-          print(arguments)
+          # ~ print(arguments)
           self.process = Popen(arguments, executable=command, stdin=PIPE, stdout=None, stderr=None, close_fds=self.close_fds)
 
         logger.debug("waiting for connection from worker")

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -913,7 +913,6 @@ class MpiChannel(AbstractMessageChannel):
         self.interpreter_executable = interpreter_executable
                 
         if not legacy_interface_type is None:
-            print(">>", legacy_interface_type)
             self.full_name_of_the_worker = self.get_full_name_of_the_worker(legacy_interface_type)
         else:
             self.full_name_of_the_worker = self.name_of_the_worker

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -1251,17 +1251,11 @@ class MpiChannel(AbstractMessageChannel):
         self._is_inuse = False
         self._communicated_splitted_message = False
         self.inuse_semaphore = threading.Semaphore()
-        
-
-
 
     @option(sections=("channel",))
     def job_scheduler(self):
         """Name of the job scheduler to use when starting the code, if given will use job scheduler to find list of hostnames for spawning"""
         return ""
-        
-
-
 
     def get_info_from_job_scheduler(self, name, number_of_workers = 1):
         if name == "slurm":
@@ -1281,7 +1275,7 @@ class MpiChannel(AbstractMessageChannel):
                 for _ in range(tasks):
                     all_nodes.append(node)
             cls._scheduler_nodes = all_nodes
-            cls._scheduler_index = 1     # start at 1 assumes that the python script is running on the first node as the first task
+            cls._scheduler_index = 1  # start at 1 assumes that the python script is running on the first node as the first task
             cls._scheduler_initialized = True
             print("NODES:", cls._scheduler_nodes)
         hostnames = []
@@ -1295,7 +1289,7 @@ class MpiChannel(AbstractMessageChannel):
         host = ','.join(hostnames)
         print("HOST:", host, cls._scheduler_index, os.environ['SLURM_TASKS_PER_NODE'])
         info = MPI.Info.Create()
-        info['host'] = host                                                     #actually in mpich and openmpi, the host parameter is interpreted as a comma separated list of host names,
+        info['host'] = host   # actually in mpich and openmpi, the host parameter is interpreted as a comma separated list of host names,
         return info
 
 
@@ -1477,20 +1471,16 @@ m.run_mpi_channel('{2}')"""
                 if len(x) > len(result):
                     result = x
         return result
-        
-            
-
 
     @option(choices=AbstractMessageChannel.DEBUGGERS.keys(), sections=("channel",))
     def debugger(self):
         """Name of the debugger to use when starting the code"""
         return "none"
-    
-    
 
     @option(type="boolean")
     def check_mpi(self):
         return True
+
 
 class SocketMessage(AbstractMessage):
       
@@ -1683,7 +1673,6 @@ class SocketMessage(AbstractMessage):
         self.send_doubles(socket, self.encoded_units)
         
         # logger.debug("message send")
-    
 
     def send_doubles(self, socket, array):
         if len(array) > 0:
@@ -1721,7 +1710,8 @@ class SocketMessage(AbstractMessage):
         if len(array) > 0:
             data_buffer = numpy.array(array, dtype='int64')
             socket.sendall(data_buffer.tobytes())
-        
+
+
 class SocketChannel(AbstractMessageChannel):
     
     def __init__(self, name_of_the_worker, legacy_interface_type=None, interpreter_executable=None, 
@@ -1741,10 +1731,10 @@ class SocketChannel(AbstractMessageChannel):
             self.hostname="localhost"
 
         if self.hostname not in ['localhost',socket.gethostname()]:
-          self.remote=True
-          self.must_check_if_worker_is_up_to_date=False
+            self.remote=True
+            self.must_check_if_worker_is_up_to_date=False
         else:
-          self.remote=False
+            self.remote=False
                     
         self.id = 0
         
@@ -1760,7 +1750,6 @@ class SocketChannel(AbstractMessageChannel):
         self.socket = None
     
         self.remote_env=remote_env
-    
 
     @option(sections=("channel",))
     def mpiexec(self):
@@ -1773,10 +1762,6 @@ class SocketChannel(AbstractMessageChannel):
     def mpiexec_number_of_workers_flag(self):
         """flag to use, so that the number of workers are defined"""
         return '-n'
-    
-
-    
-
 
     @late
     def debugger_method(self):
@@ -1935,9 +1920,6 @@ class SocketChannel(AbstractMessageChannel):
 
         return command,arguments
 
-        
-
-
     def start(self):
         
         server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -2083,8 +2065,6 @@ class SocketChannel(AbstractMessageChannel):
             message.send(self.socket)
 
             self._is_inuse = True
-        
-
 
     def recv_message(self, call_id, function_id, handle_as_array, has_units=False):
            
@@ -2095,7 +2075,6 @@ class SocketChannel(AbstractMessageChannel):
             self._communicated_splitted_message = False
             del self._merged_results_splitted_message
             return x
-        
         
         message = SocketMessage()
         
@@ -2119,8 +2098,6 @@ class SocketChannel(AbstractMessageChannel):
             return message.to_result(handle_as_array), message.encoded_units
         else:
             return message.to_result(handle_as_array)
-        
-
 
     def nonblocking_recv_message(self, call_id, function_id, handle_as_array, has_units=False):
         request = SocketMessage().nonblocking_receive(self.socket)
@@ -2182,9 +2159,7 @@ class SocketChannel(AbstractMessageChannel):
         out,err=proc.communicate(command.encode())
       else:
         os.makedirs(directory)
-        
 
-      
 
 class OutputHandler(threading.Thread):
     
@@ -2231,6 +2206,7 @@ class OutputHandler(threading.Thread):
             # logger.debug("got %d bytes", len(data))
             
             self.stream.write(data)
+
 
 class DistributedChannel(AbstractMessageChannel):
             
@@ -2315,8 +2291,6 @@ class DistributedChannel(AbstractMessageChannel):
         logger.debug("worker dir is %s", self.worker_dir)
             
         self._is_inuse = False
-      
-
 
     def check_if_worker_is_up_to_date(self, object):
 #         if self.hostname != 'localhost':

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -35,7 +35,7 @@ except ImportError:
 from amuse.support.options import OptionalAttributes, option, GlobalOptions
 from amuse.support.core import late
 from amuse.support import exceptions
-from amuse.support import get_amuse_root_dir, get_amuse_directory_root
+from amuse.support import get_amuse_root_dir, get_amuse_package_dir
 from amuse.rfi import run_command_redirected
 from amuse.config import parse_configmk_lines
 
@@ -1863,7 +1863,7 @@ class SocketChannel(AbstractMessageChannel):
         out,err=proc.communicate(command.encode())
       
         remote_package_dir=out.decode().strip(" \n\t")
-        local_package_dir=get_amuse_directory_root()
+        local_package_dir=get_amuse_package_dir()
                 
         mpiexec=remote_config["MPIEXEC"]
         initialize_mpi=remote_config["MPI_ENABLED"] == 'yes'

--- a/src/amuse/rfi/channel.py
+++ b/src/amuse/rfi/channel.py
@@ -709,7 +709,6 @@ Please do a 'make clean; make' in the root directory.
 
         current_type = type
         while not current_type.__bases__[0] is object:
-            print(current_type.__bases__[0])
             directory_of_this_module = os.path.dirname(inspect.getfile(current_type))
             full_name_of_the_worker = os.path.join(directory_of_this_module, exe_name)
             full_name_of_the_worker = os.path.normpath(os.path.abspath(full_name_of_the_worker))
@@ -1841,7 +1840,7 @@ class SocketChannel(AbstractMessageChannel):
 
     def remote_env_string(self, hostname):
         if self.remote_env is None:
-          if hostname in self.remote_envs:
+          if hostname in self.remote_envs.keys():
             return "source "+self.remote_envs[hostname]+"\n"
           else:
             return ""
@@ -1866,7 +1865,7 @@ class SocketChannel(AbstractMessageChannel):
 
         # get remote amuse package dir
         command=self.remote_env_string(self.hostname)+ \
-                "amusifier --get-amuse-dir" +"\n"
+                "amusifier --get-amuse-package-dir" +"\n"
       
         proc=Popen(args,stdout=PIPE, stdin=PIPE, executable="ssh")
         out,err=proc.communicate(command.encode())
@@ -1993,7 +1992,7 @@ class SocketChannel(AbstractMessageChannel):
         """close open file descriptors when spawning child process"""
         return False
 
-    @option(type="boolean", sections=("sockets_channel",))
+    @option(type="dict", sections=("sockets_channel",))
     def remote_envs(self):
         """ dict of remote machine - enviroment (source ..)  pairs """
         return dict()

--- a/src/amuse/rfi/core.py
+++ b/src/amuse/rfi/core.py
@@ -960,7 +960,9 @@ class CodeInterface(OptionalAttributes):
         if self.channel_type == 'mpi':
             if  MpiChannel.is_supported():
                 return MpiChannel
-            else:   
+            else:
+                warnings.warn("MPI (unexpectedly?) not available, falling back to sockets channel")
+                self.channel_type="sockets"   
                 return SocketChannel
                 
         elif self.channel_type == 'remote':
@@ -1064,15 +1066,17 @@ class CodeWithDataDirectories(object):
     
     
     def __init__(self):
-        if not self.channel_type == 'distributed':
+        if self.channel_type == 'distributed':
+            warnings.warn("Code with DistributedChannel wants to make output directory, check..")
+        else:
             self.ensure_data_directory_exists(self.get_output_directory())
     
     def ensure_data_directory_exists(self, directory):
         directory = os.path.expanduser(directory)
         directory = os.path.expandvars(directory)
-        
+                
         try:
-            os.makedirs(directory)
+            self.channel.makedirs(directory)
         except OSError as ex:
             if ex.errno == errno.EEXIST and os.path.isdir(directory):
                 pass

--- a/src/amuse/rfi/gencode.py
+++ b/src/amuse/rfi/gencode.py
@@ -25,7 +25,7 @@ from amuse.rfi.tools import create_java
 from amuse.rfi.tools import create_dir
 from amuse.rfi.tools import create_python_worker
     
-from amuse.support import get_amuse_root_dir    
+from amuse.support import get_amuse_root_dir, get_amuse_directory_root
 from amuse.support.literature import TrackLiteratureReferences    
 
 def get_amuse_directory():
@@ -45,14 +45,6 @@ def get_amuse_directory():
             #~ return directory_of_this_script
         #~ else:
             #~ return os.path.abspath(directory_of_this_script)
-
-def get_amuse_directory_root():
-    filename_of_this_script = __file__
-    directory_of_this_script = os.path.dirname(os.path.dirname(filename_of_this_script))
-    if os.path.isabs(directory_of_this_script):
-        return directory_of_this_script
-    else:
-        return os.path.abspath(directory_of_this_script)
 
 def setup_sys_path():
     amuse_directory = os.environ["AMUSE_DIR"]
@@ -172,6 +164,12 @@ class ParseCommandLine(object):
             dest="get_amuse_dir",
             help="Only output amuse directory")
         self.parser.add_option(
+            "--get-amuse-package-dir",
+            action="store_true",
+            default=False,
+            dest="get_amuse_package_dir",
+            help="Only output the amuse package root directory")
+        self.parser.add_option(
             "--get-amuse-configmk",
             action="store_true",
             default=False,
@@ -201,7 +199,7 @@ class ParseCommandLine(object):
         
         
     def parse_arguments(self):
-        if self.options.get_amuse_dir or self.options.get_amuse_configmk:
+        if self.options.get_amuse_dir or self.options.get_amuse_package_dir or self.options.get_amuse_configmk:
             return
         if self.options.mode == 'dir':
             if len(self.arguments) != 1:
@@ -384,6 +382,9 @@ def amusifier():
     
     if uc.options.get_amuse_dir:
         print(get_amuse_root_dir())
+        exit(0)
+    elif uc.options.get_amuse_package_dir:
+        print(get_amuse_directory_root())
         exit(0)
     elif uc.options.get_amuse_configmk:
         with open(os.path.join(get_amuse_root_dir(), "config.mk")) as f:

--- a/src/amuse/rfi/gencode.py
+++ b/src/amuse/rfi/gencode.py
@@ -25,7 +25,7 @@ from amuse.rfi.tools import create_java
 from amuse.rfi.tools import create_dir
 from amuse.rfi.tools import create_python_worker
     
-from amuse.support import get_amuse_root_dir, get_amuse_directory_root
+from amuse.support import get_amuse_root_dir, get_amuse_package_dir
 from amuse.support.literature import TrackLiteratureReferences    
 
 def get_amuse_directory():
@@ -384,7 +384,7 @@ def amusifier():
         print(get_amuse_root_dir())
         exit(0)
     elif uc.options.get_amuse_package_dir:
-        print(get_amuse_directory_root())
+        print(get_amuse_package_dir())
         exit(0)
     elif uc.options.get_amuse_configmk:
         with open(os.path.join(get_amuse_root_dir(), "config.mk")) as f:

--- a/src/amuse/support/__init__.py
+++ b/src/amuse/support/__init__.py
@@ -26,3 +26,11 @@ def get_amuse_root_dir():
 
 def get_amuse_data_dir():
     return _Defaults().amuse_root_dir
+
+def get_amuse_directory_root():
+    filename_of_this_script = __file__
+    directory_of_this_script = os.path.dirname(os.path.dirname(filename_of_this_script))
+    if os.path.isabs(directory_of_this_script):
+        return directory_of_this_script
+    else:
+        return os.path.abspath(directory_of_this_script)

--- a/src/amuse/support/__init__.py
+++ b/src/amuse/support/__init__.py
@@ -27,7 +27,7 @@ def get_amuse_root_dir():
 def get_amuse_data_dir():
     return _Defaults().amuse_root_dir
 
-def get_amuse_directory_root():
+def get_amuse_package_dir():
     filename_of_this_script = __file__
     directory_of_this_script = os.path.dirname(os.path.dirname(filename_of_this_script))
     if os.path.isabs(directory_of_this_script):


### PR DESCRIPTION
This PR allows workers to be started remotely using sockets_channel under the following conditions:
- passwordless ssh access (public key setup)
- amuse is installed
- if an environment needs to be activated with source, specify with remote_env keyword or in amuserc (documented in amuserc.template
- permissions in firewall etc 

