### PR TITLE
Revert FDPS version to 7.0 for PeTar

### DIFF
--- a/src/amuse/community/petar/download.py
+++ b/src/amuse/community/petar/download.py
@@ -115,7 +115,7 @@ def new_option_parser():
     )
     result.add_option(
         "--fdps-version",
-        default='7b02b365b7377c0d5239bf309a2012e71575ef97',
+        default='55b2bafd316805bad22057cf4ee96217735279bf',
         dest="fdps_version",
         help="FDPS commit hash to download",
         type="string"


### PR DESCRIPTION
7.0 is stable, 7.1 is causing some issues...