### PR TITLE
Add finer controls for timestepping in mesa

### DIFF
--- a/src/amuse/community/mesa_r15140/examples/photo_load.py
+++ b/src/amuse/community/mesa_r15140/examples/photo_load.py
@@ -1,0 +1,54 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from amuse.units import units
+from amuse.community.mesa.interface import MESA
+from amuse import datamodel
+
+stellar_evolution = MESA(version='15140')
+
+masses=[2.0] | units.MSun
+stars = datamodel.Particles(len(masses), mass=masses)
+
+stars = stellar_evolution.native_stars.add_particles(stars)
+star = stars[0]
+
+star.evolve_one_step()
+
+print(star.time_step)
+
+star.time_step = 1. | units.yr
+
+star.evolve_one_step()
+
+star.save_photo('photo')
+star.save_model('model.mod')
+
+
+star.evolve_one_step()
+
+age = star.age
+
+model_number = star.get_history('model_number')
+
+
+masses=[1.0] | units.MSun
+stars = datamodel.Particles(len(masses), mass=masses,filename=['photo'])
+
+stars = stellar_evolution.photo_stars.add_particles(stars)
+star = stars[0]
+
+star.evolve_one_step() # Photos will give exactly the same answer compared to a run without a save/load
+
+print(star.age, star.get_history('model_number'), star.mass)
+
+
+masses=[1.0] | units.MSun
+stars = datamodel.Particles(len(masses), mass=masses,filename=['model.mod'])
+
+stars = stellar_evolution.pre_built_stars.add_particles(stars)
+star = stars[0]
+
+star.evolve_one_step() # Models do not give exactly the same answer as a photo
+
+print(star.age, star.get_history('model_number'), star.mass)

--- a/src/amuse/community/mesa_r15140/interface.f90
+++ b/src/amuse/community/mesa_r15140/interface.f90
@@ -1306,6 +1306,78 @@ module amuse_mesa
 
 
 
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Procedures for manually controlling how a step gets taken
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+   integer function solve_one_step(AMUSE_ID, first_try, result)
+      integer, intent(in) :: AMUSE_ID
+      logical, intent(in) :: first_try
+      integer, intent(out) :: result
+      integer :: ierr 
+
+      ierr = 0
+
+      call do_solve_one_step(AMUSE_ID, first_try, result, ierr)
+      solve_one_step = ierr
+
+   end function solve_one_step
+
+   integer function solve_one_step_pre(AMUSE_ID, result)
+      integer, intent(in) :: AMUSE_ID
+      integer, intent(out) :: result
+      integer :: ierr 
+
+      call do_solve_one_step_pre(AMUSE_ID, result, ierr)
+      solve_one_step_pre = ierr
+
+   end function solve_one_step_pre
+
+
+   integer function solve_one_step_post(AMUSE_ID, result)
+      integer, intent(in) :: AMUSE_ID
+      integer, intent(out) :: result
+      integer :: ierr 
+
+      call do_solve_one_step_post(AMUSE_ID, result, ierr)
+      solve_one_step_post = ierr
+
+   end function solve_one_step_post
+
+
+   integer function prepare_retry_step(AMUSE_ID, dt, result)
+   ! Prepare toretake a timestep with a different dt
+   ! Does not actualy retry the step
+      integer, intent(in) :: AMUSE_ID
+      double precision,intent(in) :: dt
+      integer, intent(out) :: result
+      integer :: ierr 
+
+
+      call set_current_dt(AMUSE_ID, dt, ierr) ! Sets dt not dt_next
+      if(ierr/=MESA_SUCESS) then
+         prepare_retry_step = ierr
+         return
+      end if
+
+      result = do_prepare_for_retry(AMUSE_id)
+      prepare_retry_step = 0
+
+   end function prepare_retry_step
+
+
+   integer function prepare_redo_step(AMUSE_ID, result)
+   ! Retake the same timestep with the same dt. Useful when mdot changes
+   ! Does not actualy redo the step 
+      integer, intent(in) :: AMUSE_ID
+      integer, intent(out) :: result
+      integer :: ierr 
+
+      result = do_prepare_for_redo(AMUSE_id)
+      prepare_redo_step = 0
+
+   end function prepare_redo_step
 
 
 end module AMUSE_mesa


### PR DESCRIPTION
MESA has the concept of both a "redo" and a "retry". A redo re-computes the same step with the same dt, but lets you change the physics (say the mass transfer rate). While a retry re-computes a step with a different timestep. This is helpful when evolving multiple stars and you need to keep them in sync. 