### PR TITLE
Fix stellar type for low mass ms stars

### DIFF
--- a/src/amuse/community/mesa_r15140/interface.f90
+++ b/src/amuse/community/mesa_r15140/interface.f90
@@ -584,7 +584,7 @@ module amuse_mesa
       integer, intent(out) :: AMUSE_value
       integer :: ierr
       double precision :: lgR, mass, ch1, che3, che4, cc12, cne20
-      double precision :: lgL, lgLH, ah1, ahe3, ahe4, lgLHe
+      double precision :: lgL, lgLH, ah1, ahe3, ahe4, lgLHe, logg
       AMUSE_value = -99
       get_stellar_type = -1
 
@@ -618,9 +618,12 @@ module amuse_mesa
       call get_history_value(AMUSE_id,'average he4',ahe4, ierr)
       if(ierr/=MESA_SUCESS) return
 
+      call get_history_value(AMUSE_id,'photosphere_logg',logg, ierr)
+      if(ierr/=MESA_SUCESS) return
 
 
-      if (lgR > -1.0) then
+
+      if (logg < 6.0) then
          if(ch1 > 1d-4) then ! MS
             if(lgLH-lgL < -1 ) then ! Pre-main-sequence star
                AMUSE_value = 17


### PR DESCRIPTION
Low Z, 0.1Msun stars can have radii < 0.1Rsun so would be counted as a WD