### PR TITLE
Fix bug of adding particles in the middle of simulations for PeTar

### DIFF
--- a/src/amuse/community/petar/Makefile
+++ b/src/amuse/community/petar/Makefile
@@ -40,7 +40,7 @@ LDFLAGS  += -lm $(MUSE_LD_FLAGS)
 
 OBJS = interface.o 
 
-FILELIST=interface.cc interface.py interface.h
+DIRLIST=src/PeTar src/SDAR src/FDPS
 
 CODELIB = 
 
@@ -60,18 +60,16 @@ distclean: clean
 
 DOWNLOAD_FROM_WEB = $(PYTHON) ./download.py
 
-download:
-	$(RM) -Rf .pc
-	$(RM) -Rf src
-	mkdir src
+$(DIRLIST):
+#	$(RM) -Rf .pc
+#	$(RM) -Rf src
+#       mkdir src
 	$(DOWNLOAD_FROM_WEB)
 
 __init__.py:
 	touch $@
 
-$(FILELIST): |download
-
-src/PeTar/src/get_version.hpp: src/PeTar/src/get_version.hpp.in |src/PeTar
+src/PeTar/src/get_version.hpp: |src/PeTar
 	sed 's/@VERSION@/'`cat src/PeTar/VERSION`'_'`cat src/SDAR/VERSION`'/g' src/PeTar/src/get_version.hpp.in >src/PeTar/src/get_version.hpp
 
 test_interface: $(OBJS) test_interface.o
@@ -86,5 +84,5 @@ worker_code.h: interface.py
 petar_worker: worker_code.cc worker_code.h $(CODELIB) $(OBJS) interface.h
 	$(MPICXX) $(CXXFLAGS) $(SC_FLAGS) $(AM_CFLAGS) $(LDFLAGS) $< $(OBJS) $(CODELIB) -o $@ $(SC_MPI_CLIBS) $(LIBS) $(AM_LIBS)
 
-interface.o: interface.cc src/PeTar/src/get_version.hpp 
+interface.o: interface.cc src/PeTar/src/get_version.hpp |$(DIRLIST)
 	$(MPICXX) $(CXXFLAGS) $(SC_FLAGS) -c -o $@ $< 

--- a/src/amuse/community/petar/download.py
+++ b/src/amuse/community/petar/download.py
@@ -47,21 +47,25 @@ class GetCodeFromHttp:
         print("done")
 
     def start(self):
-        if os.path.exists('src'):
-            counter = 0
-            while os.path.exists('src.{0}'.format(counter)):
-                counter += 1
-                if counter > 100:
-                    print("too many backup directories")
-                    break
-            os.rename('src', 'src.{0}'.format(counter))
-
-        os.mkdir('src')
+        if not os.path.exists('src'):
+            os.mkdir('src')
+#            if not update_flag:
+#                return
+#            counter = 0
+#            while os.path.exists('src.{0}'.format(counter)):
+#                counter += 1
+#                if counter > 100:
+#                    print("too many backup directories")
+#                    break
+#            os.rename('src', 'src.{0}'.format(counter))
 
         for i, url_template in enumerate(self.url_template):
             url = url_template.format(version=self.version[i])
             filename = self.filename_template.format(version=self.version[i])
             filepath = os.path.join(self.src_directory(), filename)
+            if os.path.exists('src/'+self.name[i]):
+                print("src/%s exist" % self.name[i])
+                continue
             print(
                 "downloading version", self.version[i],
                 "from", url, "to", filename

--- a/src/amuse/community/petar/interface.h
+++ b/src/amuse/community/petar/interface.h
@@ -87,6 +87,10 @@ int get_tree_step(double * dt_soft);
 
 int set_tree_step(double dt_soft);
 
+int get_output_step(double * dt_output);
+
+int set_output_step(double dt_output);
+
 int get_kinetic_energy(double * kinetic_energy);
 
 int get_potential_energy(double * potential_energy);

--- a/src/amuse/community/petar/interface.py
+++ b/src/amuse/community/petar/interface.py
@@ -356,6 +356,48 @@ class petarInterface(
         """
         return function
 
+    @legacy_function
+    def get_output_step():
+        """
+        Get dt_output, the PeTar internal output time step (0.125)
+        """
+        function = LegacyFunctionSpecification()
+        function.addParameter(
+            'dt_output', dtype='float64', direction=function.OUT,
+            description=(
+                "dt_output, the PeTar internal output time step (0.125)"
+            )
+        )
+        function.result_type = 'int32'
+        function.result_doc = """
+        0 - OK
+            the parameter was retrieved
+        -1 - ERROR
+            could not retrieve parameter
+        """
+        return function
+
+    @legacy_function
+    def set_output_step():
+        """
+        Set dt_output, the PeTar internal output time step (0.125)
+        """
+        function = LegacyFunctionSpecification()
+        function.addParameter(
+            'dt_output', dtype='float64', direction=function.IN,
+            description=(
+                "dt_output, the PeTar internal output time step (0.125)"
+            )
+        )
+        function.result_type = 'int32'
+        function.result_doc = """
+        0 - OK
+            the parameter was set
+        -1 - ERROR
+            could not set parameter
+        """
+        return function
+
 
 class petar(GravitationalDynamics, GravityFieldCode):
 
@@ -441,6 +483,14 @@ class petar(GravitationalDynamics, GravityFieldCode):
             "dt_soft",
             "Tree time step (if zero, auto-determine)",
             default_value=0.0 | nbody_system.time
+        )
+
+        handler.add_method_parameter(
+            "get_output_step",
+            "set_output_step",
+            "dt_output",
+            "PeTar internal output time step (0.125)",
+            default_value=0.125 | nbody_system.time
         )
 
     def define_methods(self, handler):
@@ -535,6 +585,25 @@ class petar(GravitationalDynamics, GravityFieldCode):
 
         handler.add_method(
             "get_tree_step",
+            (),
+            (
+                nbody_system.time,
+                handler.ERROR_CODE,
+            )
+        )
+
+        handler.add_method(
+            "set_output_step",
+            (
+                nbody_system.time,
+            ),
+            (
+                handler.ERROR_CODE,
+            )
+        )
+
+        handler.add_method(
+            "get_output_step",
             (),
             (
                 nbody_system.time,


### PR DESCRIPTION
I have fixed the issue of add new particles in the middle of simulations for PeTar. In the old version, the changeover radii and search radii are not correctly initialized for new particles added in the middle of simulations. If any binaries are added, they are not integrated by using SDAR method, and thus the binary may not be integrated accurately. 

This fix also includes the update of Makefile and download.py. The previous version will download src codes everytime when make is used. Since the download versions are fixed, this is not necessary. In addition, this cause difficulty for recompiling and debugging the codes. 

Two more methods set_output_step/get_output_step are added for better printing of debugging info for PeTar.