### PR TITLE
fix missing memory cleanup for MPI tasks other than 1

### DIFF
--- a/src/amuse/community/gadget2/interface.cc
+++ b/src/amuse/community/gadget2/interface.cc
@@ -1453,6 +1453,7 @@ int check_counts_and_free(int *count, int length){
 #ifndef NOMPI
         MPI_Reduce(count, NULL, length, MPI_INT, MPI_SUM, 0, GADGET_WORLD);
 #endif
+        delete[] count;
         return 0;
     } else {
 #ifndef NOMPI


### PR DESCRIPTION
This fixes #739
`count` was not deleted for other tasks due to the `return 0`, leading to a memory leak there.