### PR TITLE
Add new argparse defaults / deprecate optparse

### DIFF
--- a/src/amuse/support/argparse.py
+++ b/src/amuse/support/argparse.py
@@ -1,0 +1,68 @@
+import argparse
+
+
+def new_argument_parser(
+    **kwargs
+):
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_amuse_arguments(parser, **kwargs)
+    return parser
+
+
+def add_amuse_arguments(
+    parser,
+    literature=True,
+    units=False,
+):
+    if literature:
+        # Note: at the moment these are dummy arguments, with
+        # amuse.support.literature parsing sys.argv on its own.
+        # They are therefore usable as command line arguments, but the values
+        # here are not used further.
+        parser.add_argument(
+            '--no-report-references',
+            dest='no_report_references',
+            action='store_true',
+            default=False,
+            help="don't report literature references to stdout",
+        )
+        parser.add_argument(
+            '--bibtex',
+            dest='create_bibtex',
+            action='store_true',
+            default=False,
+            help="create bibtex literature file",
+        )
+    if units:
+        # These need to be parsed to be usable.
+        parser.add_argument(
+            '--length',
+            dest='unit_length',
+            type=str,
+            default='parsec',
+            help="length unit",
+        )
+        parser.add_argument(
+            '--mass',
+            dest='unit_mass',
+            type=str,
+            default='MSun',
+            help="mass unit",
+        )
+        parser.add_argument(
+            '--time',
+            dest='unit_time',
+            type=str,
+            default='Myr',
+            help="time unit",
+        )
+        parser.add_argument(
+            '--speed',
+            dest='unit_speed',
+            type=str,
+            default='kms',
+            help="speed unit",
+        )
+    return parser

--- a/src/amuse/units/optparse.py
+++ b/src/amuse/units/optparse.py
@@ -1,7 +1,7 @@
 print(
     "warning: amuse.units.optparse is deprecated, please use "
     "amuse.support.argparse instead (see "
-    "https://github.com/amusecode/amuse/...)"
+    "https://github.com/amusecode/amuse/pull/1011)"
 )
 
 import optparse

--- a/src/amuse/units/optparse.py
+++ b/src/amuse/units/optparse.py
@@ -1,4 +1,8 @@
-
+print(
+    "warning: amuse.units.optparse is deprecated, please use "
+    "amuse.support.argparse instead (see "
+    "https://github.com/amusecode/amuse/...)"
+)
 
 import optparse
 import textwrap
@@ -110,7 +114,6 @@ class OptionParser(optparse.OptionParser):
              add_help_option=True,
              prog=None,
              epilog=None):
-
 
         if formatter is None:
             formatter = IndentedHelpFormatter()


### PR DESCRIPTION
Related to #172 and #1008
- Adds a deprecation message to amuse.units.optparse
- adds amuse.support.argparse, which sets up an ArgumentParser instance with default AMUSE arguments and settings