### PR TITLE
Update rebound/patch_files.py - bugfix

### DIFF
--- a/src/amuse/community/rebound/patch_files.py
+++ b/src/amuse/community/rebound/patch_files.py
@@ -40,7 +40,7 @@ def is_quilt_installed():
         return False
 
     version_re = re.compile(r"(\d).(\d\d)")
-    match = version_re.match(stdoutstring)
+    match = version_re.match(str(stdoutstring))
     if not match:
         return False
 


### PR DESCRIPTION
`.match` expects a `str`, not a `bytes-like object`
This same bug probably appears elsewhere, it may be better to not have a separate `patch_files.py` for different community codes.