### PR TITLE
Update rebound interface to Rebound release version 4.0.1

### DIFF
--- a/src/amuse/community/rebound/Makefile
+++ b/src/amuse/community/rebound/Makefile
@@ -20,15 +20,37 @@ OBJS = interface.o
 
 CODELIB = src/librebound.a
 CODEDIR = src/rebound
-LIB_OBJ = $(CODEDIR)/src/rebound.o $(CODEDIR)/src/tree.o $(CODEDIR)/src/particle.o $(CODEDIR)/src/gravity.o \
-          $(CODEDIR)/src/integrator.o $(CODEDIR)/src/integrator_whfast.o $(CODEDIR)/src/integrator_whfasthelio.o \
-          $(CODEDIR)/src/integrator_ias15.o $(CODEDIR)/src/integrator_sei.o $(CODEDIR)/src/integrator_leapfrog.o \
-          $(CODEDIR)/src/integrator_hermes.o $(CODEDIR)/src/boundary.o \
-          $(CODEDIR)/src/collision.o $(CODEDIR)/src/tools.o \
-          $(CODEDIR)/src/communication_mpi.o $(CODEDIR)/src/display.o $(CODEDIR)/src/derivatives.o \
-          $(CODEDIR)/src/glad.o $(CODEDIR)/src/integrator_janus.o $(CODEDIR)/src/transformations.o \
-          $(CODEDIR)/src/simulationarchive.o $(CODEDIR)/src/output.o \
-          $(CODEDIR)/src/input.o \
+LIB_OBJ = \
+	  $(CODEDIR)/src/rebound.o \
+	  $(CODEDIR)/src/tree.o \
+	  $(CODEDIR)/src/particle.o \
+	  $(CODEDIR)/src/gravity.o \
+          $(CODEDIR)/src/integrator.o \
+	  $(CODEDIR)/src/integrator_whfast.o \
+	  $(CODEDIR)/src/integrator_whfast512.o \
+	  $(CODEDIR)/src/integrator_saba.o \
+          $(CODEDIR)/src/integrator_ias15.o \
+	  $(CODEDIR)/src/integrator_sei.o \
+	  $(CODEDIR)/src/integrator_bs.o \
+	  $(CODEDIR)/src/integrator_leapfrog.o \
+          $(CODEDIR)/src/integrator_mercurius.o \
+          $(CODEDIR)/src/integrator_eos.o \
+	  $(CODEDIR)/src/boundary.o \
+	  $(CODEDIR)/src/input.o \
+	  $(CODEDIR)/src/binarydiff.o \
+	  $(CODEDIR)/src/output.o \
+          $(CODEDIR)/src/collision.o \
+          $(CODEDIR)/src/communication_mpi.o \
+	  $(CODEDIR)/src/display.o \
+	  $(CODEDIR)/src/tools.o \
+	  $(CODEDIR)/src/rotations.o \
+	  $(CODEDIR)/src/derivatives.o \
+          $(CODEDIR)/src/simulationarchive.o \
+          $(CODEDIR)/src/glad.o \
+	  $(CODEDIR)/src/integrator_janus.o \
+	  $(CODEDIR)/src/transformations.o \
+	  $(CODEDIR)/src/fmemopen.o \
+          $(CODEDIR)/src/server.o
 
 DOWNLOAD_FROM_WEB = $(PYTHON) ./download.py
 PATCH_FILES = $(PYTHON) ./patch_files.py
@@ -39,25 +61,8 @@ AM_CFLAGS = -I$(AMUSE_DIR)/lib/amuse_mpi
 
 all: rebound_worker 
 
-DOWNLOAD_CODES?=1
-
-ifdef DOWNLOAD_CODES
 $(CODEDIR)/Makefile:
 	make -C . download
-else
-$(CODEDIR)/Makefile:
-	@echo ""
-	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-	@echo ""
-	@echo "DOWNLOAD_CODES is not set. Rebound will not be downloaded and built."
-	@echo "If you do want Rebound, set DOWNLOAD_CODES to 1."
-	@echo "bash> export DOWNLOAD_CODES=1"
-	@echo "csh> setenv DOWNLOAD_CODES 1"
-	@echo ""
-	@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-	@echo ""
-	@make -s --no-print-directory -C . raise_error
-endif
 
 download:
 	$(RM) -Rf .pc
@@ -85,7 +90,7 @@ distclean:
 	$(RM) -Rf .pc
 
 $(CODELIB): $(CODEDIR)/Makefile
-	make -C $(CODEDIR) all CC=$(CC)
+	make -C $(CODEDIR) librebound CC=$(CC)
 	ar rv $(CODELIB) $(LIB_OBJ)
 	ranlib $(CODELIB)
 

--- a/src/amuse/community/rebound/download.py
+++ b/src/amuse/community/rebound/download.py
@@ -2,18 +2,22 @@
 
 import subprocess
 import os
-import sys
-import time
+import argparse
 import urllib.request
 import urllib.parse
 import urllib.error
-from optparse import OptionParser
+from shutil import which
 
 
-class GetCodeFromHttp(object):
-    url_template = "https://github.com/hannorein/rebound/archive/{version}.tar.gz"
+class GetCodeFromHttp:
     filename_template = "{version}.tar.gz"
-    version = ""
+    name = ["rebound"]
+    url_template = [
+        "https://github.com/hannorein/rebound/archive/{version}.tar.gz"
+    ]
+    version = [
+        "",
+    ]
 
     def directory(self):
         return os.path.abspath(os.path.dirname(__file__))
@@ -21,13 +25,13 @@ class GetCodeFromHttp(object):
     def src_directory(self):
         return os.path.join(self.directory(), "src")
 
-    def unpack_downloaded_file(self, filename):
-        print("unpacking", filename)
+    def unpack_downloaded_file(self, filename, name, version):
+        print(f"unpacking {filename}")
         arguments = ["tar", "-xf"]
         arguments.append(filename)
         subprocess.call(arguments, cwd=os.path.join(self.src_directory()))
         subprocess.call(
-            ["mv", "rebound-{version}".format(version=self.version), "rebound"],
+            ["mv", f"{name}-{version}", name],
             cwd=os.path.join(self.src_directory()),
         )
         print("done")
@@ -35,42 +39,54 @@ class GetCodeFromHttp(object):
     def start(self):
         if os.path.exists("src"):
             counter = 0
-            while os.path.exists("src.{0}".format(counter)):
+            while os.path.exists(f"src.{counter}"):
                 counter += 1
                 if counter > 100:
                     print("too many backup directories")
                     break
-            os.rename("src", "src.{0}".format(counter))
+            os.rename("src", f"src.{counter}")
 
         os.mkdir("src")
 
-        url = self.url_template.format(version=self.version)
-        filename = self.filename_template.format(version=self.version)
-        filepath = os.path.join(self.src_directory(), filename)
-        print("downloading version", self.version, "from", url, "to", filename)
-        urllib.request.urlretrieve(url, filepath)
-        print("downloading finished")
-        self.unpack_downloaded_file(filename)
+        for i, url_template in enumerate(self.url_template):
+            url = url_template.format(version=self.version[i])
+            filename = self.filename_template.format(version=self.version[i])
+            filepath = os.path.join(self.src_directory(), filename)
+            print(f"downloading version {self.version[i]} from {url} to {filename}")
+            if which("wget") is not None:
+                arguments = ["wget", url]
+                subprocess.call(arguments, cwd=os.path.join(self.src_directory()))
+            elif which("curl") is not None:
+                arguments = ["curl", "-L", "-O", url]
+                subprocess.call(arguments, cwd=os.path.join(self.src_directory()))
+            else:
+                urllib.request.urlretrieve(url, filepath)
+            print("downloading finished")
+            self.unpack_downloaded_file(filename, self.name[i], self.version[i])
+
+
+def new_argument_parser():
+    result = argparse.ArgumentParser()
+    result.add_argument(
+        "--rebound-version",
+        default="111bcd50de54e4cc70e1d4915918226a4adbe188",
+        # default="4df2b4603058e7d767aee9c26b586b55a5f4de65",
+        dest="rebound_version",
+        help="Rebound commit hash to download",
+        type=str,
+    )
+    return result
 
 
 def main(version=""):
+    arguments = new_argument_parser().parse_args()
+    version = [
+        arguments.rebound_version,
+    ]
     instance = GetCodeFromHttp()
     instance.version = version
     instance.start()
 
 
-def new_option_parser():
-    result = OptionParser()
-    result.add_option(
-        "--version",
-        default="31d117bdc92182073d0941c331f76e95f515bfc6",
-        dest="version",
-        help="version number to download",
-        type="string",
-    )
-    return result
-
-
 if __name__ == "__main__":
-    options, arguments = new_option_parser().parse_args()
-    main(**options.__dict__)
+    main()

--- a/src/amuse/community/rebound/interface.cc
+++ b/src/amuse/community/rebound/interface.cc
@@ -71,7 +71,7 @@ static inline particle_location get_particle_from_identity(int index_of_the_part
     for( ReboundSimulationVector::iterator i = codes.begin(); i != codes.end(); i++) {
         code_state cs = *i;
         particle.code = cs.code;
-        particle.p = reb_get_particle_by_hash(particle.code, index_of_the_particle);
+        particle.p = reb_simulation_particle_by_hash(particle.code, index_of_the_particle);
         if (particle.p != NULL) break;
         //*i = cs;
     }
@@ -124,7 +124,7 @@ int set_mass(int index_of_the_particle, double mass){
 
     if(p->m==0){
         if(mass>0){
-            int index_old=reb_get_particle_index(p);
+            int index_old=reb_simulation_particle_index(p);
             if(index_old!=code->N_active){
                 struct reb_particle tmp = code->particles[index_old];
                 for(int j=index_old; j>code->N_active; j--){
@@ -137,7 +137,7 @@ int set_mass(int index_of_the_particle, double mass){
     }
     else {
         if(mass==0){
-            int index_old=reb_get_particle_index(p);
+            int index_old=reb_simulation_particle_index(p);
             code->N_active--;
 
             if(index_old!=code->N_active){
@@ -178,7 +178,7 @@ int new_particle(int * index_of_the_particle, double mass, double x,
       pt.m = mass;
       pt.r = radius; 
       pt.hash = new_hash;
-      reb_add(codes[code_index].code, pt);
+      reb_simulation_add(codes[code_index].code, pt);
       //std::cout<<"new particle :"<<pt.id<< " << "<<code_index<<" << "<<pt.x<<std::endl;
       *index_of_the_particle = new_hash;
 
@@ -275,10 +275,10 @@ int _evolve_code(double _tmax, code_state * cs){
             return(1);
         }
        
-        reb_step(code);                                 // 0 to not do timing within step 
+        reb_simulation_step(code);                                 // 0 to not do timing within step 
         
         if ((code->t+code->dt)*dtsign>=tmax*dtsign && exact_finish_time==1){
-            reb_integrator_synchronize(code);
+            reb_simulation_synchronize(code);
             code->dt = tmax-code->t;
             last_step++;
         }else{
@@ -383,7 +383,7 @@ int _evolve_code(double _tmax, code_state * cs){
             }
         }
     }
-    reb_integrator_synchronize(code);
+    reb_simulation_synchronize(code);
     code->dt = code->dt_last_done;
     get_kinetic_energy(cs->subset, &ke1);
     //printf("Code time: %d ,  %f -> %f (%f,%f)\n",cs->subset , code->t, tmax, ke1, (ke1-ke)/ke);
@@ -437,7 +437,7 @@ int _delete_particle(int index_of_the_particle, int code_index){
     if(code_index < 0 || code_index >= (signed) codes.size()){
         return -10;
     }
-    reb_remove_by_hash(codes[code_index].code, index_of_the_particle, keepSorted);
+    reb_simulation_remove_particle_by_hash(codes[code_index].code, index_of_the_particle, keepSorted);
     return 0;
 }
 
@@ -495,7 +495,7 @@ int get_state(int index_of_the_particle, double * mass, double * x,
 #endif // COLLISIONS_NONE
     for( ReboundSimulationVector::iterator i = codes.begin(); i != codes.end(); i++) {
         code_state cs = *i;
-        p = reb_get_particle_by_hash(cs.code, index_of_the_particle);
+        p = reb_simulation_particle_by_hash(cs.code, index_of_the_particle);
         if (p != NULL) {
             *subset = cs.subset;
             break;
@@ -608,7 +608,7 @@ int get_subset(int index_of_the_particle, int * subset){
     struct reb_particle* p=NULL;
     for( ReboundSimulationVector::iterator i = codes.begin(); i != codes.end(); i++) {
         code_state cs = *i;
-        p = reb_get_particle_by_hash(cs.code, index_of_the_particle);
+        p = reb_simulation_particle_by_hash(cs.code, index_of_the_particle);
         if (p != NULL) {
             *subset = cs.subset;
             break;
@@ -638,7 +638,7 @@ int set_subset(int index_of_the_particle, int subset){
     struct reb_particle* p=NULL;
     for( ReboundSimulationVector::iterator i = codes.begin(); i != codes.end(); i++) {
         code_state cs = *i;
-        p = reb_get_particle_by_hash(cs.code, index_of_the_particle);
+        p = reb_simulation_particle_by_hash(cs.code, index_of_the_particle);
         if (p != NULL) {
             if(cs.subset != subset) {return -2;}
             break;
@@ -653,8 +653,8 @@ int cleanup_code() {
     for( ReboundSimulationVector::iterator i = codes.begin(); i != codes.end(); i++) {
         code_state cs = *i;
         if(cs.code){
-            reb_remove_all(cs.code);
-            reb_free_simulation(cs.code);
+            reb_simulation_remove_all_particles(cs.code);
+            reb_simulation_free(cs.code);
             cs.code = 0;
             *i = cs;
         }
@@ -679,7 +679,7 @@ int initialize_code(){
     int nt = omp_get_max_threads();
     omp_set_num_threads(nt);
 #endif
-    reb_simulation * code = reb_create_simulation();
+    reb_simulation * code = reb_simulation_create();
     codes.push_back(code_state(code));
     code->integrator = reb_simulation::REB_INTEGRATOR_IAS15;
     code->N_active = 0;
@@ -789,8 +789,8 @@ int set_velocity(int index_of_the_particle, double vx, double vy,
 }
 
 int new_subset(int * index, double time_offset) {
-    reb_simulation * code = reb_create_simulation();
-    reb_integrator_reset(code);
+    reb_simulation * code = reb_simulation_create();
+    reb_simulation_reset_integrator(code);
     code->dt = timestep;
     if(time_offset < 0) {time_offset = _time;}
     code->integrator = reb_simulation::REB_INTEGRATOR_IAS15;
@@ -811,8 +811,8 @@ int stop_subset(int code_index) {
     code_state cs = codes[code_index];
     if(cs.code) {
         reb_simulation * code = cs.code;
-        reb_remove_all(code);
-        reb_free_simulation(code);
+        reb_simulation_remove_all_particles(code);
+        reb_simulation_free(code);
         cs.code = 0;
         codes[code_index] = cs;
     }
@@ -845,10 +845,12 @@ int _set_integrator(int value, int code_index){
             code->integrator = reb_simulation::REB_INTEGRATOR_LEAPFROG;
             break;
         case 5:
-            code->integrator = reb_simulation::REB_INTEGRATOR_HERMES;
+            // This integrator was removed
+            return -1;
             break;
         case 6:
-            code->integrator = reb_simulation::REB_INTEGRATOR_WHFASTHELIO;
+            // This integrator was removed
+            return -1;
             break;
         case 7:
             code->integrator = reb_simulation::REB_INTEGRATOR_NONE;
@@ -856,6 +858,21 @@ int _set_integrator(int value, int code_index){
         case 8:
             code->integrator = reb_simulation::REB_INTEGRATOR_JANUS;
             break;
+	case 9:
+	    code->integrator = reb_simulation::REB_INTEGRATOR_WHFAST512;
+	    break;
+	case 10:
+	    code->integrator = reb_simulation::REB_INTEGRATOR_SABA;
+	    break;
+	case 11:
+	    code->integrator = reb_simulation::REB_INTEGRATOR_MERCURIUS;
+	    break;
+	case 12:
+	    code->integrator = reb_simulation::REB_INTEGRATOR_EOS;
+	    break;
+	case 13:
+	    code->integrator = reb_simulation::REB_INTEGRATOR_BS;
+	    break;
         default:
             code->integrator = reb_simulation::REB_INTEGRATOR_NONE;
             return -1;
@@ -1014,7 +1031,7 @@ int set_boundary_size(double boundary_size, int code_index){
         return -11;
     }
     reb_simulation * code = codes[code_index].code;
-    reb_configure_box(code,boundary_size,1,1,1);
+    reb_simulation_configure_box(code,boundary_size,1,1,1);
     return 0;
 }
 

--- a/src/amuse/community/rebound/interface.py
+++ b/src/amuse/community/rebound/interface.py
@@ -1,8 +1,17 @@
-from amuse.community import *
-from amuse.community.interface.gd import GravitationalDynamicsInterface
-from amuse.community.interface.gd import GravitationalDynamics
-from amuse.community.interface.gd import SinglePointGravityFieldInterface
-from amuse.community.interface.gd import GravityFieldCode
+from amuse.units import nbody_system
+from amuse.community import (
+    CodeInterface,
+    LiteratureReferencesMixIn,
+    StoppingConditionInterface,
+    StoppingConditions,
+    legacy_function,
+    LegacyFunctionSpecification,
+)
+from amuse.community.interface.gd import (
+    GravitationalDynamicsInterface,
+    GravitationalDynamics,
+    GravityFieldCode,
+)
 
 
 class ReboundInterface(
@@ -10,7 +19,6 @@ class ReboundInterface(
     LiteratureReferencesMixIn,
     GravitationalDynamicsInterface,
     StoppingConditionInterface,
-    # SinglePointGravityFieldInterface
 ):
     """
     REBOUND - An open-source multi-purpose N-body code
@@ -105,7 +113,10 @@ class ReboundInterface(
             "subset",
             dtype="int32",
             direction=function.IN,
-            description="The subset index of the particle (defaults to 0, use new_subset for higher indices)",
+            description=(
+                "The subset index of the particle "
+                "(defaults to 0, use new_subset for higher indices)"
+            ),
             default=0,
         )
         function.result_type = "int32"
@@ -180,10 +191,15 @@ class ReboundInterface(
         "whfast": 1,
         "sei": 2,
         "leapfrog": 4,
-        "hermes": 5,
-        "whfast-helio": 6,
+        "hermes": 5,  # removed
+        "whfast-helio": 6,  # removed
         "none": 7,
         "janus": 8,
+        "whfast512": 9,
+        "saba": 10,
+        "mercurius": 11,
+        "eos": 12,
+        "bs": 13,
     }
 
     def set_integrator(self, name, code_index=0):
@@ -226,7 +242,12 @@ class ReboundInterface(
         function.can_handle_array = False
         return function
 
-    SOLVERS = {"none": 0, "basic": 1, "compensated": 2, "tree": 3}
+    SOLVERS = {
+        "none": 0,
+        "basic": 1,
+        "compensated": 2,
+        "tree": 3,
+    }
 
     def set_solver(self, name, code_index=0):
         return self._set_solver(self.SOLVERS[name], code_index)
@@ -280,7 +301,8 @@ class ReboundInterface(
     def get_eps2():
         function = LegacyFunctionSpecification()
         """
-        Get epsilon^2, a softening parameter for gravitational potentials with point particles.
+        Get epsilon^2, a softening parameter for gravitational potentials with
+        point particles.
         """
         function = LegacyFunctionSpecification()
         function.addParameter(
@@ -294,7 +316,10 @@ class ReboundInterface(
             "epsilon_squared",
             dtype="float64",
             direction=function.OUT,
-            description="epsilon^2, a softening parameter for gravitational potentials with point particles",
+            description=(
+                "epsilon^2, a softening parameter for gravitational "
+                "potentials with point particles"
+            ),
             unit=nbody_system.length * nbody_system.length,
         )
         function.result_type = "int32"
@@ -309,14 +334,18 @@ class ReboundInterface(
     @legacy_function
     def set_eps2():
         """
-        Set epsilon^2, a softening parameter for gravitational potentials with point particles.
+        Set epsilon^2, a softening parameter for gravitational potentials with
+        point particles.
         """
         function = LegacyFunctionSpecification()
         function.addParameter(
             "epsilon_squared",
             dtype="float64",
             direction=function.IN,
-            description="epsilon^2, a softening parameter for gravitational potentials with point particles",
+            description=(
+                "epsilon^2, a softening parameter for gravitational "
+                "potentials with point particles"
+            ),
             unit=nbody_system.length * nbody_system.length,
         )
         function.addParameter(
@@ -338,7 +367,9 @@ class ReboundInterface(
     @legacy_function
     def _set_boundary():
         function = LegacyFunctionSpecification()
-        function.addParameter("boundary_name", dtype="i", direction=function.IN)
+        function.addParameter(
+            "boundary_name", dtype="i", direction=function.IN
+        )
         function.addParameter(
             "code_index",
             dtype="int32",
@@ -360,12 +391,19 @@ class ReboundInterface(
             description="Index of the code in rebound",
             default=0,
         )
-        function.addParameter("boundary_name", dtype="i", direction=function.OUT)
+        function.addParameter(
+            "boundary_name", dtype="i", direction=function.OUT
+        )
         function.result_type = "int32"
         function.can_handle_array = False
         return function
 
-    BOUNDARIES = {"none": 0, "open": 1, "periodic": 2, "shear": 3}
+    BOUNDARIES = {
+        "none": 0,
+        "open": 1,
+        "periodic": 2,
+        "shear": 3,
+    }
 
     def set_boundary(self, name, code_index=0):
         return self._set_boundary(self.BOUNDARIES[name], code_index)
@@ -443,7 +481,8 @@ class ReboundInterface(
         """
         function = LegacyFunctionSpecification()
         function.addParameter(
-            "timestep", dtype="float64", direction=function.IN, description="timestep"
+            "timestep", dtype="float64", direction=function.IN,
+            description="timestep"
         )
         function.addParameter(
             "code_index",
@@ -518,7 +557,8 @@ class ReboundInterface(
     @legacy_function
     def evolve_model():
         """
-        Evolve the model until the given time, or until a stopping condition is set.
+        Evolve the model until the given time, or until a stopping condition is
+        set.
         """
         function = LegacyFunctionSpecification()
         function.addParameter(
@@ -532,7 +572,9 @@ class ReboundInterface(
             "code_index",
             dtype="int32",
             direction=function.IN,
-            description="Index of the code in rebound (default -1, evolve all systems)",
+            description=(
+                "Index of the code in rebound (default -1, evolve all systems)"
+            ),
             default=-1,
         )
         function.result_type = "int32"
@@ -541,9 +583,9 @@ class ReboundInterface(
     @legacy_function
     def get_time():
         """
-        Retrieve the model time. This time should be close to the end time specified
-        in the evolve code. Or, when a collision was detected, it will be the
-        model time of the collision.
+        Retrieve the model time. This time should be close to the end time
+        specified in the evolve code. Or, when a collision was detected, it
+        will be the model time of the collision.
         """
         function = LegacyFunctionSpecification()
         function.addParameter(
@@ -599,7 +641,8 @@ class ReboundInterface(
     @legacy_function
     def new_subset():
         """
-        Create a new particle subset (and corresponding code). This subset will evolve seperately from others.
+        Create a new particle subset (and corresponding code). This subset will
+        evolve separately from others.
         """
         function = LegacyFunctionSpecification()
         function.can_handle_array = True
@@ -616,7 +659,9 @@ class ReboundInterface(
             "time_offset",
             dtype="float64",
             direction=function.IN,
-            description="Time of the system (defaults to the current model time)",
+            description=(
+                "Time of the system (defaults to the current model time)"
+            ),
             default=-1,
         )
         function.result_type = "int32"
@@ -629,8 +674,9 @@ class ReboundInterface(
     @legacy_function
     def get_state():
         """
-        Retrieve the current state of a particle. The *minimal* information of a stellar
-        dynamics particle (mass, radius, position and velocity) is returned.
+        Retrieve the current state of a particle. The *minimal* information of
+        a stellar dynamics particle (mass, radius, position and velocity) is
+        returned.
         """
         function = LegacyFunctionSpecification()
         function.can_handle_array = True
@@ -638,7 +684,10 @@ class ReboundInterface(
             "index_of_the_particle",
             dtype="int32",
             direction=function.IN,
-            description="Index of the particle to get the state from. This index must have been returned by an earlier call to :meth:`new_particle`",
+            description=(
+                "Index of the particle to get the state from. This index must "
+                "have been returned by an earlier call to :meth:`new_particle`"
+            ),
         )
         function.addParameter(
             "mass",
@@ -713,7 +762,10 @@ class ReboundInterface(
             "index_of_the_particle",
             dtype="int32",
             direction=function.IN,
-            description="Index of the particle to get the subset of. This index must have been returned by an earlier call to :meth:`new_particle`",
+            description=(
+                "Index of the particle to get the subset of. This index must "
+                "have been returned by an earlier call to :meth:`new_particle`"
+            ),
         )
         function.addParameter(
             "subset",
@@ -725,7 +777,7 @@ class ReboundInterface(
         function.can_handle_array = True
         function.result_doc = """
         0 - OK
-            particle was found in the model and the information was retreived
+            particle was found in the model and the information was retrieved
         -1 - ERROR
             particle could not be found
         """
@@ -764,19 +816,25 @@ class ReboundInterface(
             "index_of_the_particle",
             dtype="int32",
             direction=function.IN,
-            description="Index of the particle to get the subset of. This index must have been returned by an earlier call to :meth:`new_particle`",
+            description=(
+                "Index of the particle to get the subset of. This index must "
+                "have been returned by an earlier call to :meth:`new_particle`"
+            ),
         )
         function.addParameter(
             "subset",
             dtype="int32",
             direction=function.IN,
-            description="The new subset of the particle, as this is actually read only this will fail if changed!",
+            description=(
+                "The new subset of the particle, as this is actually read only "
+                "this will fail if changed!"
+            ),
         )
         function.result_type = "int32"
         function.can_handle_array = True
         function.result_doc = """
         0 - OK
-            particle was found in the model and the information was retreived
+            particle was found in the model and the information was retrieved
         -1 - ERROR
             particle could not be found
         """
@@ -828,8 +886,9 @@ class Rebound(GravitationalDynamics, GravityFieldCode):
             "get_solver",
             "set_solver",
             "solver",
-            "name of the gravity solver to use ({0})".format(
-                sorted(self.SOLVERS.keys())
+            (
+                f"name of the gravity solver to use "
+                f"({sorted(self.SOLVERS.keys())})"
             ),
             default_value="compensated",
         )
@@ -846,7 +905,10 @@ class Rebound(GravitationalDynamics, GravityFieldCode):
             "get_opening_angle2",
             "set_opening_angle2",
             "opening_angle2",
-            "opening angle, theta, for building the tree in case of tree solver: between 0 and 1",
+            (
+                "opening angle, theta, for building the tree in case of "
+                "tree solver: between 0 and 1"
+            ),
             default_value=0.5,
         )
 
@@ -854,8 +916,9 @@ class Rebound(GravitationalDynamics, GravityFieldCode):
             "get_boundary",
             "set_boundary",
             "boundary",
-            "name of the boundary type to use ({0}) (required for tree solver)".format(
-                sorted(self.BOUNDARIES.keys())
+            (
+                f"name of the boundary type to use "
+                f"({sorted(self.BOUNDARIES.keys())}) (required for tree solver)"
             ),
             default_value="none",
         )
@@ -907,7 +970,9 @@ class Rebound(GravitationalDynamics, GravityFieldCode):
             ),
         )
         handler.add_method(
-            "evolve_model", (nbody_system.time, handler.INDEX), (handler.ERROR_CODE,)
+            "evolve_model",
+            (nbody_system.time, handler.INDEX),
+            (handler.ERROR_CODE,)
         )
         handler.add_method(
             "get_time",
@@ -953,7 +1018,9 @@ class Rebound(GravitationalDynamics, GravityFieldCode):
             ),
         )
         handler.add_method(
-            "get_subset", (handler.NO_UNIT,), (handler.NO_UNIT, handler.ERROR_CODE)
+            "get_subset",
+            (handler.NO_UNIT,),
+            (handler.NO_UNIT, handler.ERROR_CODE),
         )
         handler.add_method(
             "set_subset",


### PR DESCRIPTION
The Rebound version currently in AMUSE is quite old - this updates it to the latest release.
The current tests for the rebound interface still work, but should probably be extended.