### PR TITLE
Let hermite end at exactly the requested time by default

### DIFF
--- a/src/amuse/community/hermite/interface.cc
+++ b/src/amuse/community/hermite/interface.cc
@@ -73,7 +73,7 @@ static real t_evolve = t;                // Time requested by evolve.  Control r
                                 // system is computed by extrapolation.
 static real t_wanted = 0;
 static double begin_time = 0;
-static double end_time_accuracy_factor = 0.5;
+static double end_time_accuracy_factor = 0.0;
 
 static vector<int>  ident;
 static vector<real> mass, radius, potential;

--- a/src/amuse/community/hermite/interface.py
+++ b/src/amuse/community/hermite/interface.py
@@ -248,7 +248,7 @@ class Hermite(GravitationalDynamics, GravityFieldCode):
                 
             Valid factors are between -1.0 and 1.0
             """,
-            default_value = 1.0
+            default_value = 0.0
         )
         handler.add_method_parameter(
             "get_dt_dia",


### PR DESCRIPTION
set default value of hermite.parameters.end_time_accuracy_factor from 0.5 to 0.0