### PR TITLE
quantities: Make mean() more generic.

### DIFF
--- a/src/amuse/test/suite/core_tests/test_quantities.py
+++ b/src/amuse/test/suite/core_tests/test_quantities.py
@@ -415,6 +415,12 @@ class TestQuantities(amusetest.TestCase):
         x[0] = -1
         self.assertEqual(a, [1, 2, 3, 4, 5] | units.m)
 
+    def test_mean(self):
+        x = [1.0, 2.0, 3.0] | si.kg
+        mask = [True, True, False]
+        self.assertEqual(x.mean(), 2.0 | si.kg)
+        self.assertEqual(x.mean(where=mask), 1.5 | si.kg)
+
 
 class TestAdaptingVectorQuantities(amusetest.TestCase):
 

--- a/src/amuse/units/quantities.py
+++ b/src/amuse/units/quantities.py
@@ -973,8 +973,8 @@ class VectorQuantity(Quantity):
     def T(self):
         return VectorQuantity(self.number.T, self.unit)
 
-    def mean(self, axis=None, dtype=None, out=None):
-        return new_quantity(self.number.mean(axis, dtype, out), self.unit)
+    def mean(self, *args, **kwargs):
+        return new_quantity(self.number.mean(*args, **kwargs), self.unit)
 
     def median(self, **kwargs):
         return new_quantity(numpy.median(self.number, **kwargs), self.unit)


### PR DESCRIPTION
I ran into this while trying to pass the `where` argument to `numpy.mean()`.