### PR TITLE
split off astronomical constants from units

### DIFF
--- a/src/amuse/units/astronomical_constants.py
+++ b/src/amuse/units/astronomical_constants.py
@@ -1,0 +1,19 @@
+"""
+Series of astronomical constants, which are in turn used by the units of the
+same names.
+"""
+
+import numpy as np
+from amuse.units.si import m, kg
+from amuse.units.derivedsi import W, km
+
+au = 149597870691.0 | m
+parsec = au / np.tan(np.pi / (180 * 60 * 60))
+lightyear = 9460730472580.8 | km
+Lsun = 3.839e26 | W
+Msun = 1.98892e30 | kg
+Rsun = 6.955e8 | m
+Mjupiter = 1.8987e27 | kg
+Rjupiter = 71492.0 | km
+Mearth = 5.9722e24 | kg
+Rearth = 6371.0088 | km  # IUGG mean radius

--- a/src/amuse/units/units.py
+++ b/src/amuse/units/units.py
@@ -4,6 +4,7 @@ Units supported in AMUSE
 
 import numpy
 from . import constants
+from . import astronomical_constants
 from . import quantities
 
 # The two imports below are to explicitly expose everything directly used in
@@ -43,20 +44,20 @@ Ry = named(
 
 # astronomical units
 angstrom = named("angstrom", "angstrom", 1e-10 * m)
-au = named("astronomical unit", "au", 149597870691.0 * m)
-aud = named("au per day", "aud", 149597870691.0 * m / day)
-parsec = named("parsec", "parsec", au / numpy.tan(numpy.pi / (180 * 60 * 60)))
+au = named("astronomical unit", "au", astronomical_constants.au.as_unit())
+aud = named("au per day", "aud", astronomical_constants.au.as_unit() / day)
+parsec = named("parsec", "parsec", astronomical_constants.parsec.as_unit())
 kpc = named("kilo parsec", "kpc", 10**3 * parsec)
 Mpc = named("mega parsec", "Mpc", 10**6 * parsec)
 Gpc = named("giga parsec", "Gpc", 10**9 * parsec)
-lightyear = named("light year", "ly", 9460730472580.8 * km)
-LSun = named("solar luminosity", "LSun", 3.839e26 * W)
-MSun = named("solar mass", "MSun", 1.98892e30 * kg)
-RSun = named("solar radius", "RSun", 6.955e8 * m)
-MJupiter = named("jupiter mass", "MJupiter", 1.8987e27 * kg)
-RJupiter = named("jupiter radius", "RJupiter", 71492.0 * km)
-MEarth = named("earth mass", "MEarth", 5.9722e24 * kg)
-REarth = named("earth radius", "REarth", 6371.0088 * km)  # IUGG mean radius
+lightyear = named("light year", "ly", astronomical_constants.lightyear.as_unit())
+LSun = named("solar luminosity", "LSun", astronomical_constants.Lsun.as_unit())
+MSun = named("solar mass", "MSun", astronomical_constants.Msun.as_unit())
+RSun = named("solar radius", "RSun", astronomical_constants.Rsun.as_unit())
+MJupiter = named("jupiter mass", "MJupiter", astronomical_constants.Mjupiter.as_unit())
+RJupiter = named("jupiter radius", "RJupiter", astronomical_constants.Rjupiter.as_unit())
+MEarth = named("earth mass", "MEarth", astronomical_constants.Mearth.as_unit())
+REarth = named("earth radius", "REarth", astronomical_constants.Rearth.as_unit())
 kyr = named("kilo year", "kyr", 1000 * yr)
 myr = named("million year", "Myr", 1000000 * yr)
 gyr = named("giga (billion) year", "Gyr", 1000000000 * yr)


### PR DESCRIPTION
Astronomical constants have changed, this is part of an effort to make these easier updateable.
units.py should not contain changeable values anymore.