### PR TITLE
Update g6lib.c

### DIFF
--- a/lib/g6/g6lib.c
+++ b/lib/g6/g6lib.c
@@ -109,7 +109,7 @@ inline double vec_dot(vector3 va, vector3 vb){
     return result;
 }
 
-inline clear_i_particle(g6_i_particle * particle) {
+inline void clear_i_particle(g6_i_particle * particle) {
     int k;
     for(k = 0; k < 3; k++) {
         particle->acc[k] = 0.0;


### PR DESCRIPTION
Fixes issue encountered with GCC 14.1:
```
g6lib.c:112:8: error: return type defaults to 'int' [-Wimplicit-int]
  112 | inline clear_i_particle(g6_i_particle * particle) {
      |        ^~~~~~~~~~~~~~~~
make: *** [g6lib.o] Error 1
```