### PR TITLE
Fix amusifier Python 3.13 compatibility

### DIFF
--- a/src/amuse/datamodel/attributes.py
+++ b/src/amuse/datamodel/attributes.py
@@ -17,7 +17,7 @@ class DomainMetaclass(type):
     def __new__(metaclass, name, bases, dict):
         replacement_dictionary = {}
         for key, value in dict.items():
-            if isinstance(value, tuple):
+            if not key.startswith('__') and isinstance(value, tuple):
                 default_value, description = value
                 replacement_dictionary[key] = AttributeDefinition(
                     key, description, default_value.unit, default_value

--- a/src/amuse/datamodel/base.py
+++ b/src/amuse/datamodel/base.py
@@ -528,7 +528,7 @@ def new_particles_function_attribute_with_doc(function):
 
 def new_particle_function_attribute_with_doc(function):
     class BoundParticleFunctionAttribute(object):
-        if function.__doc__:
+        if function is not None and function.__doc__:
             __doc__ = (
                 "\n  Documentation on '{0}' particle function attribute:"
                 "\n\n".format(function.__name__) + function.__doc__


### PR DESCRIPTION
Here are some small fixes to make the amusifier not crash on Python 3.13. I've tested this manually on 3.13 and also on 3.8 to check for regressions, and it works on both.

To explain:

In attributes.py, `dict` is the namespace of the class, so it contains the parameter declarations in the classes but also a bunch of variables made by Python. The latter all have dunder names, the former don't, but instead of checking the name of the key, we check the type of the value. Python 3.13 added a new variable that happens to have an empty tuple as its value, so we crash.

In `base.py`, `function` is `None` (by design, apparently) and `None` used to have a `__doc__` that was `None`, but in Python 3.13 it's a string describing the `None` object. So it's no longer the case that any object that has a `__doc__` also has a `__name__`, because now `None` has the former but not the latter. That was questionable anyway. So there's an extra check for `None` here.

Fixes #1082