### PR TITLE
Issue 940: update mpreal.h

### DIFF
--- a/src/amuse/community/adaptb/src/mpreal.h
+++ b/src/amuse/community/adaptb/src/mpreal.h
@@ -1,34 +1,35 @@
 /*
-    MPFR C++: Multi-precision floating point number class for C++. 
+    MPFR C++: Multi-precision floating point number class for C++.
     Based on MPFR library:    http://mpfr.org
 
     Project homepage:    http://www.holoborodko.com/pavel/mpfr
     Contact e-mail:      pavel@holoborodko.com
 
-    Copyright (c) 2008-2019 Pavel Holoborodko
+    Copyright (c) 2008-2024 Pavel Holoborodko
 
     Contributors:
-    Dmitriy Gubanov, Konstantin Holoborodko, Brian Gladman, 
-    Helmut Jarausch, Fokko Beekhof, Ulrich Mutze, Heinz van Saanen, 
-    Pere Constans, Peter van Hoof, Gael Guennebaud, Tsai Chia Cheng, 
+    Dmitriy Gubanov, Konstantin Holoborodko, Brian Gladman,
+    Helmut Jarausch, Fokko Beekhof, Ulrich Mutze, Heinz van Saanen,
+    Pere Constans, Peter van Hoof, Gael Guennebaud, Tsai Chia Cheng,
     Alexei Zubanov, Jauhien Piatlicki, Victor Berger, John Westwood,
     Petr Aleksandrov, Orion Poplawski, Charles Karney, Arash Partow,
-    Rodney James, Jorge Leitao, Jerome Benoit, Michal Maly.
+    Rodney James, Jorge Leitao, Jerome Benoit, Michal Maly, 
+    Abhinav Natarajan, Valerio Di Lecce, Luca Vandelli.
 
     Licensing:
     (A) MPFR C++ is under GNU General Public License ("GPL").
-    
-    (B) Non-free licenses may also be purchased from the author, for users who 
+
+    (B) Non-free licenses may also be purchased from the author, for users who
         do not want their programs protected by the GPL.
 
-        The non-free licenses are for users that wish to use MPFR C++ in 
-        their products but are unwilling to release their software 
-        under the GPL (which would require them to release source code 
+        The non-free licenses are for users that wish to use MPFR C++ in
+        their products but are unwilling to release their software
+        under the GPL (which would require them to release source code
         and allow free redistribution).
 
         Such users can purchase an unlimited-use license from the author.
         Contact us for more details.
-    
+
     GNU General Public License ("GPL") copyright permissions statement:
     **************************************************************************
     This program is free software: you can redistribute it and/or modify
@@ -68,19 +69,19 @@
 
 // Library version
 #define MPREAL_VERSION_MAJOR 3
-#define MPREAL_VERSION_MINOR 6
-#define MPREAL_VERSION_PATCHLEVEL 6
-#define MPREAL_VERSION_STRING "3.6.6"
+#define MPREAL_VERSION_MINOR 7
+#define MPREAL_VERSION_PATCHLEVEL 1
+#define MPREAL_VERSION_STRING "3.7.1"
 
 // Detect compiler using signatures from http://predef.sourceforge.net/
 #if defined(__GNUC__) && defined(__INTEL_COMPILER)
-    #define IsInf(x) isinf(x)                   // Intel ICC compiler on Linux 
+    #define MPREAL_IS_INF(x) isinf(x)           // Intel ICC compiler on Linux
 
-#elif defined(_MSC_VER)                         // Microsoft Visual C++ 
-    #define IsInf(x) (!_finite(x))                           
+#elif defined(_MSC_VER)                         // Microsoft Visual C++
+    #define MPREAL_IS_INF(x) (!_finite(x))
 
 #else
-    #define IsInf(x) std::isinf(x)              // GNU C/C++ (and/or other compilers), just hope for C99 conformance
+    #define MPREAL_IS_INF(x) std::isinf(x)      // GNU C/C++ (and/or other compilers), just hope for C99 conformance
 #endif
 
 // A Clang feature extension to determine compiler features.
@@ -98,12 +99,12 @@
 
     #define MPREAL_HAVE_MOVE_SUPPORT
 
-    // Use fields in mpfr_t structure to check if it was initialized / set dummy initialization 
+    // Use fields in mpfr_t structure to check if it was initialized / set dummy initialization
     #define mpfr_is_initialized(x)      (0 != (x)->_mpfr_d)
     #define mpfr_set_uninitialized(x)   ((x)->_mpfr_d = 0 )
 #endif
 
-// Detect support for explicit converters. 
+// Detect support for explicit converters.
 #if (__has_feature(cxx_explicit_conversions) || \
        (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC_MINOR >= 5) || __cplusplus >= 201103L || \
        (defined(_MSC_VER) && _MSC_VER >= 1800) || \
@@ -112,24 +113,33 @@
     #define MPREAL_HAVE_EXPLICIT_CONVERTERS
 #endif
 
-#define MPFR_USE_INTMAX_T   // Enable 64-bit integer types - should be defined before mpfr.h
-
 #if defined(MPREAL_HAVE_MSVC_DEBUGVIEW) && defined(_MSC_VER) && defined(_DEBUG)
     #define MPREAL_MSVC_DEBUGVIEW_CODE     DebugView = toString();
     #define MPREAL_MSVC_DEBUGVIEW_DATA     std::string DebugView;
 #else
-    #define MPREAL_MSVC_DEBUGVIEW_CODE 
-    #define MPREAL_MSVC_DEBUGVIEW_DATA 
+    #define MPREAL_MSVC_DEBUGVIEW_CODE
+    #define MPREAL_MSVC_DEBUGVIEW_DATA
 #endif
 
-#include <mpfr.h>
+// Check if mpfr.h was included earlier (and with compatible settings).
+#if defined (__MPFR_H) && !(defined (MPFR_USE_NO_MACRO) && defined (MPFR_USE_INTMAX_T))
+	#error The MPFR_USE_NO_MACRO and MPFR_USE_INTMAX_T must be defined for proper use of mpfr.h/mpreal.h
+#else
+    #ifndef MPFR_USE_INTMAX_T
+        #define MPFR_USE_INTMAX_T   // Enable 64-bit integer types - should be defined before mpfr.h
+    #endif
+    #ifndef MPFR_USE_NO_MACRO
+        #define MPFR_USE_NO_MACRO   // Avoid name clash with MPFR, introduced in MPFR 4.2.0
+    #endif
+	#include <mpfr.h>
+#endif
 
 #if (MPFR_VERSION < MPFR_VERSION_NUM(3,0,0))
     #include <cstdlib>                          // Needed for random()
 #endif
 
 // Less important options
-#define MPREAL_DOUBLE_BITS_OVERFLOW -1          // Triggers overflow exception during conversion to double if mpreal 
+#define MPREAL_DOUBLE_BITS_OVERFLOW -1          // Triggers overflow exception during conversion to double if mpreal
                                                 // cannot fit in MPREAL_DOUBLE_BITS_OVERFLOW bits
                                                 // = -1 disables overflow checks (default)
 
@@ -149,9 +159,9 @@ namespace mpfr {
 class mpreal {
 private:
     mpfr_t mp;
-    
+
 public:
-    
+
     // Get default rounding mode & precision
     inline static mp_rnd_t   get_default_rnd()    {    return (mp_rnd_t)(mpfr_get_default_rounding_mode());       }
     inline static mp_prec_t  get_default_prec()   {    return (mpfr_get_default_prec)();                          }
@@ -159,9 +169,9 @@ public:
     // Constructors && type conversions
     mpreal();
     mpreal(const mpreal& u);
-    mpreal(const mpf_t u);    
-    mpreal(const mpz_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());    
-    mpreal(const mpq_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());    
+    mpreal(const mpf_t u);
+    mpreal(const mpz_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
+    mpreal(const mpq_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const double u,                 mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const long double u,            mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const unsigned long long int u, mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
@@ -170,15 +180,15 @@ public:
     mpreal(const unsigned int u,           mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const long int u,               mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const int u,                    mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
-    
+
     // Construct mpreal from mpfr_t structure.
-    // shared = true allows to avoid deep copy, so that mpreal and 'u' share the same data & pointers.    
-    mpreal(const mpfr_t  u, bool shared = false);   
+    // shared = true allows to avoid deep copy, so that mpreal and 'u' share the same data & pointers.
+    mpreal(const mpfr_t  u, bool shared = false);
 
     mpreal(const char* s,             mp_prec_t prec = mpreal::get_default_prec(), int base = 10, mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const std::string& s,      mp_prec_t prec = mpreal::get_default_prec(), int base = 10, mp_rnd_t mode = mpreal::get_default_rnd());
 
-    ~mpreal();                           
+    ~mpreal();
 
 #ifdef MPREAL_HAVE_MOVE_SUPPORT
     mpreal& operator=(mpreal&& v);
@@ -187,7 +197,7 @@ public:
 
     // Operations
     // =
-    // +, -, *, /, ++, --, <<, >> 
+    // +, -, *, /, ++, --, <<, >>
     // *=, +=, -=, /=,
     // <, >, ==, <=, >=
 
@@ -197,7 +207,7 @@ public:
     mpreal& operator=(const mpz_t v);
     mpreal& operator=(const mpq_t v);
     mpreal& operator=(const long double v);
-    mpreal& operator=(const double v);        
+    mpreal& operator=(const double v);
     mpreal& operator=(const unsigned long int v);
     mpreal& operator=(const unsigned long long int v);
     mpreal& operator=(const long long int v);
@@ -231,7 +241,7 @@ public:
 
     const mpreal operator+() const;
     mpreal& operator++ ();
-    const mpreal  operator++ (int); 
+    const mpreal  operator++ (int);
 
     // -
     mpreal& operator-=(const mpreal& v);
@@ -249,7 +259,7 @@ public:
     friend const mpreal operator-(const long int b,          const mpreal& a);
     friend const mpreal operator-(const int b,               const mpreal& a);
     friend const mpreal operator-(const double b,            const mpreal& a);
-    mpreal& operator-- ();    
+    mpreal& operator-- ();
     const mpreal  operator-- (int);
 
     // *
@@ -262,7 +272,7 @@ public:
     mpreal& operator*=(const unsigned int v);
     mpreal& operator*=(const long int v);
     mpreal& operator*=(const int v);
-    
+
     // /
     mpreal& operator/=(const mpreal& v);
     mpreal& operator/=(const mpz_t v);
@@ -303,11 +313,15 @@ public:
 
 #if defined (MPREAL_HAVE_EXPLICIT_CONVERTERS)
     explicit operator bool               () const { return toBool();                 }
-    explicit operator int                () const { return int(toLong());            }
+    explicit operator signed char        () const { return (signed char)toLong();    }
+    explicit operator unsigned char      () const { return (unsigned char)toULong(); }
+    explicit operator short              () const { return (short)toLong();          }
+    explicit operator unsigned short     () const { return (unsigned short)toULong();}
+    explicit operator int                () const { return (int)toLong();            }
+    explicit operator unsigned int       () const { return (unsigned int)toULong();  }
     explicit operator long               () const { return toLong();                 }
-    explicit operator long long          () const { return toLLong();                }
-    explicit operator unsigned           () const { return unsigned(toULong());      }
     explicit operator unsigned long      () const { return toULong();                }
+    explicit operator long long          () const { return toLLong();                }
     explicit operator unsigned long long () const { return toULLong();               }
     explicit operator float              () const { return toFloat();                }
     explicit operator double             () const { return toDouble();               }
@@ -350,13 +364,13 @@ public:
     friend inline const mpreal div_2ui(const mpreal& v, unsigned long int k, mp_rnd_t rnd_mode);
     friend inline const mpreal div_2si(const mpreal& v, long int k, mp_rnd_t rnd_mode);
     friend int cmpabs(const mpreal& a,const mpreal& b);
-    
+
     friend const mpreal log  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal log2 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal logb (const mpreal& v, mp_rnd_t rnd_mode);
-    friend mp_exp_t ilogb(const mpreal& v);
+    friend     mp_exp_t ilogb(const mpreal& v);
     friend const mpreal log10(const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal exp  (const mpreal& v, mp_rnd_t rnd_mode); 
+    friend const mpreal exp  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal exp2 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal exp10(const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal log1p(const mpreal& v, mp_rnd_t rnd_mode);
@@ -405,12 +419,12 @@ public:
     friend const mpreal zeta     (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal erf      (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal erfc     (const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal besselj0 (const mpreal& v, mp_rnd_t rnd_mode); 
-    friend const mpreal besselj1 (const mpreal& v, mp_rnd_t rnd_mode); 
+    friend const mpreal besselj0 (const mpreal& v, mp_rnd_t rnd_mode);
+    friend const mpreal besselj1 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal besseljn (long n, const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal bessely0 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal bessely1 (const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal besselyn (long n, const mpreal& v, mp_rnd_t rnd_mode); 
+    friend const mpreal besselyn (long n, const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal fma      (const mpreal& v1, const mpreal& v2, const mpreal& v3, mp_rnd_t rnd_mode);
     friend const mpreal fms      (const mpreal& v1, const mpreal& v2, const mpreal& v3, mp_rnd_t rnd_mode);
     friend const mpreal agm      (const mpreal& v1, const mpreal& v2, mp_rnd_t rnd_mode);
@@ -448,7 +462,7 @@ public:
 
     // Splits mpreal value into fractional and integer parts.
     // Returns fractional part and stores integer part in n.
-    friend const mpreal modf(const mpreal& v, mpreal& n);    
+    friend const mpreal modf(const mpreal& v, mpreal& n);
 
     // Constants
     // don't forget to call mpfr_free_cache() for every thread where you are using const-functions
@@ -469,22 +483,24 @@ public:
     friend const mpreal ceil (const mpreal& v);
     friend const mpreal floor(const mpreal& v);
     friend const mpreal round(const mpreal& v);
+    friend long lround(const mpreal& v);
+    friend long long llround(const mpreal& v);
     friend const mpreal trunc(const mpreal& v);
     friend const mpreal rint_ceil   (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal rint_floor  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal rint_round  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal rint_trunc  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal frac        (const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal remainder   (         const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
-    friend const mpreal remquo      (long* q, const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
-    
+    friend const mpreal remainder   (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
+    friend const mpreal remquo      (const mpreal& x, const mpreal& y, int* q, mp_rnd_t rnd_mode);
+
     // Miscellaneous Functions
     friend const mpreal nexttoward (const mpreal& x, const mpreal& y);
     friend const mpreal nextabove  (const mpreal& x);
     friend const mpreal nextbelow  (const mpreal& x);
 
     // use gmp_randinit_default() to init state, gmp_randclear() to clear
-    friend const mpreal urandomb (gmp_randstate_t& state); 
+    friend const mpreal urandomb (gmp_randstate_t& state);
 
 // MPFR < 2.4.2 Specifics
 #if (MPFR_VERSION <= MPFR_VERSION_NUM(2,4,2))
@@ -511,9 +527,9 @@ public:
     // Aliases for get_prec(), set_prec() - needed for compatibility with std::complex<mpreal> interface
     inline mpreal&      setPrecision(int Precision, mp_rnd_t RoundingMode = get_default_rnd());
     inline int          getPrecision() const;
-    
+
     // Set mpreal to +/- inf, NaN, +/-0
-    mpreal&        setInf  (int Sign = +1);    
+    mpreal&        setInf  (int Sign = +1);
     mpreal&        setNan  ();
     mpreal&        setZero (int Sign = +1);
     mpreal&        setSign (int Sign, mp_rnd_t RoundingMode = get_default_rnd());
@@ -542,7 +558,7 @@ public:
 
     // Efficient swapping of two mpreal values - needed for std algorithms
     friend void swap(mpreal& x, mpreal& y);
-    
+
     friend const mpreal fmax(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
     friend const mpreal fmin(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
 
@@ -552,7 +568,7 @@ private:
     //
     // mpfr::mpreal=<DebugView>                              ; Show value only
     // mpfr::mpreal=<DebugView>, <mp[0]._mpfr_prec,u>bits    ; Show value & precision
-    // 
+    //
     // at the beginning of
     // [Visual Studio Installation Folder]\Common7\Packages\Debugger\autoexp.dat
     MPREAL_MSVC_DEBUGVIEW_DATA
@@ -571,15 +587,15 @@ public:
 //////////////////////////////////////////////////////////////////////////
 // Constructors & converters
 // Default constructor: creates mp number and initializes it to 0.
-inline mpreal::mpreal() 
-{ 
-    mpfr_init2(mpfr_ptr(), mpreal::get_default_prec()); 
+inline mpreal::mpreal()
+{
+    mpfr_init2(mpfr_ptr(), mpreal::get_default_prec());
     mpfr_set_zero_fast(mpfr_ptr());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
 
-inline mpreal::mpreal(const mpreal& u) 
+inline mpreal::mpreal(const mpreal& u)
 {
     mpfr_init2(mpfr_ptr(),mpfr_get_prec(u.mpfr_srcptr()));
     mpfr_set  (mpfr_ptr(),u.mpfr_srcptr(),mpreal::get_default_rnd());
@@ -651,20 +667,20 @@ inline mpreal::mpreal(const double u, mp_prec_t prec, mp_rnd_t mode)
      mpfr_init2(mpfr_ptr(), prec);
 
 #if (MPREAL_DOUBLE_BITS_OVERFLOW > -1)
-	if(fits_in_bits(u, MPREAL_DOUBLE_BITS_OVERFLOW))
-	{
-		mpfr_set_d(mpfr_ptr(), u, mode);
-	}else
-		throw conversion_overflow();
+    if(fits_in_bits(u, MPREAL_DOUBLE_BITS_OVERFLOW))
+    {
+        mpfr_set_d(mpfr_ptr(), u, mode);
+    }else
+        throw conversion_overflow();
 #else
-	mpfr_set_d(mpfr_ptr(), u, mode);
+    mpfr_set_d(mpfr_ptr(), u, mode);
 #endif
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
 
 inline mpreal::mpreal(const long double u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_ld(mpfr_ptr(), u, mode);
 
@@ -672,7 +688,7 @@ inline mpreal::mpreal(const long double u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const unsigned long long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_uj(mpfr_ptr(), u, mode);
 
@@ -680,7 +696,7 @@ inline mpreal::mpreal(const unsigned long long int u, mp_prec_t prec, mp_rnd_t m
 }
 
 inline mpreal::mpreal(const long long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_sj(mpfr_ptr(), u, mode);
 
@@ -688,7 +704,7 @@ inline mpreal::mpreal(const long long int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const unsigned long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_ui(mpfr_ptr(), u, mode);
 
@@ -696,7 +712,7 @@ inline mpreal::mpreal(const unsigned long int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const unsigned int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_ui(mpfr_ptr(), u, mode);
 
@@ -704,7 +720,7 @@ inline mpreal::mpreal(const unsigned int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_si(mpfr_ptr(), u, mode);
 
@@ -712,7 +728,7 @@ inline mpreal::mpreal(const long int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_si(mpfr_ptr(), u, mode);
 
@@ -722,7 +738,7 @@ inline mpreal::mpreal(const int u, mp_prec_t prec, mp_rnd_t mode)
 inline mpreal::mpreal(const char* s, mp_prec_t prec, int base, mp_rnd_t mode)
 {
     mpfr_init2  (mpfr_ptr(), prec);
-    mpfr_set_str(mpfr_ptr(), s, base, mode); 
+    mpfr_set_str(mpfr_ptr(), s, base, mode);
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
@@ -730,7 +746,7 @@ inline mpreal::mpreal(const char* s, mp_prec_t prec, int base, mp_rnd_t mode)
 inline mpreal::mpreal(const std::string& s, mp_prec_t prec, int base, mp_rnd_t mode)
 {
     mpfr_init2  (mpfr_ptr(), prec);
-    mpfr_set_str(mpfr_ptr(), s.c_str(), base, mode); 
+    mpfr_set_str(mpfr_ptr(), s.c_str(), base, mode);
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
@@ -738,15 +754,15 @@ inline mpreal::mpreal(const std::string& s, mp_prec_t prec, int base, mp_rnd_t m
 inline void mpreal::clear(::mpfr_ptr x)
 {
 #ifdef MPREAL_HAVE_MOVE_SUPPORT
-    if(mpfr_is_initialized(x)) 
+    if(mpfr_is_initialized(x))
 #endif
     mpfr_clear(x);
 }
 
-inline mpreal::~mpreal() 
-{ 
+inline mpreal::~mpreal()
+{
     clear(mpfr_ptr());
-}                           
+}
 
 // internal namespace needed for template magic
 namespace internal{
@@ -754,55 +770,55 @@ namespace internal{
     // Use SFINAE to restrict arithmetic operations instantiation only for numeric types
     // This is needed for smooth integration with libraries based on expression templates, like Eigen.
     // TODO: Do the same for boolean operators.
-    template <typename ArgumentType> struct result_type {};    
-    
-    template <> struct result_type<mpreal>              {typedef mpreal type;};    
-    template <> struct result_type<mpz_t>               {typedef mpreal type;};    
-    template <> struct result_type<mpq_t>               {typedef mpreal type;};    
-    template <> struct result_type<long double>         {typedef mpreal type;};    
-    template <> struct result_type<double>              {typedef mpreal type;};    
-    template <> struct result_type<unsigned long int>   {typedef mpreal type;};    
-    template <> struct result_type<unsigned int>        {typedef mpreal type;};    
-    template <> struct result_type<long int>            {typedef mpreal type;};    
-    template <> struct result_type<int>                 {typedef mpreal type;};    
-    template <> struct result_type<long long>           {typedef mpreal type;};    
-    template <> struct result_type<unsigned long long>  {typedef mpreal type;};    
+    template <typename ArgumentType> struct result_type {};
+
+    template <> struct result_type<mpreal>              {typedef mpreal type;};
+    template <> struct result_type<mpz_t>               {typedef mpreal type;};
+    template <> struct result_type<mpq_t>               {typedef mpreal type;};
+    template <> struct result_type<long double>         {typedef mpreal type;};
+    template <> struct result_type<double>              {typedef mpreal type;};
+    template <> struct result_type<unsigned long int>   {typedef mpreal type;};
+    template <> struct result_type<unsigned int>        {typedef mpreal type;};
+    template <> struct result_type<long int>            {typedef mpreal type;};
+    template <> struct result_type<int>                 {typedef mpreal type;};
+    template <> struct result_type<long long>           {typedef mpreal type;};
+    template <> struct result_type<unsigned long long>  {typedef mpreal type;};
 }
 
 // + Addition
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator+(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) += rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
-    operator+(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) += lhs;    } 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
+    operator+(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) += lhs;    }
 
 // - Subtraction
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator-(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) -= rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
     operator-(const Lhs& lhs, const mpreal& rhs){ return mpreal(lhs) -= rhs;    }
 
 // * Multiplication
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator*(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) *= rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
-    operator*(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) *= lhs;    } 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
+    operator*(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) *= lhs;    }
 
 // / Division
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator/(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) /= rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
     operator/(const Lhs& lhs, const mpreal& rhs){ return mpreal(lhs) /= rhs;    }
 
 //////////////////////////////////////////////////////////////////////////
@@ -852,17 +868,17 @@ const mpreal pow(const long int a, const double b, mp_rnd_t rnd_mode = mpreal::g
 const mpreal pow(const int a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const int a, const unsigned int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const int a, const long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
-const mpreal pow(const int a, const int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd()); 
+const mpreal pow(const int a, const int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const int a, const long double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
-const mpreal pow(const int a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd()); 
+const mpreal pow(const int a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 
-const mpreal pow(const long double a, const long double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());    
+const mpreal pow(const long double a, const long double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const unsigned int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 
-const mpreal pow(const double a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());    
+const mpreal pow(const double a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const double a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const double a, const unsigned int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const double a, const long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
@@ -879,9 +895,9 @@ inline const mpreal div_2si(const mpreal& v, long int k, mp_rnd_t rnd_mode = mpr
 inline mpreal machine_epsilon(mp_prec_t prec = mpreal::get_default_prec());
 
 // Returns smallest eps such that x + eps != x (relative machine epsilon)
-inline mpreal machine_epsilon(const mpreal& x);        
+inline mpreal machine_epsilon(const mpreal& x);
 
-// Gives max & min values for the required precision, 
+// Gives max & min values for the required precision,
 // minval is 'safe' meaning 1 / minval does not overflow
 // maxval is 'safe' meaning 1 / maxval does not underflow
 inline mpreal minval(mp_prec_t prec = mpreal::get_default_prec());
@@ -894,7 +910,7 @@ inline bool isEqualFuzzy(const mpreal& a, const mpreal& b, const mpreal& eps);
 inline bool isEqualFuzzy(const mpreal& a, const mpreal& b);
 
 // 'Bitwise' equality check
-//  maxUlps - a and b can be apart by maxUlps binary numbers. 
+//  maxUlps - a and b can be apart by maxUlps binary numbers.
 inline bool isEqualUlps(const mpreal& a, const mpreal& b, int maxUlps);
 
 //////////////////////////////////////////////////////////////////////////
@@ -920,13 +936,13 @@ inline mpreal& mpreal::operator=(const mpreal& v)
 {
     if (this != &v)
     {
-		mp_prec_t tp = mpfr_get_prec(  mpfr_srcptr());
-		mp_prec_t vp = mpfr_get_prec(v.mpfr_srcptr());
+        mp_prec_t tp = mpfr_get_prec(  mpfr_srcptr());
+        mp_prec_t vp = mpfr_get_prec(v.mpfr_srcptr());
 
-		if(tp != vp){
-			clear(mpfr_ptr());
-			mpfr_init2(mpfr_ptr(), vp);
-		}
+        if(tp != vp){
+            clear(mpfr_ptr());
+            mpfr_init2(mpfr_ptr(), vp);
+        }
 
         mpfr_set(mpfr_ptr(), v.mpfr_srcptr(), mpreal::get_default_rnd());
 
@@ -938,7 +954,7 @@ inline mpreal& mpreal::operator=(const mpreal& v)
 inline mpreal& mpreal::operator=(const mpf_t v)
 {
     mpfr_set_f(mpfr_ptr(), v, mpreal::get_default_rnd());
-    
+
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
@@ -946,7 +962,7 @@ inline mpreal& mpreal::operator=(const mpf_t v)
 inline mpreal& mpreal::operator=(const mpz_t v)
 {
     mpfr_set_z(mpfr_ptr(), v, mpreal::get_default_rnd());
-    
+
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
@@ -959,73 +975,73 @@ inline mpreal& mpreal::operator=(const mpq_t v)
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const long double v)        
-{    
+inline mpreal& mpreal::operator=(const long double v)
+{
     mpfr_set_ld(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const double v)                
-{   
+inline mpreal& mpreal::operator=(const double v)
+{
 #if (MPREAL_DOUBLE_BITS_OVERFLOW > -1)
-	if(fits_in_bits(v, MPREAL_DOUBLE_BITS_OVERFLOW))
-	{
-		mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
-	}else
-		throw conversion_overflow();
+    if(fits_in_bits(v, MPREAL_DOUBLE_BITS_OVERFLOW))
+    {
+        mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
+    }else
+        throw conversion_overflow();
 #else
-	mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
+    mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
 #endif
 
-	MPREAL_MSVC_DEBUGVIEW_CODE;
+    MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const unsigned long int v)    
-{    
-    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const unsigned long int v)
+{
+    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const unsigned int v)        
-{    
-    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const unsigned int v)
+{
+    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const unsigned long long int v)    
-{    
-    mpfr_set_uj(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const unsigned long long int v)
+{
+    mpfr_set_uj(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const long long int v)    
-{    
-    mpfr_set_sj(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const long long int v)
+{
+    mpfr_set_sj(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const long int v)            
-{    
-    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const long int v)
+{
+    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
 inline mpreal& mpreal::operator=(const int v)
-{    
-    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());    
+{
+    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -1046,7 +1062,7 @@ inline mpreal& mpreal::operator=(const char* s)
 
     if(0 == mpfr_set_str(t, s, 10, mpreal::get_default_rnd()))
     {
-        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd()); 
+        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd());
         MPREAL_MSVC_DEBUGVIEW_CODE;
     }
 
@@ -1069,7 +1085,7 @@ inline mpreal& mpreal::operator=(const std::string& s)
 
     if(0 == mpfr_set_str(t, s.c_str(), 10, mpreal::get_default_rnd()))
     {
-        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd()); 
+        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd());
         MPREAL_MSVC_DEBUGVIEW_CODE;
     }
 
@@ -1077,7 +1093,7 @@ inline mpreal& mpreal::operator=(const std::string& s)
     return *this;
 }
 
-template <typename real_t> 
+template <typename real_t>
 inline mpreal& mpreal::operator= (const std::complex<real_t>& z)
 {
     return *this = z.real();
@@ -1115,9 +1131,9 @@ inline mpreal& mpreal::operator+=(const mpq_t u)
 
 inline mpreal& mpreal::operator+= (const long double u)
 {
-    *this += mpreal(u);    
+    *this += mpreal(u);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator+= (const double u)
@@ -1173,12 +1189,12 @@ inline const mpreal mpreal::operator+()const    {    return mpreal(*this); }
 
 inline const mpreal operator+(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
-	mpfr_add(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
+    mpfr_add(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
-inline mpreal& mpreal::operator++() 
+inline mpreal& mpreal::operator++()
 {
     return *this += 1;
 }
@@ -1190,7 +1206,7 @@ inline const mpreal mpreal::operator++ (int)
     return x;
 }
 
-inline mpreal& mpreal::operator--() 
+inline mpreal& mpreal::operator--()
 {
     return *this -= 1;
 }
@@ -1227,9 +1243,9 @@ inline mpreal& mpreal::operator-=(const mpq_t v)
 
 inline mpreal& mpreal::operator-=(const long double v)
 {
-    *this -= mpreal(v);    
+    *this -= mpreal(v);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator-=(const double v)
@@ -1237,7 +1253,7 @@ inline mpreal& mpreal::operator-=(const double v)
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(2,4,0))
     mpfr_sub_d(mpfr_ptr(),mpfr_srcptr(),v,mpreal::get_default_rnd());
 #else
-    *this -= mpreal(v);    
+    *this -= mpreal(v);
 #endif
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
@@ -1281,9 +1297,9 @@ inline const mpreal mpreal::operator-()const
 
 inline const mpreal operator-(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
-	mpfr_sub(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
+    mpfr_sub(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
 inline const mpreal operator-(const double  b, const mpreal& a)
@@ -1352,9 +1368,9 @@ inline mpreal& mpreal::operator*=(const mpq_t v)
 
 inline mpreal& mpreal::operator*=(const long double v)
 {
-    *this *= mpreal(v);    
+    *this *= mpreal(v);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator*=(const double v)
@@ -1362,7 +1378,7 @@ inline mpreal& mpreal::operator*=(const double v)
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(2,4,0))
     mpfr_mul_d(mpfr_ptr(),mpfr_srcptr(),v,mpreal::get_default_rnd());
 #else
-    *this *= mpreal(v);    
+    *this *= mpreal(v);
 #endif
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -1398,9 +1414,9 @@ inline mpreal& mpreal::operator*=(const int v)
 
 inline const mpreal operator*(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
-	mpfr_mul(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
+    mpfr_mul(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1430,7 +1446,7 @@ inline mpreal& mpreal::operator/=(const long double v)
 {
     *this /= mpreal(v);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator/=(const double v)
@@ -1438,7 +1454,7 @@ inline mpreal& mpreal::operator/=(const double v)
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(2,4,0))
     mpfr_div_d(mpfr_ptr(),mpfr_srcptr(),v,mpreal::get_default_rnd());
 #else
-    *this /= mpreal(v);    
+    *this /= mpreal(v);
 #endif
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -1474,9 +1490,9 @@ inline mpreal& mpreal::operator/=(const int v)
 
 inline const mpreal operator/(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_srcptr()), mpfr_get_prec(b.mpfr_srcptr())));
-	mpfr_div(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_srcptr()), mpfr_get_prec(b.mpfr_srcptr())));
+    mpfr_div(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
 inline const mpreal operator/(const unsigned long int b, const mpreal& a)
@@ -1651,9 +1667,9 @@ inline const mpreal div_2si(const mpreal& v, long int k, mp_rnd_t rnd_mode)
 //////////////////////////////////////////////////////////////////////////
 //Relational operators
 
-// WARNING: 
+// WARNING:
 //
-// Please note that following checks for double-NaN are guaranteed to work only in IEEE math mode: 
+// Please note that following checks for double-NaN are guaranteed to work only in IEEE math mode:
 //
 // isnan(b) =  (b != b)
 // isnan(b) = !(b == b)  (we use in code below)
@@ -1717,7 +1733,7 @@ inline bool isint    (const mpreal& op){    return (mpfr_integer_p(op.mpfr_srcpt
 
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(3,0,0))
 inline bool isregular(const mpreal& op){    return (mpfr_regular_p(op.mpfr_srcptr()));}
-#endif 
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 // Type Converters
@@ -1775,20 +1791,20 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
     std::ostringstream format;
 
     int digits = (n >= 0) ? n : 2 + bits2digits(mpfr_get_prec(mpfr_srcptr()));
-    
+
     format << "%." << digits << "RNg";
 
     return toString(format.str());
 
 #else
 
-    char *s, *ns = NULL; 
+    char *s, *ns = NULL;
     size_t slen, nslen;
     mp_exp_t exp;
     std::string out;
 
     if(mpfr_inf_p(mp))
-    { 
+    {
         if(mpfr_sgn(mp)>0) return "+Inf";
         else               return "-Inf";
     }
@@ -1803,7 +1819,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
     {
         slen  = strlen(s);
         nslen = strlen(ns);
-        if(nslen<=slen) 
+        if(nslen<=slen)
         {
             mpfr_free_str(s);
             s = ns;
@@ -1820,7 +1836,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s+exp) ptr--; 
+                while (*ptr=='0' && ptr>s+exp) ptr--;
 
                 if(ptr==s+exp) out = std::string(s,exp+1);
                 else           out = std::string(s,exp+1)+'.'+std::string(s+exp+1,ptr-(s+exp+1)+1);
@@ -1831,7 +1847,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s+exp-1) ptr--; 
+                while (*ptr=='0' && ptr>s+exp-1) ptr--;
 
                 if(ptr==s+exp-1) out = std::string(s,exp);
                 else             out = std::string(s,exp)+'.'+std::string(s+exp,ptr-(s+exp)+1);
@@ -1844,7 +1860,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s+1) ptr--; 
+                while (*ptr=='0' && ptr>s+1) ptr--;
 
                 if(ptr==s+1) out = std::string(s,2);
                 else         out = std::string(s,2)+'.'+std::string(s+2,ptr-(s+2)+1);
@@ -1855,7 +1871,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s) ptr--; 
+                while (*ptr=='0' && ptr>s) ptr--;
 
                 if(ptr==s) out = std::string(s,1);
                 else       out = std::string(s,1)+'.'+std::string(s+1,ptr-(s+1)+1);
@@ -1882,7 +1898,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
 
 //////////////////////////////////////////////////////////////////////////
 // I/O
-inline std::ostream& mpreal::output(std::ostream& os) const 
+inline std::ostream& mpreal::output(std::ostream& os) const
 {
     std::ostringstream format;
     const std::ios::fmtflags flags = os.flags();
@@ -1962,14 +1978,14 @@ inline mpreal& mpreal::setPrecision(int Precision, mp_rnd_t RoundingMode)
     return *this;
 }
 
-inline mpreal& mpreal::setInf(int sign) 
-{ 
+inline mpreal& mpreal::setInf(int sign)
+{
     mpfr_set_inf(mpfr_ptr(), sign);
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
-}    
+}
 
-inline mpreal& mpreal::setNan() 
+inline mpreal& mpreal::setNan()
 {
     mpfr_set_nan(mpfr_ptr());
     MPREAL_MSVC_DEBUGVIEW_CODE;
@@ -1983,7 +1999,7 @@ inline mpreal& mpreal::setZero(int sign)
 #else
     mpfr_set_si(mpfr_ptr(), 0, (mpfr_get_default_rounding_mode)());
     setSign(sign);
-#endif 
+#endif
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -2018,7 +2034,7 @@ inline mpreal& negate(mpreal& x) // -x in place
     return x;
 }
 
-inline const mpreal frexp(const mpreal& x, mp_exp_t* exp, mp_rnd_t mode = mpreal::get_default_rnd())
+inline const mpreal frexp(const mpreal& x, mpfr_exp_t* exp, mp_rnd_t mode = mpreal::get_default_rnd())
 {
     mpreal y(x);
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(3,1,0))
@@ -2032,9 +2048,9 @@ inline const mpreal frexp(const mpreal& x, mp_exp_t* exp, mp_rnd_t mode = mpreal
 
 inline const mpreal frexp(const mpreal& x, int* exp, mp_rnd_t mode = mpreal::get_default_rnd())
 {
-    mp_exp_t expl;
-    mpreal y = frexp(x, &expl, mode);
-    *exp = int(expl);
+    mpfr_exp_t e;
+    mpreal y = frexp(x, &e, mode);
+    *exp = int(e);
     return y;
 }
 
@@ -2043,7 +2059,7 @@ inline const mpreal ldexp(const mpreal& v, mp_exp_t exp)
     mpreal x(v);
 
     // rounding is not important since we are just increasing the exponent (= exact operation)
-    mpfr_mul_2si(x.mpfr_ptr(), x.mpfr_srcptr(), exp, mpreal::get_default_rnd()); 
+    mpfr_mul_2si(x.mpfr_ptr(), x.mpfr_srcptr(), exp, mpreal::get_default_rnd());
     return x;
 }
 
@@ -2059,7 +2075,7 @@ inline mpreal machine_epsilon(mp_prec_t prec)
 }
 
 inline mpreal machine_epsilon(const mpreal& x)
-{    
+{
     /* the smallest eps such that x + eps != x */
     if( x < 0)
     {
@@ -2072,15 +2088,16 @@ inline mpreal machine_epsilon(const mpreal& x)
 // minval is 'safe' meaning 1 / minval does not overflow
 inline mpreal minval(mp_prec_t prec)
 {
-    /* min = 1/2 * 2^emin = 2^(emin - 1) */
-    return mpreal(1, prec) << mpreal::get_emin()-1;
+    // The smallest positive value in MPFR is 1/2 * 2^emin = 2^(emin - 1). However it gives infinity if inverted. 
+    // Overall safe minimum is 2^(emin + 1).
+    return mpreal(1, prec) << (mpreal::get_emin()+1);
 }
 
 // maxval is 'safe' meaning 1 / maxval does not underflow
 inline mpreal maxval(mp_prec_t prec)
 {
     /* max = (1 - eps) * 2^emax, eps is machine epsilon */
-    return (mpreal(1, prec) - machine_epsilon(prec)) << mpreal::get_emax(); 
+    return (mpreal(1, prec) - machine_epsilon(prec)) << mpreal::get_emax();
 }
 
 inline bool isEqualUlps(const mpreal& a, const mpreal& b, int maxUlps)
@@ -2123,7 +2140,7 @@ inline const mpreal modf(const mpreal& v, mpreal& n)
     mpreal f(v);
 
     // rounding is not important since we are using the same number
-    mpfr_frac (f.mpfr_ptr(),f.mpfr_srcptr(),mpreal::get_default_rnd());    
+    mpfr_frac (f.mpfr_ptr(),f.mpfr_srcptr(),mpreal::get_default_rnd());
     mpfr_trunc(n.mpfr_ptr(),v.mpfr_srcptr());
     return f;
 }
@@ -2183,10 +2200,18 @@ inline mp_exp_t mpreal::get_emax_max (void)
 //////////////////////////////////////////////////////////////////////////
 // Mathematical Functions
 //////////////////////////////////////////////////////////////////////////
+
+// Unary function template with single 'mpreal' argument
 #define MPREAL_UNARY_MATH_FUNCTION_BODY(f)                    \
         mpreal y(0, mpfr_get_prec(x.mpfr_srcptr()));          \
         mpfr_##f(y.mpfr_ptr(), x.mpfr_srcptr(), r);           \
-        return y; 
+        return y;
+
+// Binary function template with 'mpreal' and 'unsigned long' arguments
+#define MPREAL_BINARY_MATH_FUNCTION_UI_BODY(f, u)             \
+        mpreal y(0, mpfr_get_prec(x.mpfr_srcptr()));          \
+        mpfr_##f(y.mpfr_ptr(), x.mpfr_srcptr(), u, r);        \
+        return y;
 
 inline const mpreal sqr  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd())
 {   MPREAL_UNARY_MATH_FUNCTION_BODY(sqr );    }
@@ -2209,7 +2234,7 @@ inline const mpreal sqrt(const unsigned int v, mp_rnd_t rnd_mode)
 inline const mpreal sqrt(const long int v, mp_rnd_t rnd_mode)
 {
     if (v>=0)   return sqrt(static_cast<unsigned long int>(v),rnd_mode);
-    else        return mpreal().setNan(); // NaN  
+    else        return mpreal().setNan(); // NaN
 }
 
 inline const mpreal sqrt(const int v, mp_rnd_t rnd_mode)
@@ -2220,13 +2245,39 @@ inline const mpreal sqrt(const int v, mp_rnd_t rnd_mode)
 
 inline const mpreal root(const mpreal& x, unsigned long int k, mp_rnd_t r = mpreal::get_default_rnd())
 {
-    mpreal y(0, mpfr_get_prec(x.mpfr_srcptr())); 
+    mpreal y(0, mpfr_get_prec(x.mpfr_srcptr()));
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(4,0,0))
-    mpfr_rootn_ui(y.mpfr_ptr(), x.mpfr_srcptr(), k, r);  
+    mpfr_rootn_ui(y.mpfr_ptr(), x.mpfr_srcptr(), k, r);
 #else
     mpfr_root(y.mpfr_ptr(), x.mpfr_srcptr(), k, r);
 #endif
-    return y; 
+    return y;
+}
+
+inline const mpreal root(const mpreal& x, const mpreal& n, mp_rnd_t r = mpreal::get_default_rnd())
+{
+    if(isint(n) && mpfr_sgn(n.mpfr_ptr()) > 0) return root(x,n.toULong(),r);
+    else
+    {
+        mpreal y(0, (std::max)(mpfr_get_prec(x.mpfr_srcptr()),mpfr_get_prec(n.mpfr_srcptr())));
+
+        if(isnan(x) || isnan(n)) mpfr_set_nan(y.mpfr_ptr());
+        else if(isinf(n))        mpfr_set_si (y.mpfr_ptr(),1,r);
+        else if(iszero(n))       mpfr_set_inf(y.mpfr_ptr(),1);
+        else
+        {
+            mpreal a(0,mpfr_get_prec(x.mpfr_srcptr()));
+            mpreal b(0,mpfr_get_prec(n.mpfr_srcptr()));
+
+            mpfr_ui_div(b.mpfr_ptr(),1,n.mpfr_srcptr(),r);
+            mpfr_abs   (a.mpfr_ptr(),  x.mpfr_srcptr(),r);
+            mpfr_pow   (y.mpfr_ptr(),  a.mpfr_ptr(), b.mpfr_srcptr(), r);
+
+            mpfr_setsign(y.mpfr_ptr(),y.mpfr_srcptr(),mpfr_signbit(x.mpfr_srcptr()),r);
+        }
+
+        return y;
+    }
 }
 
 inline const mpreal dim(const mpreal& a, const mpreal& b, mp_rnd_t r = mpreal::get_default_rnd())
@@ -2244,6 +2295,11 @@ inline int cmpabs(const mpreal& a,const mpreal& b)
 inline int sin_cos(mpreal& s, mpreal& c, const mpreal& v, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
     return mpfr_sin_cos(s.mpfr_ptr(), c.mpfr_ptr(), v.mpfr_srcptr(), rnd_mode);
+}
+
+inline void sincos(const mpreal& x, mpreal *sin, mpreal *cos, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    mpfr_sin_cos(sin->mpfr_ptr(), cos->mpfr_ptr(), x.mpfr_srcptr(), rnd_mode);
 }
 
 inline const mpreal sqrt  (const long double v, mp_rnd_t rnd_mode)    {   return sqrt(mpreal(v),rnd_mode);    }
@@ -2269,7 +2325,7 @@ inline const mpreal asin  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd
 inline const mpreal atan  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   MPREAL_UNARY_MATH_FUNCTION_BODY(atan );    }
 
 inline const mpreal logb  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   return log2 (abs(x),r);                    }
-inline mp_exp_t ilogb(const mpreal& x) { return x.get_exp(); }
+inline     mp_exp_t ilogb (const mpreal& x) { return x.get_exp(); }
 
 inline const mpreal acot  (const mpreal& v, mp_rnd_t r = mpreal::get_default_rnd()) {   return atan (1/v, r);                      }
 inline const mpreal asec  (const mpreal& v, mp_rnd_t r = mpreal::get_default_rnd()) {   return acos (1/v, r);                      }
@@ -2302,11 +2358,108 @@ inline const mpreal besselj1(const mpreal& x, mp_rnd_t r = mpreal::get_default_r
 inline const mpreal bessely0(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   MPREAL_UNARY_MATH_FUNCTION_BODY(y0     );    }
 inline const mpreal bessely1(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   MPREAL_UNARY_MATH_FUNCTION_BODY(y1     );    }
 
-inline const mpreal nextpow2(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) 
-{   
+#if (MPFR_VERSION >= MPFR_VERSION_NUM(4,0,0))
+inline const mpreal gammainc (const mpreal& a, const mpreal& x, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /*
+       The non-normalized (upper) incomplete gamma function of a and x:
+       gammainc(a,x) := Gamma(a,x) = int(t^(a-1) * exp(-t), t=x..infinity)
+    */
+    mpreal y(0,(std::max)(a.getPrecision(), x.getPrecision()));
+    mpfr_gamma_inc(y.mpfr_ptr(), a.mpfr_srcptr(), x.mpfr_srcptr(), rnd_mode);
+    return y;
+}
+
+inline const mpreal beta (const mpreal& z, const mpreal& w, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /*
+       Beta function, uses formula (6.2.2) from Abramowitz & Stegun:
+       beta(z,w) = gamma(z)*gamma(w)/gamma(z+w)
+    */
+    mpreal y(0,(std::max)(z.getPrecision(), w.getPrecision()));
+    mpfr_beta(y.mpfr_ptr(), z.mpfr_srcptr(), w.mpfr_srcptr(), rnd_mode);
+    return y;
+}
+
+inline const mpreal log_ui (unsigned long int n, mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* Computes natural logarithm of an unsigned long  */
+    mpreal y(0, prec);
+    mpfr_log_ui(y.mpfr_ptr(),n,rnd_mode);
+    return y;
+}
+#endif
+
+#if (MPFR_VERSION >= MPFR_VERSION_NUM(4,2,0))
+
+/* f(x,u) = f(2*pi*x/u) */
+inline const mpreal cosu   (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(cosu,  u); }
+inline const mpreal sinu   (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(sinu,  u); }
+inline const mpreal tanu   (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(tanu,  u); }
+inline const mpreal acosu  (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(acosu, u); }
+inline const mpreal asinu  (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(asinu, u); }
+inline const mpreal atanu  (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(atanu, u); }
+
+/* f(x) = f(pi*x) */
+inline const mpreal cospi  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(cospi ); }
+inline const mpreal sinpi  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(sinpi ); }
+inline const mpreal tanpi  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(tanpi ); }
+inline const mpreal acospi (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(acospi); }
+inline const mpreal asinpi (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(asinpi); }
+inline const mpreal atanpi (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(atanpi); }
+
+inline const mpreal log2p1 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(log2p1 ); }  /* log2 (1+x) */
+inline const mpreal log10p1(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(log10p1); }  /* log10(1+x) */
+inline const mpreal exp2m1 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(exp2m1 ); }  /* 2^x-1      */
+inline const mpreal exp10m1(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(exp10m1); }  /* 10^x-1     */
+
+inline const mpreal atan2u(const mpreal& y, const mpreal& x, unsigned long u, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /*
+        atan2u(y,x,u) = atan(|y/x|)*u/(2*pi)   for x > 0
+        atan2u(y,x,u) = 1-atan(|y/x|)*u/(2*pi) for x < 0
+    */
+    mpreal a(0, (std::max)(y.getPrecision(), x.getPrecision()));
+    mpfr_atan2u(a.mpfr_ptr(), y.mpfr_srcptr(), x.mpfr_srcptr(), u, rnd_mode);
+    return a;
+}
+
+inline const mpreal atan2pi(const mpreal& y, const mpreal& x, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* atan2pi(x) = atan2u(u=2) */
+    mpreal a(0, (std::max)(y.getPrecision(), x.getPrecision()));
+    mpfr_atan2pi(a.mpfr_ptr(), y.mpfr_srcptr(), x.mpfr_srcptr(), rnd_mode);
+    return a;
+}
+
+inline const mpreal powr(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* powr(x,y) = exp(y*log(x)) */
+    mpreal a(0, (std::max)(x.getPrecision(), y.getPrecision()));
+    mpfr_powr(a.mpfr_ptr(), x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
+    return a;
+}
+
+inline const mpreal compound(const mpreal& x, long n, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* compound(x,n) = (1+x)^n */
+    mpreal y(0, x.getPrecision());
+    mpfr_compound_si(y.mpfr_ptr(),x.mpfr_srcptr(),n,rnd_mode);
+    return y;
+}
+
+inline const mpreal fmod(const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd())
+{
+    /* x modulo a machine integer u */
+    MPREAL_BINARY_MATH_FUNCTION_UI_BODY(fmod_ui, u);
+}
+#endif
+
+inline const mpreal nextpow2(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd())
+{
     mpreal y(0, x.getPrecision());
 
-    if(!iszero(x)) 
+    if(!iszero(x))
         y = ceil(log2(abs(x,r),r));
 
     return y;
@@ -2326,7 +2479,7 @@ inline const mpreal hypot (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode =
     return a;
 }
 
-inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c)  
+inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c)
 {
     if(isnan(a) || isnan(b) || isnan(c)) return mpreal().setNan();
     else
@@ -2341,11 +2494,11 @@ inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c)
             r = w * sqrt(sqr(absa*iw) + sqr(absb*iw) + sqr(absc*iw));
         }
 
-        return r; 
+        return r;
     }
 }
 
-inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c, const mpreal& d)  
+inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c, const mpreal& d)
 {
     if(isnan(a) || isnan(b) || isnan(c) || isnan(d)) return mpreal().setNan();
     else
@@ -2360,26 +2513,28 @@ inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c, con
             r = w * sqrt(sqr(absa*iw) + sqr(absb*iw) + sqr(absc*iw) + sqr(absd*iw));
         }
 
-        return r; 
+        return r;
     }
 }
 
 inline const mpreal remainder (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
-{    
+{
     mpreal a(0,(std::max)(y.getPrecision(), x.getPrecision()));
     mpfr_remainder(a.mpfr_ptr(), x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
     return a;
 }
 
-inline const mpreal remquo (long* q, const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+inline const mpreal remquo (const mpreal& x, const mpreal& y, int* q, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
+    long lq;
     mpreal a(0,(std::max)(y.getPrecision(), x.getPrecision()));
-    mpfr_remquo(a.mpfr_ptr(),q, x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
+    mpfr_remquo(a.mpfr_ptr(), &lq, x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
+    if (q) *q = int(lq);
     return a;
 }
 
 inline const mpreal fac_ui (unsigned long int v, mp_prec_t prec     = mpreal::get_default_prec(),
-			                                     mp_rnd_t  rnd_mode = mpreal::get_default_rnd())
+                                                 mp_rnd_t  rnd_mode = mpreal::get_default_rnd())
 {
     mpreal x(0, prec);
     mpfr_fac_ui(x.mpfr_ptr(),v,rnd_mode);
@@ -2418,9 +2573,9 @@ inline const mpreal fma (const mpreal& v1, const mpreal& v2, const mpreal& v3, m
     mpreal a;
     mp_prec_t p1, p2, p3;
 
-    p1 = v1.get_prec(); 
-    p2 = v2.get_prec(); 
-    p3 = v3.get_prec(); 
+    p1 = v1.get_prec();
+    p2 = v2.get_prec();
+    p3 = v3.get_prec();
 
     a.set_prec(p3>p2?(p3>p1?p3:p1):(p2>p1?p2:p1));
 
@@ -2433,9 +2588,9 @@ inline const mpreal fms (const mpreal& v1, const mpreal& v2, const mpreal& v3, m
     mpreal a;
     mp_prec_t p1, p2, p3;
 
-    p1 = v1.get_prec(); 
-    p2 = v2.get_prec(); 
-    p3 = v3.get_prec(); 
+    p1 = v1.get_prec();
+    p2 = v2.get_prec();
+    p3 = v3.get_prec();
 
     a.set_prec(p3>p2?(p3>p1?p3:p1):(p2>p1?p2:p1));
 
@@ -2448,8 +2603,8 @@ inline const mpreal agm (const mpreal& v1, const mpreal& v2, mp_rnd_t rnd_mode =
     mpreal a;
     mp_prec_t p1, p2;
 
-    p1 = v1.get_prec(); 
-    p2 = v2.get_prec(); 
+    p1 = v1.get_prec();
+    p2 = v2.get_prec();
 
     a.set_prec(p1>p2?p1:p2);
 
@@ -2467,7 +2622,7 @@ inline const mpreal sum (const mpreal tab[], const unsigned long int n, int& sta
 
     mpreal x;
     status = mpfr_sum(x.mpfr_ptr(), (mpfr_ptr*)p, n, mode);
-    
+
     delete [] p;
     return x;
 }
@@ -2481,9 +2636,9 @@ inline int sinh_cosh(mpreal& s, mpreal& c, const mpreal& v, mp_rnd_t rnd_mode = 
     return mpfr_sinh_cosh(s.mp,c.mp,v.mp,rnd_mode);
 }
 
-inline const mpreal li2 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) 
-{   
-    MPREAL_UNARY_MATH_FUNCTION_BODY(li2);    
+inline const mpreal li2 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd())
+{
+    MPREAL_UNARY_MATH_FUNCTION_BODY(li2);
 }
 
 inline const mpreal rem (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
@@ -2495,16 +2650,16 @@ inline const mpreal rem (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = m
 inline const mpreal mod (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
     (void)rnd_mode;
-    
-    /*  
+
+    /*
 
     m = mod(x,y) if y != 0, returns x - n*y where n = floor(x/y)
 
     The following are true by convention:
     - mod(x,0) is x
     - mod(x,x) is 0
-    - mod(x,y) for x != y and y != 0 has the same sign as y.    
-    
+    - mod(x,y) for x != y and y != 0 has the same sign as y.
+
     */
 
     if(iszero(y)) return x;
@@ -2520,8 +2675,8 @@ inline const mpreal fmod (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = 
     mpreal a;
     mp_prec_t yp, xp;
 
-    yp = y.get_prec(); 
-    xp = x.get_prec(); 
+    yp = y.get_prec();
+    xp = x.get_prec();
 
     a.set_prec(yp>xp?yp:xp);
 
@@ -2605,6 +2760,24 @@ inline const mpreal round(const mpreal& v)
     return x;
 }
 
+inline long lround(const mpreal& v)
+{
+    long r = std::numeric_limits<long>::min();
+    mpreal x = round(v);
+    if (abs(x) < -mpreal(r))    // Assume mpreal(LONG_MIN) is exact
+      r = x.toLong();
+    return r;
+}
+
+inline long long llround(const mpreal& v)
+{
+    long long r = std::numeric_limits<long long>::min();
+    mpreal x = round(v);
+    if (abs(x) < -mpreal(r))    // Assume mpreal(LLONG_MIN) is exact
+      r = x.toLLong();
+    return r;
+}
+
 inline const mpreal trunc(const mpreal& v)
 {
     mpreal x(v);
@@ -2631,8 +2804,8 @@ inline int sgn(const mpreal& op)
 //////////////////////////////////////////////////////////////////////////
 // Miscellaneous Functions
 inline void         swap (mpreal& a, mpreal& b)            {    mpfr_swap(a.mpfr_ptr(),b.mpfr_ptr());   }
-inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x>y?x:y);       }
-inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (x<y?x:y);       }
+inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x<y?y:x);       }
+inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (y<x?y:x);       }
 
 inline const mpreal fmax(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
@@ -2753,20 +2926,20 @@ inline const mpreal grandom(unsigned int seed = 0)
 //////////////////////////////////////////////////////////////////////////
 // Set/Get global properties
 inline void mpreal::set_default_prec(mp_prec_t prec)
-{ 
-    mpfr_set_default_prec(prec); 
+{
+    mpfr_set_default_prec(prec);
 }
 
 inline void mpreal::set_default_rnd(mp_rnd_t rnd_mode)
-{ 
-    mpfr_set_default_rounding_mode(rnd_mode); 
+{
+    mpfr_set_default_rounding_mode(rnd_mode);
 }
 
 inline bool mpreal::fits_in_bits(double x, int n)
-{   
+{
     int i;
     double t;
-    return IsInf(x) || (std::modf ( std::ldexp ( std::frexp ( x, &i ), n ), &t ) == 0.0);
+    return MPREAL_IS_INF(x) || (std::modf ( std::ldexp ( std::frexp ( x, &i ), n ), &t ) == 0.0);
 }
 
 inline const mpreal pow(const mpreal& a, const mpreal& b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
@@ -2781,6 +2954,18 @@ inline const mpreal pow(const mpreal& a, const mpz_t b, mp_rnd_t rnd_mode = mpre
     mpreal x(a);
     mpfr_pow_z(x.mp,x.mp,b,rnd_mode);
     return x;
+}
+
+inline const mpreal pow(const mpreal& a, const long long b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    (void)rnd_mode;
+    return pow(a,mpreal(b));
+}
+
+inline const mpreal pow(const mpreal& a, const unsigned long long b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    (void)rnd_mode;
+    return pow(a,mpreal(b));
 }
 
 inline const mpreal pow(const mpreal& a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
@@ -3013,7 +3198,7 @@ inline const mpreal pow(const int a, const double b, mp_rnd_t rnd_mode)
     else        return pow(mpreal(a),mpreal(b),rnd_mode); //mpfr_pow
 }
 
-// pow long double 
+// pow long double
 inline const mpreal pow(const long double a, const long double b, mp_rnd_t rnd_mode)
 {
     return pow(mpreal(a),mpreal(b),rnd_mode);
@@ -3070,11 +3255,10 @@ inline const mpreal pow(const double a, const int b, mp_rnd_t rnd_mode)
 // Non-throwing swap C++ idiom: http://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Non-throwing_swap
 namespace std
 {
-	// we are allowed to extend namespace std with specializations only
     template <>
-    inline void swap(mpfr::mpreal& x, mpfr::mpreal& y) 
-    { 
-        return mpfr::swap(x, y); 
+    inline void swap(mpfr::mpreal& x, mpfr::mpreal& y)
+    {
+        return mpfr::swap(x, y);
     }
 
     template<>
@@ -3085,7 +3269,7 @@ namespace std
         static const bool is_signed         = true;
         static const bool is_integer        = false;
         static const bool is_exact          = false;
-        static const int  radix             = 2;    
+        static const int  radix             = 2;
 
         static const bool has_infinity      = true;
         static const bool has_quiet_NaN     = true;
@@ -3105,7 +3289,7 @@ namespace std
 
         // Returns smallest eps such that 1 + eps != 1 (classic machine epsilon)
         inline static mpfr::mpreal epsilon(mp_prec_t precision = mpfr::mpreal::get_default_prec()) {  return  mpfr::machine_epsilon(precision); }
-		
+
         // Returns smallest eps such that x + eps != x (relative machine epsilon)
         inline static mpfr::mpreal epsilon(const mpfr::mpreal& x) {  return mpfr::machine_epsilon(x);  }
 
@@ -3113,8 +3297,8 @@ namespace std
         {
             mp_rnd_t r = mpfr::mpreal::get_default_rnd();
 
-            if(r == GMP_RNDN)  return mpfr::mpreal(0.5, precision); 
-            else               return mpfr::mpreal(1.0, precision);    
+            if(r == GMP_RNDN)  return mpfr::mpreal(0.5, precision);
+            else               return mpfr::mpreal(1.0, precision);
         }
 
         inline static const mpfr::mpreal infinity()         { return mpfr::const_infinity();     }
@@ -3125,17 +3309,17 @@ namespace std
         // Please note, exponent range is not fixed in MPFR
         static const int min_exponent = MPFR_EMIN_DEFAULT;
         static const int max_exponent = MPFR_EMAX_DEFAULT;
-        MPREAL_PERMISSIVE_EXPR static const int min_exponent10 = (int) (MPFR_EMIN_DEFAULT * 0.3010299956639811); 
-        MPREAL_PERMISSIVE_EXPR static const int max_exponent10 = (int) (MPFR_EMAX_DEFAULT * 0.3010299956639811); 
+        MPREAL_PERMISSIVE_EXPR static const int min_exponent10 = (int) (MPFR_EMIN_DEFAULT * 0.3010299956639811);
+        MPREAL_PERMISSIVE_EXPR static const int max_exponent10 = (int) (MPFR_EMAX_DEFAULT * 0.3010299956639811);
 
 #ifdef MPREAL_HAVE_DYNAMIC_STD_NUMERIC_LIMITS
 
         // Following members should be constant according to standard, but they can be variable in MPFR
-        // So we define them as functions here. 
+        // So we define them as functions here.
         //
         // This is preferable way for std::numeric_limits<mpfr::mpreal> specialization.
-        // But it is incompatible with standard std::numeric_limits and might not work with other libraries, e.g. boost. 
-        // See below for compatible implementation. 
+        // But it is incompatible with standard std::numeric_limits and might not work with other libraries, e.g. boost.
+        // See below for compatible implementation.
         inline static float_round_style round_style()
         {
             mp_rnd_t r = mpfr::mpreal::get_default_rnd();
@@ -3143,9 +3327,9 @@ namespace std
             switch (r)
             {
             case GMP_RNDN: return round_to_nearest;
-            case GMP_RNDZ: return round_toward_zero; 
-            case GMP_RNDU: return round_toward_infinity; 
-            case GMP_RNDD: return round_toward_neg_infinity; 
+            case GMP_RNDZ: return round_toward_zero;
+            case GMP_RNDU: return round_toward_infinity;
+            case GMP_RNDD: return round_toward_neg_infinity;
             default: return round_indeterminate;
             }
         }
@@ -3172,13 +3356,13 @@ namespace std
         // If possible, please use functions digits() and round_style() defined above.
         //
         // These (default) values are preserved for compatibility with existing libraries, e.g. boost.
-        // Change them accordingly to your application. 
+        // Change them accordingly to your application.
         //
         // For example, if you use 256 bits of precision uniformly in your program, then:
         // digits       = 256
-        // digits10     = 77 
+        // digits10     = 77
         // max_digits10 = 78
-        // 
+        //
         // Approximate formula for decimal digits is: digits10 = floor(log10(2) * digits). See bits2digits() for more details.
 
         static const std::float_round_style round_style = round_to_nearest;

--- a/src/amuse/community/brutus/interface.cc
+++ b/src/amuse/community/brutus/interface.cc
@@ -2,7 +2,6 @@
 // Includes
 ////////////////////////////////////////////////////////
 #include <iostream>
-using namespace std;
 
 #include <fstream>
 #include <cstdlib>
@@ -14,21 +13,21 @@ using namespace std;
 ////////////////////////////////////////////////////////
 // Declare global variables
 ////////////////////////////////////////////////////////
-ofstream odata;
+std::ofstream odata;
 
 int particle_id_counter = 0;
 
-int numBits = 64;  
+int numBits = 64;
 int numDigits = numBits/4;
 
-string out_directory;
+std::string out_directory;
 std::map<int, int> local_index_map;
 
 /*
  * We need this result_strings array to ensure that
  * C++ strings are not reclaimed before the function ends
  */
-string result_strings[10];
+std::string result_strings[10];
 
 Brutus *brutus = NULL;
 
@@ -38,15 +37,18 @@ mpreal t = "0";
 
 mpreal epsilon = "1e-6"; // Bulirsch-Stoer tolerance
 
-vector<mpreal> data, data_radius;
+std::vector<mpreal> data, data_radius;
 
 ////////////////////////////////////////////////////////
 // Amuse interface functions
 ////////////////////////////////////////////////////////
+
+extern "C" {
+
 int initialize_code() {
     odata.open("temp.log");
 
-    mpreal::set_default_prec(numBits);  
+    mpreal::set_default_prec(numBits);
 
     brutus = new Brutus();
 
@@ -62,7 +64,7 @@ int initialize_code() {
 
 // functions with "_string" assign strings to mpreals, and without "_string" assign doubles to mpreals
 
-int new_particle_string(int *particle_identifier, char* mass, 
+int new_particle_string(int *particle_identifier, char* mass,
         char* x, char* y, char* z, char* vx, char* vy, char* vz, char* radius) {
 
     data.push_back(mass);
@@ -80,7 +82,7 @@ int new_particle_string(int *particle_identifier, char* mass,
 
     return 0;
 }
-int new_particle_float64(int *particle_identifier, double mass, 
+int new_particle_float64(int *particle_identifier, double mass,
         double x, double y, double z, double vx, double vy, double vz, double radius) {
 
     data.push_back( (mpreal)mass );
@@ -139,7 +141,7 @@ int get_begin_time(double * output) {
 // Timestep parameter, eta
 int set_eta_string(char* myeta) {
     eta = myeta;
-    brutus->set_eta(eta); 
+    brutus->set_eta(eta);
     return 0;
 }
 int get_eta_string(char **myeta) {
@@ -200,12 +202,12 @@ int get_bs_tolerance_string(char **bs_tolerance) {
 }
 int set_bs_tolerance(double bs_tolerance) {
 
-odata << t << ": changing e from " << epsilon << ", to " << bs_tolerance << endl;
+odata << t << ": changing e from " << epsilon << ", to " << bs_tolerance << std::endl;
 
     epsilon = (mpreal) bs_tolerance;
     brutus->set_tolerance(epsilon);
 
-odata << epsilon << " " << brutus->get_tolerance() << endl;
+odata << epsilon << " " << brutus->get_tolerance() << std::endl;
 
     return 0;
 }
@@ -215,14 +217,14 @@ int get_bs_tolerance(double *bs_tolerance) {
 }
 // Word-length, numBits in mantissa
 int set_word_length(int mynumBits) {
-odata << t << ": changing L from " << numBits << ", to " << mynumBits << endl;
+odata << t << ": changing L from " << numBits << ", to " << mynumBits << std::endl;
 
     numBits = mynumBits;
     mpreal::set_default_prec(numBits);
     numDigits = (int)abs(log10( pow("2.0", -numBits) )).toLong();
     brutus->set_numBits(numBits);
 
-odata << numBits << " " << brutus->get_numBits() << endl;
+odata << numBits << " " << brutus->get_numBits() << std::endl;
 
     return 0;
 }
@@ -263,7 +265,7 @@ int get_mass_string(int id, char **mass) {
   mass_string = data[id*7+0].toString();
   *mass = (char*) mass_string.c_str();
   return 0;
-} 
+}
 int set_mass_string(int id, char *mass) {
   if (id < 0 || id >= particle_id_counter){
     return -1;
@@ -277,7 +279,7 @@ int get_mass(int id, double* mass) {
   }
   *mass = data[id*7+0].toDouble();
   return 0;
-} 
+}
 int set_mass(int id, double mass) {
   if (id < 0 || id >= particle_id_counter){
     return -1;
@@ -379,7 +381,7 @@ std::string get_state_strings_vx;
 std::string get_state_strings_vy;
 std::string get_state_strings_vz;
 std::string get_state_strings_r;
-int get_state_string(int id, char** m, char** x, char** y, char** z, char** vx, char** vy, char** vz, char** radius) {  
+int get_state_string(int id, char** m, char** x, char** y, char** z, char** vx, char** vy, char** vz, char** radius) {
   if (id < 0 || id >= particle_id_counter){
     return -1;
   }
@@ -445,7 +447,7 @@ int set_state(int id, double m, double x, double y, double z, double vx, double 
 }
 
 std::string radius_string;
-int get_radius_string(int id, char** radius){ 
+int get_radius_string(int id, char** radius){
   if (id < 0 || id >= particle_id_counter){
     return -1;
   }
@@ -460,7 +462,7 @@ int set_radius_string(int id, char* radius) {
   data_radius[id] = radius;
   return 0;
 }
-int get_radius(int id, double* radius){ 
+int get_radius(int id, double* radius){
   if (id < 0 || id >= particle_id_counter){
     return -1;
   }
@@ -523,7 +525,7 @@ int get_index_of_first_particle(int* id){return -2;}
 int get_index_of_next_particle(int id, int* idnext){return -2;}
 
 std::string total_mass_string;
-int get_total_mass_string(char **M){ 
+int get_total_mass_string(char **M){
   int N = data.size()/7;
   mpreal Mtot = "0";
   for(int i=0; i<N; i++) {
@@ -534,7 +536,7 @@ int get_total_mass_string(char **M){
   return 0;
 }
 
-int get_total_mass(double* M){ 
+int get_total_mass(double* M){
   int N = data.size()/7;
   mpreal Mtot = "0";
   for(int i=0; i<N; i++) {
@@ -564,7 +566,7 @@ int get_potential_energy_m(mpreal* ep) {
 
       eptot -= mi*mj/sqrt(dr2);
     }
-  }  
+  }
 
   *ep = eptot;
   return 0;
@@ -608,8 +610,8 @@ int get_kinetic_energy_string( char **ep) {
 std::string total_energy_string;
 
 int get_total_energy_string( char **ep) {
-    mpreal ektot = "0";   
-    mpreal eptot = "0";   
+    mpreal ektot = "0";
+    mpreal eptot = "0";
     mpreal etot = "0";
     get_potential_energy_m(&eptot);
     get_kinetic_energy_m(&ektot);
@@ -633,40 +635,40 @@ int get_kinetic_energy(double* ek) {
   return 0;
 }
 
-int get_center_of_mass_position(double* x , double* y, double* z){ 
+int get_center_of_mass_position(double* x , double* y, double* z){
   int N = data.size()/7;
   mpreal Mtot = "0";
   for(int i=0; i<N; i++) {
     Mtot += data[i*7];
   }
 
-  vector<mpreal> rcm(3,"0");
+  std::vector<mpreal> rcm(3,"0");
   for(int i=0; i<N; i++) {
     for(int j=0; j<3; j++) {
       rcm[j] += data[i*7]*data[i*7+(j+1)];
     }
   }
-  for(int i=0; i<3; i++) rcm[i] /= Mtot;  
+  for(int i=0; i<3; i++) rcm[i] /= Mtot;
 
   *x = rcm[0].toDouble();
   *y = rcm[1].toDouble();
   *z = rcm[2].toDouble();
   return 0;
 }
-int get_center_of_mass_velocity(double* vx, double* vy, double* vz){ 
+int get_center_of_mass_velocity(double* vx, double* vy, double* vz){
   int N = data.size()/7;
   mpreal Mtot = "0";
   for(int i=0; i<N; i++) {
     Mtot += data[i*7];
   }
 
-  vector<mpreal> vcm(3,"0");
+  std::vector<mpreal> vcm(3,"0");
   for(int i=0; i<N; i++) {
     for(int j=0; j<3; j++) {
       vcm[j] += data[i*7]*data[i*7+(j+4)];
     }
   }
-  for(int i=0; i<3; i++) vcm[i] /= Mtot;  
+  for(int i=0; i<3; i++) vcm[i] /= Mtot;
 
   *vx = vcm[0].toDouble();
   *vy = vcm[1].toDouble();
@@ -675,3 +677,7 @@ int get_center_of_mass_velocity(double* vx, double* vy, double* vz){
 }
 
 int get_acceleration(int id, double* ax, double* ay, double* az){return -2;}
+int set_acceleration(int id, double ax, double ay, double az){return -2;}
+
+}       // extern "C"
+

--- a/src/amuse/community/brutus/interface.cc
+++ b/src/amuse/community/brutus/interface.cc
@@ -43,8 +43,6 @@ std::vector<mpreal> data, data_radius;
 // Amuse interface functions
 ////////////////////////////////////////////////////////
 
-extern "C" {
-
 int initialize_code() {
     odata.open("temp.log");
 
@@ -678,6 +676,4 @@ int get_center_of_mass_velocity(double* vx, double* vy, double* vz){
 
 int get_acceleration(int id, double* ax, double* ay, double* az){return -2;}
 int set_acceleration(int id, double ax, double ay, double az){return -2;}
-
-}       // extern "C"
 

--- a/src/amuse/community/brutus/mpfrc++/copying.txt
+++ b/src/amuse/community/brutus/mpfrc++/copying.txt
@@ -1,0 +1,674 @@
+                   GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/src/amuse/community/brutus/mpfrc++/mpreal.h
+++ b/src/amuse/community/brutus/mpfrc++/mpreal.h
@@ -1,34 +1,35 @@
 /*
-    MPFR C++: Multi-precision floating point number class for C++. 
+    MPFR C++: Multi-precision floating point number class for C++.
     Based on MPFR library:    http://mpfr.org
 
     Project homepage:    http://www.holoborodko.com/pavel/mpfr
     Contact e-mail:      pavel@holoborodko.com
 
-    Copyright (c) 2008-2019 Pavel Holoborodko
+    Copyright (c) 2008-2024 Pavel Holoborodko
 
     Contributors:
-    Dmitriy Gubanov, Konstantin Holoborodko, Brian Gladman, 
-    Helmut Jarausch, Fokko Beekhof, Ulrich Mutze, Heinz van Saanen, 
-    Pere Constans, Peter van Hoof, Gael Guennebaud, Tsai Chia Cheng, 
+    Dmitriy Gubanov, Konstantin Holoborodko, Brian Gladman,
+    Helmut Jarausch, Fokko Beekhof, Ulrich Mutze, Heinz van Saanen,
+    Pere Constans, Peter van Hoof, Gael Guennebaud, Tsai Chia Cheng,
     Alexei Zubanov, Jauhien Piatlicki, Victor Berger, John Westwood,
     Petr Aleksandrov, Orion Poplawski, Charles Karney, Arash Partow,
-    Rodney James, Jorge Leitao, Jerome Benoit, Michal Maly.
+    Rodney James, Jorge Leitao, Jerome Benoit, Michal Maly, 
+    Abhinav Natarajan, Valerio Di Lecce, Luca Vandelli.
 
     Licensing:
     (A) MPFR C++ is under GNU General Public License ("GPL").
-    
-    (B) Non-free licenses may also be purchased from the author, for users who 
+
+    (B) Non-free licenses may also be purchased from the author, for users who
         do not want their programs protected by the GPL.
 
-        The non-free licenses are for users that wish to use MPFR C++ in 
-        their products but are unwilling to release their software 
-        under the GPL (which would require them to release source code 
+        The non-free licenses are for users that wish to use MPFR C++ in
+        their products but are unwilling to release their software
+        under the GPL (which would require them to release source code
         and allow free redistribution).
 
         Such users can purchase an unlimited-use license from the author.
         Contact us for more details.
-    
+
     GNU General Public License ("GPL") copyright permissions statement:
     **************************************************************************
     This program is free software: you can redistribute it and/or modify
@@ -68,19 +69,19 @@
 
 // Library version
 #define MPREAL_VERSION_MAJOR 3
-#define MPREAL_VERSION_MINOR 6
-#define MPREAL_VERSION_PATCHLEVEL 6
-#define MPREAL_VERSION_STRING "3.6.6"
+#define MPREAL_VERSION_MINOR 7
+#define MPREAL_VERSION_PATCHLEVEL 1
+#define MPREAL_VERSION_STRING "3.7.1"
 
 // Detect compiler using signatures from http://predef.sourceforge.net/
 #if defined(__GNUC__) && defined(__INTEL_COMPILER)
-    #define IsInf(x) isinf(x)                   // Intel ICC compiler on Linux 
+    #define MPREAL_IS_INF(x) isinf(x)           // Intel ICC compiler on Linux
 
-#elif defined(_MSC_VER)                         // Microsoft Visual C++ 
-    #define IsInf(x) (!_finite(x))                           
+#elif defined(_MSC_VER)                         // Microsoft Visual C++
+    #define MPREAL_IS_INF(x) (!_finite(x))
 
 #else
-    #define IsInf(x) std::isinf(x)              // GNU C/C++ (and/or other compilers), just hope for C99 conformance
+    #define MPREAL_IS_INF(x) std::isinf(x)      // GNU C/C++ (and/or other compilers), just hope for C99 conformance
 #endif
 
 // A Clang feature extension to determine compiler features.
@@ -98,12 +99,12 @@
 
     #define MPREAL_HAVE_MOVE_SUPPORT
 
-    // Use fields in mpfr_t structure to check if it was initialized / set dummy initialization 
+    // Use fields in mpfr_t structure to check if it was initialized / set dummy initialization
     #define mpfr_is_initialized(x)      (0 != (x)->_mpfr_d)
     #define mpfr_set_uninitialized(x)   ((x)->_mpfr_d = 0 )
 #endif
 
-// Detect support for explicit converters. 
+// Detect support for explicit converters.
 #if (__has_feature(cxx_explicit_conversions) || \
        (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC_MINOR >= 5) || __cplusplus >= 201103L || \
        (defined(_MSC_VER) && _MSC_VER >= 1800) || \
@@ -112,24 +113,33 @@
     #define MPREAL_HAVE_EXPLICIT_CONVERTERS
 #endif
 
-#define MPFR_USE_INTMAX_T   // Enable 64-bit integer types - should be defined before mpfr.h
-
 #if defined(MPREAL_HAVE_MSVC_DEBUGVIEW) && defined(_MSC_VER) && defined(_DEBUG)
     #define MPREAL_MSVC_DEBUGVIEW_CODE     DebugView = toString();
     #define MPREAL_MSVC_DEBUGVIEW_DATA     std::string DebugView;
 #else
-    #define MPREAL_MSVC_DEBUGVIEW_CODE 
-    #define MPREAL_MSVC_DEBUGVIEW_DATA 
+    #define MPREAL_MSVC_DEBUGVIEW_CODE
+    #define MPREAL_MSVC_DEBUGVIEW_DATA
 #endif
 
-#include <mpfr.h>
+// Check if mpfr.h was included earlier (and with compatible settings).
+#if defined (__MPFR_H) && !(defined (MPFR_USE_NO_MACRO) && defined (MPFR_USE_INTMAX_T))
+	#error The MPFR_USE_NO_MACRO and MPFR_USE_INTMAX_T must be defined for proper use of mpfr.h/mpreal.h
+#else
+    #ifndef MPFR_USE_INTMAX_T
+        #define MPFR_USE_INTMAX_T   // Enable 64-bit integer types - should be defined before mpfr.h
+    #endif
+    #ifndef MPFR_USE_NO_MACRO
+        #define MPFR_USE_NO_MACRO   // Avoid name clash with MPFR, introduced in MPFR 4.2.0
+    #endif
+	#include <mpfr.h>
+#endif
 
 #if (MPFR_VERSION < MPFR_VERSION_NUM(3,0,0))
     #include <cstdlib>                          // Needed for random()
 #endif
 
 // Less important options
-#define MPREAL_DOUBLE_BITS_OVERFLOW -1          // Triggers overflow exception during conversion to double if mpreal 
+#define MPREAL_DOUBLE_BITS_OVERFLOW -1          // Triggers overflow exception during conversion to double if mpreal
                                                 // cannot fit in MPREAL_DOUBLE_BITS_OVERFLOW bits
                                                 // = -1 disables overflow checks (default)
 
@@ -149,9 +159,9 @@ namespace mpfr {
 class mpreal {
 private:
     mpfr_t mp;
-    
+
 public:
-    
+
     // Get default rounding mode & precision
     inline static mp_rnd_t   get_default_rnd()    {    return (mp_rnd_t)(mpfr_get_default_rounding_mode());       }
     inline static mp_prec_t  get_default_prec()   {    return (mpfr_get_default_prec)();                          }
@@ -159,9 +169,9 @@ public:
     // Constructors && type conversions
     mpreal();
     mpreal(const mpreal& u);
-    mpreal(const mpf_t u);    
-    mpreal(const mpz_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());    
-    mpreal(const mpq_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());    
+    mpreal(const mpf_t u);
+    mpreal(const mpz_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
+    mpreal(const mpq_t u,                  mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const double u,                 mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const long double u,            mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const unsigned long long int u, mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
@@ -170,15 +180,15 @@ public:
     mpreal(const unsigned int u,           mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const long int u,               mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const int u,                    mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t mode = mpreal::get_default_rnd());
-    
+
     // Construct mpreal from mpfr_t structure.
-    // shared = true allows to avoid deep copy, so that mpreal and 'u' share the same data & pointers.    
-    mpreal(const mpfr_t  u, bool shared = false);   
+    // shared = true allows to avoid deep copy, so that mpreal and 'u' share the same data & pointers.
+    mpreal(const mpfr_t  u, bool shared = false);
 
     mpreal(const char* s,             mp_prec_t prec = mpreal::get_default_prec(), int base = 10, mp_rnd_t mode = mpreal::get_default_rnd());
     mpreal(const std::string& s,      mp_prec_t prec = mpreal::get_default_prec(), int base = 10, mp_rnd_t mode = mpreal::get_default_rnd());
 
-    ~mpreal();                           
+    ~mpreal();
 
 #ifdef MPREAL_HAVE_MOVE_SUPPORT
     mpreal& operator=(mpreal&& v);
@@ -187,7 +197,7 @@ public:
 
     // Operations
     // =
-    // +, -, *, /, ++, --, <<, >> 
+    // +, -, *, /, ++, --, <<, >>
     // *=, +=, -=, /=,
     // <, >, ==, <=, >=
 
@@ -197,7 +207,7 @@ public:
     mpreal& operator=(const mpz_t v);
     mpreal& operator=(const mpq_t v);
     mpreal& operator=(const long double v);
-    mpreal& operator=(const double v);        
+    mpreal& operator=(const double v);
     mpreal& operator=(const unsigned long int v);
     mpreal& operator=(const unsigned long long int v);
     mpreal& operator=(const long long int v);
@@ -231,7 +241,7 @@ public:
 
     const mpreal operator+() const;
     mpreal& operator++ ();
-    const mpreal  operator++ (int); 
+    const mpreal  operator++ (int);
 
     // -
     mpreal& operator-=(const mpreal& v);
@@ -249,7 +259,7 @@ public:
     friend const mpreal operator-(const long int b,          const mpreal& a);
     friend const mpreal operator-(const int b,               const mpreal& a);
     friend const mpreal operator-(const double b,            const mpreal& a);
-    mpreal& operator-- ();    
+    mpreal& operator-- ();
     const mpreal  operator-- (int);
 
     // *
@@ -262,7 +272,7 @@ public:
     mpreal& operator*=(const unsigned int v);
     mpreal& operator*=(const long int v);
     mpreal& operator*=(const int v);
-    
+
     // /
     mpreal& operator/=(const mpreal& v);
     mpreal& operator/=(const mpz_t v);
@@ -303,11 +313,15 @@ public:
 
 #if defined (MPREAL_HAVE_EXPLICIT_CONVERTERS)
     explicit operator bool               () const { return toBool();                 }
-    explicit operator int                () const { return int(toLong());            }
+    explicit operator signed char        () const { return (signed char)toLong();    }
+    explicit operator unsigned char      () const { return (unsigned char)toULong(); }
+    explicit operator short              () const { return (short)toLong();          }
+    explicit operator unsigned short     () const { return (unsigned short)toULong();}
+    explicit operator int                () const { return (int)toLong();            }
+    explicit operator unsigned int       () const { return (unsigned int)toULong();  }
     explicit operator long               () const { return toLong();                 }
-    explicit operator long long          () const { return toLLong();                }
-    explicit operator unsigned           () const { return unsigned(toULong());      }
     explicit operator unsigned long      () const { return toULong();                }
+    explicit operator long long          () const { return toLLong();                }
     explicit operator unsigned long long () const { return toULLong();               }
     explicit operator float              () const { return toFloat();                }
     explicit operator double             () const { return toDouble();               }
@@ -350,13 +364,13 @@ public:
     friend inline const mpreal div_2ui(const mpreal& v, unsigned long int k, mp_rnd_t rnd_mode);
     friend inline const mpreal div_2si(const mpreal& v, long int k, mp_rnd_t rnd_mode);
     friend int cmpabs(const mpreal& a,const mpreal& b);
-    
+
     friend const mpreal log  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal log2 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal logb (const mpreal& v, mp_rnd_t rnd_mode);
-    friend mp_exp_t ilogb(const mpreal& v);
+    friend     mp_exp_t ilogb(const mpreal& v);
     friend const mpreal log10(const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal exp  (const mpreal& v, mp_rnd_t rnd_mode); 
+    friend const mpreal exp  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal exp2 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal exp10(const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal log1p(const mpreal& v, mp_rnd_t rnd_mode);
@@ -405,12 +419,12 @@ public:
     friend const mpreal zeta     (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal erf      (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal erfc     (const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal besselj0 (const mpreal& v, mp_rnd_t rnd_mode); 
-    friend const mpreal besselj1 (const mpreal& v, mp_rnd_t rnd_mode); 
+    friend const mpreal besselj0 (const mpreal& v, mp_rnd_t rnd_mode);
+    friend const mpreal besselj1 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal besseljn (long n, const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal bessely0 (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal bessely1 (const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal besselyn (long n, const mpreal& v, mp_rnd_t rnd_mode); 
+    friend const mpreal besselyn (long n, const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal fma      (const mpreal& v1, const mpreal& v2, const mpreal& v3, mp_rnd_t rnd_mode);
     friend const mpreal fms      (const mpreal& v1, const mpreal& v2, const mpreal& v3, mp_rnd_t rnd_mode);
     friend const mpreal agm      (const mpreal& v1, const mpreal& v2, mp_rnd_t rnd_mode);
@@ -448,7 +462,7 @@ public:
 
     // Splits mpreal value into fractional and integer parts.
     // Returns fractional part and stores integer part in n.
-    friend const mpreal modf(const mpreal& v, mpreal& n);    
+    friend const mpreal modf(const mpreal& v, mpreal& n);
 
     // Constants
     // don't forget to call mpfr_free_cache() for every thread where you are using const-functions
@@ -469,22 +483,24 @@ public:
     friend const mpreal ceil (const mpreal& v);
     friend const mpreal floor(const mpreal& v);
     friend const mpreal round(const mpreal& v);
+    friend long lround(const mpreal& v);
+    friend long long llround(const mpreal& v);
     friend const mpreal trunc(const mpreal& v);
     friend const mpreal rint_ceil   (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal rint_floor  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal rint_round  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal rint_trunc  (const mpreal& v, mp_rnd_t rnd_mode);
     friend const mpreal frac        (const mpreal& v, mp_rnd_t rnd_mode);
-    friend const mpreal remainder   (         const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
-    friend const mpreal remquo      (long* q, const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
-    
+    friend const mpreal remainder   (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
+    friend const mpreal remquo      (const mpreal& x, const mpreal& y, int* q, mp_rnd_t rnd_mode);
+
     // Miscellaneous Functions
     friend const mpreal nexttoward (const mpreal& x, const mpreal& y);
     friend const mpreal nextabove  (const mpreal& x);
     friend const mpreal nextbelow  (const mpreal& x);
 
     // use gmp_randinit_default() to init state, gmp_randclear() to clear
-    friend const mpreal urandomb (gmp_randstate_t& state); 
+    friend const mpreal urandomb (gmp_randstate_t& state);
 
 // MPFR < 2.4.2 Specifics
 #if (MPFR_VERSION <= MPFR_VERSION_NUM(2,4,2))
@@ -511,9 +527,9 @@ public:
     // Aliases for get_prec(), set_prec() - needed for compatibility with std::complex<mpreal> interface
     inline mpreal&      setPrecision(int Precision, mp_rnd_t RoundingMode = get_default_rnd());
     inline int          getPrecision() const;
-    
+
     // Set mpreal to +/- inf, NaN, +/-0
-    mpreal&        setInf  (int Sign = +1);    
+    mpreal&        setInf  (int Sign = +1);
     mpreal&        setNan  ();
     mpreal&        setZero (int Sign = +1);
     mpreal&        setSign (int Sign, mp_rnd_t RoundingMode = get_default_rnd());
@@ -542,7 +558,7 @@ public:
 
     // Efficient swapping of two mpreal values - needed for std algorithms
     friend void swap(mpreal& x, mpreal& y);
-    
+
     friend const mpreal fmax(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
     friend const mpreal fmin(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode);
 
@@ -552,7 +568,7 @@ private:
     //
     // mpfr::mpreal=<DebugView>                              ; Show value only
     // mpfr::mpreal=<DebugView>, <mp[0]._mpfr_prec,u>bits    ; Show value & precision
-    // 
+    //
     // at the beginning of
     // [Visual Studio Installation Folder]\Common7\Packages\Debugger\autoexp.dat
     MPREAL_MSVC_DEBUGVIEW_DATA
@@ -571,15 +587,15 @@ public:
 //////////////////////////////////////////////////////////////////////////
 // Constructors & converters
 // Default constructor: creates mp number and initializes it to 0.
-inline mpreal::mpreal() 
-{ 
-    mpfr_init2(mpfr_ptr(), mpreal::get_default_prec()); 
+inline mpreal::mpreal()
+{
+    mpfr_init2(mpfr_ptr(), mpreal::get_default_prec());
     mpfr_set_zero_fast(mpfr_ptr());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
 
-inline mpreal::mpreal(const mpreal& u) 
+inline mpreal::mpreal(const mpreal& u)
 {
     mpfr_init2(mpfr_ptr(),mpfr_get_prec(u.mpfr_srcptr()));
     mpfr_set  (mpfr_ptr(),u.mpfr_srcptr(),mpreal::get_default_rnd());
@@ -651,20 +667,20 @@ inline mpreal::mpreal(const double u, mp_prec_t prec, mp_rnd_t mode)
      mpfr_init2(mpfr_ptr(), prec);
 
 #if (MPREAL_DOUBLE_BITS_OVERFLOW > -1)
-	if(fits_in_bits(u, MPREAL_DOUBLE_BITS_OVERFLOW))
-	{
-		mpfr_set_d(mpfr_ptr(), u, mode);
-	}else
-		throw conversion_overflow();
+    if(fits_in_bits(u, MPREAL_DOUBLE_BITS_OVERFLOW))
+    {
+        mpfr_set_d(mpfr_ptr(), u, mode);
+    }else
+        throw conversion_overflow();
 #else
-	mpfr_set_d(mpfr_ptr(), u, mode);
+    mpfr_set_d(mpfr_ptr(), u, mode);
 #endif
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
 
 inline mpreal::mpreal(const long double u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_ld(mpfr_ptr(), u, mode);
 
@@ -672,7 +688,7 @@ inline mpreal::mpreal(const long double u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const unsigned long long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_uj(mpfr_ptr(), u, mode);
 
@@ -680,7 +696,7 @@ inline mpreal::mpreal(const unsigned long long int u, mp_prec_t prec, mp_rnd_t m
 }
 
 inline mpreal::mpreal(const long long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_sj(mpfr_ptr(), u, mode);
 
@@ -688,7 +704,7 @@ inline mpreal::mpreal(const long long int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const unsigned long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_ui(mpfr_ptr(), u, mode);
 
@@ -696,7 +712,7 @@ inline mpreal::mpreal(const unsigned long int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const unsigned int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_ui(mpfr_ptr(), u, mode);
 
@@ -704,7 +720,7 @@ inline mpreal::mpreal(const unsigned int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const long int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_si(mpfr_ptr(), u, mode);
 
@@ -712,7 +728,7 @@ inline mpreal::mpreal(const long int u, mp_prec_t prec, mp_rnd_t mode)
 }
 
 inline mpreal::mpreal(const int u, mp_prec_t prec, mp_rnd_t mode)
-{ 
+{
     mpfr_init2 (mpfr_ptr(), prec);
     mpfr_set_si(mpfr_ptr(), u, mode);
 
@@ -722,7 +738,7 @@ inline mpreal::mpreal(const int u, mp_prec_t prec, mp_rnd_t mode)
 inline mpreal::mpreal(const char* s, mp_prec_t prec, int base, mp_rnd_t mode)
 {
     mpfr_init2  (mpfr_ptr(), prec);
-    mpfr_set_str(mpfr_ptr(), s, base, mode); 
+    mpfr_set_str(mpfr_ptr(), s, base, mode);
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
@@ -730,7 +746,7 @@ inline mpreal::mpreal(const char* s, mp_prec_t prec, int base, mp_rnd_t mode)
 inline mpreal::mpreal(const std::string& s, mp_prec_t prec, int base, mp_rnd_t mode)
 {
     mpfr_init2  (mpfr_ptr(), prec);
-    mpfr_set_str(mpfr_ptr(), s.c_str(), base, mode); 
+    mpfr_set_str(mpfr_ptr(), s.c_str(), base, mode);
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
 }
@@ -738,15 +754,15 @@ inline mpreal::mpreal(const std::string& s, mp_prec_t prec, int base, mp_rnd_t m
 inline void mpreal::clear(::mpfr_ptr x)
 {
 #ifdef MPREAL_HAVE_MOVE_SUPPORT
-    if(mpfr_is_initialized(x)) 
+    if(mpfr_is_initialized(x))
 #endif
     mpfr_clear(x);
 }
 
-inline mpreal::~mpreal() 
-{ 
+inline mpreal::~mpreal()
+{
     clear(mpfr_ptr());
-}                           
+}
 
 // internal namespace needed for template magic
 namespace internal{
@@ -754,55 +770,55 @@ namespace internal{
     // Use SFINAE to restrict arithmetic operations instantiation only for numeric types
     // This is needed for smooth integration with libraries based on expression templates, like Eigen.
     // TODO: Do the same for boolean operators.
-    template <typename ArgumentType> struct result_type {};    
-    
-    template <> struct result_type<mpreal>              {typedef mpreal type;};    
-    template <> struct result_type<mpz_t>               {typedef mpreal type;};    
-    template <> struct result_type<mpq_t>               {typedef mpreal type;};    
-    template <> struct result_type<long double>         {typedef mpreal type;};    
-    template <> struct result_type<double>              {typedef mpreal type;};    
-    template <> struct result_type<unsigned long int>   {typedef mpreal type;};    
-    template <> struct result_type<unsigned int>        {typedef mpreal type;};    
-    template <> struct result_type<long int>            {typedef mpreal type;};    
-    template <> struct result_type<int>                 {typedef mpreal type;};    
-    template <> struct result_type<long long>           {typedef mpreal type;};    
-    template <> struct result_type<unsigned long long>  {typedef mpreal type;};    
+    template <typename ArgumentType> struct result_type {};
+
+    template <> struct result_type<mpreal>              {typedef mpreal type;};
+    template <> struct result_type<mpz_t>               {typedef mpreal type;};
+    template <> struct result_type<mpq_t>               {typedef mpreal type;};
+    template <> struct result_type<long double>         {typedef mpreal type;};
+    template <> struct result_type<double>              {typedef mpreal type;};
+    template <> struct result_type<unsigned long int>   {typedef mpreal type;};
+    template <> struct result_type<unsigned int>        {typedef mpreal type;};
+    template <> struct result_type<long int>            {typedef mpreal type;};
+    template <> struct result_type<int>                 {typedef mpreal type;};
+    template <> struct result_type<long long>           {typedef mpreal type;};
+    template <> struct result_type<unsigned long long>  {typedef mpreal type;};
 }
 
 // + Addition
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator+(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) += rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
-    operator+(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) += lhs;    } 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
+    operator+(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) += lhs;    }
 
 // - Subtraction
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator-(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) -= rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
     operator-(const Lhs& lhs, const mpreal& rhs){ return mpreal(lhs) -= rhs;    }
 
 // * Multiplication
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator*(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) *= rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
-    operator*(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) *= lhs;    } 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
+    operator*(const Lhs& lhs, const mpreal& rhs){ return mpreal(rhs) *= lhs;    }
 
 // / Division
-template <typename Rhs> 
-inline const typename internal::result_type<Rhs>::type 
+template <typename Rhs>
+inline const typename internal::result_type<Rhs>::type
     operator/(const mpreal& lhs, const Rhs& rhs){ return mpreal(lhs) /= rhs;    }
 
-template <typename Lhs> 
-inline const typename internal::result_type<Lhs>::type 
+template <typename Lhs>
+inline const typename internal::result_type<Lhs>::type
     operator/(const Lhs& lhs, const mpreal& rhs){ return mpreal(lhs) /= rhs;    }
 
 //////////////////////////////////////////////////////////////////////////
@@ -852,17 +868,17 @@ const mpreal pow(const long int a, const double b, mp_rnd_t rnd_mode = mpreal::g
 const mpreal pow(const int a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const int a, const unsigned int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const int a, const long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
-const mpreal pow(const int a, const int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd()); 
+const mpreal pow(const int a, const int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const int a, const long double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
-const mpreal pow(const int a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd()); 
+const mpreal pow(const int a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 
-const mpreal pow(const long double a, const long double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());    
+const mpreal pow(const long double a, const long double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const unsigned int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const long double a, const int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 
-const mpreal pow(const double a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());    
+const mpreal pow(const double a, const double b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const double a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const double a, const unsigned int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
 const mpreal pow(const double a, const long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd());
@@ -879,9 +895,9 @@ inline const mpreal div_2si(const mpreal& v, long int k, mp_rnd_t rnd_mode = mpr
 inline mpreal machine_epsilon(mp_prec_t prec = mpreal::get_default_prec());
 
 // Returns smallest eps such that x + eps != x (relative machine epsilon)
-inline mpreal machine_epsilon(const mpreal& x);        
+inline mpreal machine_epsilon(const mpreal& x);
 
-// Gives max & min values for the required precision, 
+// Gives max & min values for the required precision,
 // minval is 'safe' meaning 1 / minval does not overflow
 // maxval is 'safe' meaning 1 / maxval does not underflow
 inline mpreal minval(mp_prec_t prec = mpreal::get_default_prec());
@@ -894,7 +910,7 @@ inline bool isEqualFuzzy(const mpreal& a, const mpreal& b, const mpreal& eps);
 inline bool isEqualFuzzy(const mpreal& a, const mpreal& b);
 
 // 'Bitwise' equality check
-//  maxUlps - a and b can be apart by maxUlps binary numbers. 
+//  maxUlps - a and b can be apart by maxUlps binary numbers.
 inline bool isEqualUlps(const mpreal& a, const mpreal& b, int maxUlps);
 
 //////////////////////////////////////////////////////////////////////////
@@ -920,13 +936,13 @@ inline mpreal& mpreal::operator=(const mpreal& v)
 {
     if (this != &v)
     {
-		mp_prec_t tp = mpfr_get_prec(  mpfr_srcptr());
-		mp_prec_t vp = mpfr_get_prec(v.mpfr_srcptr());
+        mp_prec_t tp = mpfr_get_prec(  mpfr_srcptr());
+        mp_prec_t vp = mpfr_get_prec(v.mpfr_srcptr());
 
-		if(tp != vp){
-			clear(mpfr_ptr());
-			mpfr_init2(mpfr_ptr(), vp);
-		}
+        if(tp != vp){
+            clear(mpfr_ptr());
+            mpfr_init2(mpfr_ptr(), vp);
+        }
 
         mpfr_set(mpfr_ptr(), v.mpfr_srcptr(), mpreal::get_default_rnd());
 
@@ -938,7 +954,7 @@ inline mpreal& mpreal::operator=(const mpreal& v)
 inline mpreal& mpreal::operator=(const mpf_t v)
 {
     mpfr_set_f(mpfr_ptr(), v, mpreal::get_default_rnd());
-    
+
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
@@ -946,7 +962,7 @@ inline mpreal& mpreal::operator=(const mpf_t v)
 inline mpreal& mpreal::operator=(const mpz_t v)
 {
     mpfr_set_z(mpfr_ptr(), v, mpreal::get_default_rnd());
-    
+
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
@@ -959,73 +975,73 @@ inline mpreal& mpreal::operator=(const mpq_t v)
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const long double v)        
-{    
+inline mpreal& mpreal::operator=(const long double v)
+{
     mpfr_set_ld(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const double v)                
-{   
+inline mpreal& mpreal::operator=(const double v)
+{
 #if (MPREAL_DOUBLE_BITS_OVERFLOW > -1)
-	if(fits_in_bits(v, MPREAL_DOUBLE_BITS_OVERFLOW))
-	{
-		mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
-	}else
-		throw conversion_overflow();
+    if(fits_in_bits(v, MPREAL_DOUBLE_BITS_OVERFLOW))
+    {
+        mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
+    }else
+        throw conversion_overflow();
 #else
-	mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
+    mpfr_set_d(mpfr_ptr(),v,mpreal::get_default_rnd());
 #endif
 
-	MPREAL_MSVC_DEBUGVIEW_CODE;
+    MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const unsigned long int v)    
-{    
-    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const unsigned long int v)
+{
+    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const unsigned int v)        
-{    
-    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const unsigned int v)
+{
+    mpfr_set_ui(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const unsigned long long int v)    
-{    
-    mpfr_set_uj(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const unsigned long long int v)
+{
+    mpfr_set_uj(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const long long int v)    
-{    
-    mpfr_set_sj(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const long long int v)
+{
+    mpfr_set_sj(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
-inline mpreal& mpreal::operator=(const long int v)            
-{    
-    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());    
+inline mpreal& mpreal::operator=(const long int v)
+{
+    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
 }
 
 inline mpreal& mpreal::operator=(const int v)
-{    
-    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());    
+{
+    mpfr_set_si(mpfr_ptr(), v, mpreal::get_default_rnd());
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -1046,7 +1062,7 @@ inline mpreal& mpreal::operator=(const char* s)
 
     if(0 == mpfr_set_str(t, s, 10, mpreal::get_default_rnd()))
     {
-        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd()); 
+        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd());
         MPREAL_MSVC_DEBUGVIEW_CODE;
     }
 
@@ -1069,7 +1085,7 @@ inline mpreal& mpreal::operator=(const std::string& s)
 
     if(0 == mpfr_set_str(t, s.c_str(), 10, mpreal::get_default_rnd()))
     {
-        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd()); 
+        mpfr_set(mpfr_ptr(), t, mpreal::get_default_rnd());
         MPREAL_MSVC_DEBUGVIEW_CODE;
     }
 
@@ -1077,7 +1093,7 @@ inline mpreal& mpreal::operator=(const std::string& s)
     return *this;
 }
 
-template <typename real_t> 
+template <typename real_t>
 inline mpreal& mpreal::operator= (const std::complex<real_t>& z)
 {
     return *this = z.real();
@@ -1115,9 +1131,9 @@ inline mpreal& mpreal::operator+=(const mpq_t u)
 
 inline mpreal& mpreal::operator+= (const long double u)
 {
-    *this += mpreal(u);    
+    *this += mpreal(u);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator+= (const double u)
@@ -1173,12 +1189,12 @@ inline const mpreal mpreal::operator+()const    {    return mpreal(*this); }
 
 inline const mpreal operator+(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
-	mpfr_add(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
+    mpfr_add(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
-inline mpreal& mpreal::operator++() 
+inline mpreal& mpreal::operator++()
 {
     return *this += 1;
 }
@@ -1190,7 +1206,7 @@ inline const mpreal mpreal::operator++ (int)
     return x;
 }
 
-inline mpreal& mpreal::operator--() 
+inline mpreal& mpreal::operator--()
 {
     return *this -= 1;
 }
@@ -1227,9 +1243,9 @@ inline mpreal& mpreal::operator-=(const mpq_t v)
 
 inline mpreal& mpreal::operator-=(const long double v)
 {
-    *this -= mpreal(v);    
+    *this -= mpreal(v);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator-=(const double v)
@@ -1237,7 +1253,7 @@ inline mpreal& mpreal::operator-=(const double v)
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(2,4,0))
     mpfr_sub_d(mpfr_ptr(),mpfr_srcptr(),v,mpreal::get_default_rnd());
 #else
-    *this -= mpreal(v);    
+    *this -= mpreal(v);
 #endif
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
@@ -1281,9 +1297,9 @@ inline const mpreal mpreal::operator-()const
 
 inline const mpreal operator-(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
-	mpfr_sub(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
+    mpfr_sub(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
 inline const mpreal operator-(const double  b, const mpreal& a)
@@ -1352,9 +1368,9 @@ inline mpreal& mpreal::operator*=(const mpq_t v)
 
 inline mpreal& mpreal::operator*=(const long double v)
 {
-    *this *= mpreal(v);    
+    *this *= mpreal(v);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator*=(const double v)
@@ -1362,7 +1378,7 @@ inline mpreal& mpreal::operator*=(const double v)
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(2,4,0))
     mpfr_mul_d(mpfr_ptr(),mpfr_srcptr(),v,mpreal::get_default_rnd());
 #else
-    *this *= mpreal(v);    
+    *this *= mpreal(v);
 #endif
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -1398,9 +1414,9 @@ inline mpreal& mpreal::operator*=(const int v)
 
 inline const mpreal operator*(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
-	mpfr_mul(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_ptr()), mpfr_get_prec(b.mpfr_ptr())));
+    mpfr_mul(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1430,7 +1446,7 @@ inline mpreal& mpreal::operator/=(const long double v)
 {
     *this /= mpreal(v);
     MPREAL_MSVC_DEBUGVIEW_CODE;
-    return *this;    
+    return *this;
 }
 
 inline mpreal& mpreal::operator/=(const double v)
@@ -1438,7 +1454,7 @@ inline mpreal& mpreal::operator/=(const double v)
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(2,4,0))
     mpfr_div_d(mpfr_ptr(),mpfr_srcptr(),v,mpreal::get_default_rnd());
 #else
-    *this /= mpreal(v);    
+    *this /= mpreal(v);
 #endif
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -1474,9 +1490,9 @@ inline mpreal& mpreal::operator/=(const int v)
 
 inline const mpreal operator/(const mpreal& a, const mpreal& b)
 {
-	mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_srcptr()), mpfr_get_prec(b.mpfr_srcptr())));
-	mpfr_div(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
-	return c;
+    mpreal c(0, (std::max)(mpfr_get_prec(a.mpfr_srcptr()), mpfr_get_prec(b.mpfr_srcptr())));
+    mpfr_div(c.mpfr_ptr(), a.mpfr_srcptr(), b.mpfr_srcptr(), mpreal::get_default_rnd());
+    return c;
 }
 
 inline const mpreal operator/(const unsigned long int b, const mpreal& a)
@@ -1651,9 +1667,9 @@ inline const mpreal div_2si(const mpreal& v, long int k, mp_rnd_t rnd_mode)
 //////////////////////////////////////////////////////////////////////////
 //Relational operators
 
-// WARNING: 
+// WARNING:
 //
-// Please note that following checks for double-NaN are guaranteed to work only in IEEE math mode: 
+// Please note that following checks for double-NaN are guaranteed to work only in IEEE math mode:
 //
 // isnan(b) =  (b != b)
 // isnan(b) = !(b == b)  (we use in code below)
@@ -1717,7 +1733,7 @@ inline bool isint    (const mpreal& op){    return (mpfr_integer_p(op.mpfr_srcpt
 
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(3,0,0))
 inline bool isregular(const mpreal& op){    return (mpfr_regular_p(op.mpfr_srcptr()));}
-#endif 
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 // Type Converters
@@ -1775,20 +1791,20 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
     std::ostringstream format;
 
     int digits = (n >= 0) ? n : 2 + bits2digits(mpfr_get_prec(mpfr_srcptr()));
-    
+
     format << "%." << digits << "RNg";
 
     return toString(format.str());
 
 #else
 
-    char *s, *ns = NULL; 
+    char *s, *ns = NULL;
     size_t slen, nslen;
     mp_exp_t exp;
     std::string out;
 
     if(mpfr_inf_p(mp))
-    { 
+    {
         if(mpfr_sgn(mp)>0) return "+Inf";
         else               return "-Inf";
     }
@@ -1803,7 +1819,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
     {
         slen  = strlen(s);
         nslen = strlen(ns);
-        if(nslen<=slen) 
+        if(nslen<=slen)
         {
             mpfr_free_str(s);
             s = ns;
@@ -1820,7 +1836,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s+exp) ptr--; 
+                while (*ptr=='0' && ptr>s+exp) ptr--;
 
                 if(ptr==s+exp) out = std::string(s,exp+1);
                 else           out = std::string(s,exp+1)+'.'+std::string(s+exp+1,ptr-(s+exp+1)+1);
@@ -1831,7 +1847,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s+exp-1) ptr--; 
+                while (*ptr=='0' && ptr>s+exp-1) ptr--;
 
                 if(ptr==s+exp-1) out = std::string(s,exp);
                 else             out = std::string(s,exp)+'.'+std::string(s+exp,ptr-(s+exp)+1);
@@ -1844,7 +1860,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s+1) ptr--; 
+                while (*ptr=='0' && ptr>s+1) ptr--;
 
                 if(ptr==s+1) out = std::string(s,2);
                 else         out = std::string(s,2)+'.'+std::string(s+2,ptr-(s+2)+1);
@@ -1855,7 +1871,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
             {
                 // Remove zeros starting from right end
                 char* ptr = s+slen-1;
-                while (*ptr=='0' && ptr>s) ptr--; 
+                while (*ptr=='0' && ptr>s) ptr--;
 
                 if(ptr==s) out = std::string(s,1);
                 else       out = std::string(s,1)+'.'+std::string(s+1,ptr-(s+1)+1);
@@ -1882,7 +1898,7 @@ inline std::string mpreal::toString(int n, int b, mp_rnd_t mode) const
 
 //////////////////////////////////////////////////////////////////////////
 // I/O
-inline std::ostream& mpreal::output(std::ostream& os) const 
+inline std::ostream& mpreal::output(std::ostream& os) const
 {
     std::ostringstream format;
     const std::ios::fmtflags flags = os.flags();
@@ -1962,14 +1978,14 @@ inline mpreal& mpreal::setPrecision(int Precision, mp_rnd_t RoundingMode)
     return *this;
 }
 
-inline mpreal& mpreal::setInf(int sign) 
-{ 
+inline mpreal& mpreal::setInf(int sign)
+{
     mpfr_set_inf(mpfr_ptr(), sign);
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
-}    
+}
 
-inline mpreal& mpreal::setNan() 
+inline mpreal& mpreal::setNan()
 {
     mpfr_set_nan(mpfr_ptr());
     MPREAL_MSVC_DEBUGVIEW_CODE;
@@ -1983,7 +1999,7 @@ inline mpreal& mpreal::setZero(int sign)
 #else
     mpfr_set_si(mpfr_ptr(), 0, (mpfr_get_default_rounding_mode)());
     setSign(sign);
-#endif 
+#endif
 
     MPREAL_MSVC_DEBUGVIEW_CODE;
     return *this;
@@ -2018,7 +2034,7 @@ inline mpreal& negate(mpreal& x) // -x in place
     return x;
 }
 
-inline const mpreal frexp(const mpreal& x, mp_exp_t* exp, mp_rnd_t mode = mpreal::get_default_rnd())
+inline const mpreal frexp(const mpreal& x, mpfr_exp_t* exp, mp_rnd_t mode = mpreal::get_default_rnd())
 {
     mpreal y(x);
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(3,1,0))
@@ -2032,9 +2048,9 @@ inline const mpreal frexp(const mpreal& x, mp_exp_t* exp, mp_rnd_t mode = mpreal
 
 inline const mpreal frexp(const mpreal& x, int* exp, mp_rnd_t mode = mpreal::get_default_rnd())
 {
-    mp_exp_t expl;
-    mpreal y = frexp(x, &expl, mode);
-    *exp = int(expl);
+    mpfr_exp_t e;
+    mpreal y = frexp(x, &e, mode);
+    *exp = int(e);
     return y;
 }
 
@@ -2043,7 +2059,7 @@ inline const mpreal ldexp(const mpreal& v, mp_exp_t exp)
     mpreal x(v);
 
     // rounding is not important since we are just increasing the exponent (= exact operation)
-    mpfr_mul_2si(x.mpfr_ptr(), x.mpfr_srcptr(), exp, mpreal::get_default_rnd()); 
+    mpfr_mul_2si(x.mpfr_ptr(), x.mpfr_srcptr(), exp, mpreal::get_default_rnd());
     return x;
 }
 
@@ -2059,7 +2075,7 @@ inline mpreal machine_epsilon(mp_prec_t prec)
 }
 
 inline mpreal machine_epsilon(const mpreal& x)
-{    
+{
     /* the smallest eps such that x + eps != x */
     if( x < 0)
     {
@@ -2072,15 +2088,16 @@ inline mpreal machine_epsilon(const mpreal& x)
 // minval is 'safe' meaning 1 / minval does not overflow
 inline mpreal minval(mp_prec_t prec)
 {
-    /* min = 1/2 * 2^emin = 2^(emin - 1) */
-    return mpreal(1, prec) << mpreal::get_emin()-1;
+    // The smallest positive value in MPFR is 1/2 * 2^emin = 2^(emin - 1). However it gives infinity if inverted. 
+    // Overall safe minimum is 2^(emin + 1).
+    return mpreal(1, prec) << (mpreal::get_emin()+1);
 }
 
 // maxval is 'safe' meaning 1 / maxval does not underflow
 inline mpreal maxval(mp_prec_t prec)
 {
     /* max = (1 - eps) * 2^emax, eps is machine epsilon */
-    return (mpreal(1, prec) - machine_epsilon(prec)) << mpreal::get_emax(); 
+    return (mpreal(1, prec) - machine_epsilon(prec)) << mpreal::get_emax();
 }
 
 inline bool isEqualUlps(const mpreal& a, const mpreal& b, int maxUlps)
@@ -2123,7 +2140,7 @@ inline const mpreal modf(const mpreal& v, mpreal& n)
     mpreal f(v);
 
     // rounding is not important since we are using the same number
-    mpfr_frac (f.mpfr_ptr(),f.mpfr_srcptr(),mpreal::get_default_rnd());    
+    mpfr_frac (f.mpfr_ptr(),f.mpfr_srcptr(),mpreal::get_default_rnd());
     mpfr_trunc(n.mpfr_ptr(),v.mpfr_srcptr());
     return f;
 }
@@ -2183,10 +2200,18 @@ inline mp_exp_t mpreal::get_emax_max (void)
 //////////////////////////////////////////////////////////////////////////
 // Mathematical Functions
 //////////////////////////////////////////////////////////////////////////
+
+// Unary function template with single 'mpreal' argument
 #define MPREAL_UNARY_MATH_FUNCTION_BODY(f)                    \
         mpreal y(0, mpfr_get_prec(x.mpfr_srcptr()));          \
         mpfr_##f(y.mpfr_ptr(), x.mpfr_srcptr(), r);           \
-        return y; 
+        return y;
+
+// Binary function template with 'mpreal' and 'unsigned long' arguments
+#define MPREAL_BINARY_MATH_FUNCTION_UI_BODY(f, u)             \
+        mpreal y(0, mpfr_get_prec(x.mpfr_srcptr()));          \
+        mpfr_##f(y.mpfr_ptr(), x.mpfr_srcptr(), u, r);        \
+        return y;
 
 inline const mpreal sqr  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd())
 {   MPREAL_UNARY_MATH_FUNCTION_BODY(sqr );    }
@@ -2209,7 +2234,7 @@ inline const mpreal sqrt(const unsigned int v, mp_rnd_t rnd_mode)
 inline const mpreal sqrt(const long int v, mp_rnd_t rnd_mode)
 {
     if (v>=0)   return sqrt(static_cast<unsigned long int>(v),rnd_mode);
-    else        return mpreal().setNan(); // NaN  
+    else        return mpreal().setNan(); // NaN
 }
 
 inline const mpreal sqrt(const int v, mp_rnd_t rnd_mode)
@@ -2220,13 +2245,39 @@ inline const mpreal sqrt(const int v, mp_rnd_t rnd_mode)
 
 inline const mpreal root(const mpreal& x, unsigned long int k, mp_rnd_t r = mpreal::get_default_rnd())
 {
-    mpreal y(0, mpfr_get_prec(x.mpfr_srcptr())); 
+    mpreal y(0, mpfr_get_prec(x.mpfr_srcptr()));
 #if (MPFR_VERSION >= MPFR_VERSION_NUM(4,0,0))
-    mpfr_rootn_ui(y.mpfr_ptr(), x.mpfr_srcptr(), k, r);  
+    mpfr_rootn_ui(y.mpfr_ptr(), x.mpfr_srcptr(), k, r);
 #else
     mpfr_root(y.mpfr_ptr(), x.mpfr_srcptr(), k, r);
 #endif
-    return y; 
+    return y;
+}
+
+inline const mpreal root(const mpreal& x, const mpreal& n, mp_rnd_t r = mpreal::get_default_rnd())
+{
+    if(isint(n) && mpfr_sgn(n.mpfr_ptr()) > 0) return root(x,n.toULong(),r);
+    else
+    {
+        mpreal y(0, (std::max)(mpfr_get_prec(x.mpfr_srcptr()),mpfr_get_prec(n.mpfr_srcptr())));
+
+        if(isnan(x) || isnan(n)) mpfr_set_nan(y.mpfr_ptr());
+        else if(isinf(n))        mpfr_set_si (y.mpfr_ptr(),1,r);
+        else if(iszero(n))       mpfr_set_inf(y.mpfr_ptr(),1);
+        else
+        {
+            mpreal a(0,mpfr_get_prec(x.mpfr_srcptr()));
+            mpreal b(0,mpfr_get_prec(n.mpfr_srcptr()));
+
+            mpfr_ui_div(b.mpfr_ptr(),1,n.mpfr_srcptr(),r);
+            mpfr_abs   (a.mpfr_ptr(),  x.mpfr_srcptr(),r);
+            mpfr_pow   (y.mpfr_ptr(),  a.mpfr_ptr(), b.mpfr_srcptr(), r);
+
+            mpfr_setsign(y.mpfr_ptr(),y.mpfr_srcptr(),mpfr_signbit(x.mpfr_srcptr()),r);
+        }
+
+        return y;
+    }
 }
 
 inline const mpreal dim(const mpreal& a, const mpreal& b, mp_rnd_t r = mpreal::get_default_rnd())
@@ -2244,6 +2295,11 @@ inline int cmpabs(const mpreal& a,const mpreal& b)
 inline int sin_cos(mpreal& s, mpreal& c, const mpreal& v, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
     return mpfr_sin_cos(s.mpfr_ptr(), c.mpfr_ptr(), v.mpfr_srcptr(), rnd_mode);
+}
+
+inline void sincos(const mpreal& x, mpreal *sin, mpreal *cos, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    mpfr_sin_cos(sin->mpfr_ptr(), cos->mpfr_ptr(), x.mpfr_srcptr(), rnd_mode);
 }
 
 inline const mpreal sqrt  (const long double v, mp_rnd_t rnd_mode)    {   return sqrt(mpreal(v),rnd_mode);    }
@@ -2269,7 +2325,7 @@ inline const mpreal asin  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd
 inline const mpreal atan  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   MPREAL_UNARY_MATH_FUNCTION_BODY(atan );    }
 
 inline const mpreal logb  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   return log2 (abs(x),r);                    }
-inline mp_exp_t ilogb(const mpreal& x) { return x.get_exp(); }
+inline     mp_exp_t ilogb (const mpreal& x) { return x.get_exp(); }
 
 inline const mpreal acot  (const mpreal& v, mp_rnd_t r = mpreal::get_default_rnd()) {   return atan (1/v, r);                      }
 inline const mpreal asec  (const mpreal& v, mp_rnd_t r = mpreal::get_default_rnd()) {   return acos (1/v, r);                      }
@@ -2302,11 +2358,108 @@ inline const mpreal besselj1(const mpreal& x, mp_rnd_t r = mpreal::get_default_r
 inline const mpreal bessely0(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   MPREAL_UNARY_MATH_FUNCTION_BODY(y0     );    }
 inline const mpreal bessely1(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) {   MPREAL_UNARY_MATH_FUNCTION_BODY(y1     );    }
 
-inline const mpreal nextpow2(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) 
-{   
+#if (MPFR_VERSION >= MPFR_VERSION_NUM(4,0,0))
+inline const mpreal gammainc (const mpreal& a, const mpreal& x, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /*
+       The non-normalized (upper) incomplete gamma function of a and x:
+       gammainc(a,x) := Gamma(a,x) = int(t^(a-1) * exp(-t), t=x..infinity)
+    */
+    mpreal y(0,(std::max)(a.getPrecision(), x.getPrecision()));
+    mpfr_gamma_inc(y.mpfr_ptr(), a.mpfr_srcptr(), x.mpfr_srcptr(), rnd_mode);
+    return y;
+}
+
+inline const mpreal beta (const mpreal& z, const mpreal& w, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /*
+       Beta function, uses formula (6.2.2) from Abramowitz & Stegun:
+       beta(z,w) = gamma(z)*gamma(w)/gamma(z+w)
+    */
+    mpreal y(0,(std::max)(z.getPrecision(), w.getPrecision()));
+    mpfr_beta(y.mpfr_ptr(), z.mpfr_srcptr(), w.mpfr_srcptr(), rnd_mode);
+    return y;
+}
+
+inline const mpreal log_ui (unsigned long int n, mp_prec_t prec = mpreal::get_default_prec(), mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* Computes natural logarithm of an unsigned long  */
+    mpreal y(0, prec);
+    mpfr_log_ui(y.mpfr_ptr(),n,rnd_mode);
+    return y;
+}
+#endif
+
+#if (MPFR_VERSION >= MPFR_VERSION_NUM(4,2,0))
+
+/* f(x,u) = f(2*pi*x/u) */
+inline const mpreal cosu   (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(cosu,  u); }
+inline const mpreal sinu   (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(sinu,  u); }
+inline const mpreal tanu   (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(tanu,  u); }
+inline const mpreal acosu  (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(acosu, u); }
+inline const mpreal asinu  (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(asinu, u); }
+inline const mpreal atanu  (const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_BINARY_MATH_FUNCTION_UI_BODY(atanu, u); }
+
+/* f(x) = f(pi*x) */
+inline const mpreal cospi  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(cospi ); }
+inline const mpreal sinpi  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(sinpi ); }
+inline const mpreal tanpi  (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(tanpi ); }
+inline const mpreal acospi (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(acospi); }
+inline const mpreal asinpi (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(asinpi); }
+inline const mpreal atanpi (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(atanpi); }
+
+inline const mpreal log2p1 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(log2p1 ); }  /* log2 (1+x) */
+inline const mpreal log10p1(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(log10p1); }  /* log10(1+x) */
+inline const mpreal exp2m1 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(exp2m1 ); }  /* 2^x-1      */
+inline const mpreal exp10m1(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) { MPREAL_UNARY_MATH_FUNCTION_BODY(exp10m1); }  /* 10^x-1     */
+
+inline const mpreal atan2u(const mpreal& y, const mpreal& x, unsigned long u, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /*
+        atan2u(y,x,u) = atan(|y/x|)*u/(2*pi)   for x > 0
+        atan2u(y,x,u) = 1-atan(|y/x|)*u/(2*pi) for x < 0
+    */
+    mpreal a(0, (std::max)(y.getPrecision(), x.getPrecision()));
+    mpfr_atan2u(a.mpfr_ptr(), y.mpfr_srcptr(), x.mpfr_srcptr(), u, rnd_mode);
+    return a;
+}
+
+inline const mpreal atan2pi(const mpreal& y, const mpreal& x, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* atan2pi(x) = atan2u(u=2) */
+    mpreal a(0, (std::max)(y.getPrecision(), x.getPrecision()));
+    mpfr_atan2pi(a.mpfr_ptr(), y.mpfr_srcptr(), x.mpfr_srcptr(), rnd_mode);
+    return a;
+}
+
+inline const mpreal powr(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* powr(x,y) = exp(y*log(x)) */
+    mpreal a(0, (std::max)(x.getPrecision(), y.getPrecision()));
+    mpfr_powr(a.mpfr_ptr(), x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
+    return a;
+}
+
+inline const mpreal compound(const mpreal& x, long n, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    /* compound(x,n) = (1+x)^n */
+    mpreal y(0, x.getPrecision());
+    mpfr_compound_si(y.mpfr_ptr(),x.mpfr_srcptr(),n,rnd_mode);
+    return y;
+}
+
+inline const mpreal fmod(const mpreal& x, unsigned long u, mp_rnd_t r = mpreal::get_default_rnd())
+{
+    /* x modulo a machine integer u */
+    MPREAL_BINARY_MATH_FUNCTION_UI_BODY(fmod_ui, u);
+}
+#endif
+
+inline const mpreal nextpow2(const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd())
+{
     mpreal y(0, x.getPrecision());
 
-    if(!iszero(x)) 
+    if(!iszero(x))
         y = ceil(log2(abs(x,r),r));
 
     return y;
@@ -2326,7 +2479,7 @@ inline const mpreal hypot (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode =
     return a;
 }
 
-inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c)  
+inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c)
 {
     if(isnan(a) || isnan(b) || isnan(c)) return mpreal().setNan();
     else
@@ -2341,11 +2494,11 @@ inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c)
             r = w * sqrt(sqr(absa*iw) + sqr(absb*iw) + sqr(absc*iw));
         }
 
-        return r; 
+        return r;
     }
 }
 
-inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c, const mpreal& d)  
+inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c, const mpreal& d)
 {
     if(isnan(a) || isnan(b) || isnan(c) || isnan(d)) return mpreal().setNan();
     else
@@ -2360,26 +2513,28 @@ inline const mpreal hypot(const mpreal& a, const mpreal& b, const mpreal& c, con
             r = w * sqrt(sqr(absa*iw) + sqr(absb*iw) + sqr(absc*iw) + sqr(absd*iw));
         }
 
-        return r; 
+        return r;
     }
 }
 
 inline const mpreal remainder (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
-{    
+{
     mpreal a(0,(std::max)(y.getPrecision(), x.getPrecision()));
     mpfr_remainder(a.mpfr_ptr(), x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
     return a;
 }
 
-inline const mpreal remquo (long* q, const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+inline const mpreal remquo (const mpreal& x, const mpreal& y, int* q, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
+    long lq;
     mpreal a(0,(std::max)(y.getPrecision(), x.getPrecision()));
-    mpfr_remquo(a.mpfr_ptr(),q, x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
+    mpfr_remquo(a.mpfr_ptr(), &lq, x.mpfr_srcptr(), y.mpfr_srcptr(), rnd_mode);
+    if (q) *q = int(lq);
     return a;
 }
 
 inline const mpreal fac_ui (unsigned long int v, mp_prec_t prec     = mpreal::get_default_prec(),
-			                                     mp_rnd_t  rnd_mode = mpreal::get_default_rnd())
+                                                 mp_rnd_t  rnd_mode = mpreal::get_default_rnd())
 {
     mpreal x(0, prec);
     mpfr_fac_ui(x.mpfr_ptr(),v,rnd_mode);
@@ -2418,9 +2573,9 @@ inline const mpreal fma (const mpreal& v1, const mpreal& v2, const mpreal& v3, m
     mpreal a;
     mp_prec_t p1, p2, p3;
 
-    p1 = v1.get_prec(); 
-    p2 = v2.get_prec(); 
-    p3 = v3.get_prec(); 
+    p1 = v1.get_prec();
+    p2 = v2.get_prec();
+    p3 = v3.get_prec();
 
     a.set_prec(p3>p2?(p3>p1?p3:p1):(p2>p1?p2:p1));
 
@@ -2433,9 +2588,9 @@ inline const mpreal fms (const mpreal& v1, const mpreal& v2, const mpreal& v3, m
     mpreal a;
     mp_prec_t p1, p2, p3;
 
-    p1 = v1.get_prec(); 
-    p2 = v2.get_prec(); 
-    p3 = v3.get_prec(); 
+    p1 = v1.get_prec();
+    p2 = v2.get_prec();
+    p3 = v3.get_prec();
 
     a.set_prec(p3>p2?(p3>p1?p3:p1):(p2>p1?p2:p1));
 
@@ -2448,8 +2603,8 @@ inline const mpreal agm (const mpreal& v1, const mpreal& v2, mp_rnd_t rnd_mode =
     mpreal a;
     mp_prec_t p1, p2;
 
-    p1 = v1.get_prec(); 
-    p2 = v2.get_prec(); 
+    p1 = v1.get_prec();
+    p2 = v2.get_prec();
 
     a.set_prec(p1>p2?p1:p2);
 
@@ -2467,7 +2622,7 @@ inline const mpreal sum (const mpreal tab[], const unsigned long int n, int& sta
 
     mpreal x;
     status = mpfr_sum(x.mpfr_ptr(), (mpfr_ptr*)p, n, mode);
-    
+
     delete [] p;
     return x;
 }
@@ -2481,9 +2636,9 @@ inline int sinh_cosh(mpreal& s, mpreal& c, const mpreal& v, mp_rnd_t rnd_mode = 
     return mpfr_sinh_cosh(s.mp,c.mp,v.mp,rnd_mode);
 }
 
-inline const mpreal li2 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd()) 
-{   
-    MPREAL_UNARY_MATH_FUNCTION_BODY(li2);    
+inline const mpreal li2 (const mpreal& x, mp_rnd_t r = mpreal::get_default_rnd())
+{
+    MPREAL_UNARY_MATH_FUNCTION_BODY(li2);
 }
 
 inline const mpreal rem (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
@@ -2495,16 +2650,16 @@ inline const mpreal rem (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = m
 inline const mpreal mod (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
     (void)rnd_mode;
-    
-    /*  
+
+    /*
 
     m = mod(x,y) if y != 0, returns x - n*y where n = floor(x/y)
 
     The following are true by convention:
     - mod(x,0) is x
     - mod(x,x) is 0
-    - mod(x,y) for x != y and y != 0 has the same sign as y.    
-    
+    - mod(x,y) for x != y and y != 0 has the same sign as y.
+
     */
 
     if(iszero(y)) return x;
@@ -2520,8 +2675,8 @@ inline const mpreal fmod (const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = 
     mpreal a;
     mp_prec_t yp, xp;
 
-    yp = y.get_prec(); 
-    xp = x.get_prec(); 
+    yp = y.get_prec();
+    xp = x.get_prec();
 
     a.set_prec(yp>xp?yp:xp);
 
@@ -2605,6 +2760,24 @@ inline const mpreal round(const mpreal& v)
     return x;
 }
 
+inline long lround(const mpreal& v)
+{
+    long r = std::numeric_limits<long>::min();
+    mpreal x = round(v);
+    if (abs(x) < -mpreal(r))    // Assume mpreal(LONG_MIN) is exact
+      r = x.toLong();
+    return r;
+}
+
+inline long long llround(const mpreal& v)
+{
+    long long r = std::numeric_limits<long long>::min();
+    mpreal x = round(v);
+    if (abs(x) < -mpreal(r))    // Assume mpreal(LLONG_MIN) is exact
+      r = x.toLLong();
+    return r;
+}
+
 inline const mpreal trunc(const mpreal& v)
 {
     mpreal x(v);
@@ -2631,8 +2804,8 @@ inline int sgn(const mpreal& op)
 //////////////////////////////////////////////////////////////////////////
 // Miscellaneous Functions
 inline void         swap (mpreal& a, mpreal& b)            {    mpfr_swap(a.mpfr_ptr(),b.mpfr_ptr());   }
-inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x>y?x:y);       }
-inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (x<y?x:y);       }
+inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x<y?y:x);       }
+inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (y<x?y:x);       }
 
 inline const mpreal fmax(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {
@@ -2753,20 +2926,20 @@ inline const mpreal grandom(unsigned int seed = 0)
 //////////////////////////////////////////////////////////////////////////
 // Set/Get global properties
 inline void mpreal::set_default_prec(mp_prec_t prec)
-{ 
-    mpfr_set_default_prec(prec); 
+{
+    mpfr_set_default_prec(prec);
 }
 
 inline void mpreal::set_default_rnd(mp_rnd_t rnd_mode)
-{ 
-    mpfr_set_default_rounding_mode(rnd_mode); 
+{
+    mpfr_set_default_rounding_mode(rnd_mode);
 }
 
 inline bool mpreal::fits_in_bits(double x, int n)
-{   
+{
     int i;
     double t;
-    return IsInf(x) || (std::modf ( std::ldexp ( std::frexp ( x, &i ), n ), &t ) == 0.0);
+    return MPREAL_IS_INF(x) || (std::modf ( std::ldexp ( std::frexp ( x, &i ), n ), &t ) == 0.0);
 }
 
 inline const mpreal pow(const mpreal& a, const mpreal& b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
@@ -2781,6 +2954,18 @@ inline const mpreal pow(const mpreal& a, const mpz_t b, mp_rnd_t rnd_mode = mpre
     mpreal x(a);
     mpfr_pow_z(x.mp,x.mp,b,rnd_mode);
     return x;
+}
+
+inline const mpreal pow(const mpreal& a, const long long b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    (void)rnd_mode;
+    return pow(a,mpreal(b));
+}
+
+inline const mpreal pow(const mpreal& a, const unsigned long long b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
+{
+    (void)rnd_mode;
+    return pow(a,mpreal(b));
 }
 
 inline const mpreal pow(const mpreal& a, const unsigned long int b, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
@@ -3013,7 +3198,7 @@ inline const mpreal pow(const int a, const double b, mp_rnd_t rnd_mode)
     else        return pow(mpreal(a),mpreal(b),rnd_mode); //mpfr_pow
 }
 
-// pow long double 
+// pow long double
 inline const mpreal pow(const long double a, const long double b, mp_rnd_t rnd_mode)
 {
     return pow(mpreal(a),mpreal(b),rnd_mode);
@@ -3070,11 +3255,10 @@ inline const mpreal pow(const double a, const int b, mp_rnd_t rnd_mode)
 // Non-throwing swap C++ idiom: http://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Non-throwing_swap
 namespace std
 {
-	// we are allowed to extend namespace std with specializations only
     template <>
-    inline void swap(mpfr::mpreal& x, mpfr::mpreal& y) 
-    { 
-        return mpfr::swap(x, y); 
+    inline void swap(mpfr::mpreal& x, mpfr::mpreal& y)
+    {
+        return mpfr::swap(x, y);
     }
 
     template<>
@@ -3085,7 +3269,7 @@ namespace std
         static const bool is_signed         = true;
         static const bool is_integer        = false;
         static const bool is_exact          = false;
-        static const int  radix             = 2;    
+        static const int  radix             = 2;
 
         static const bool has_infinity      = true;
         static const bool has_quiet_NaN     = true;
@@ -3105,7 +3289,7 @@ namespace std
 
         // Returns smallest eps such that 1 + eps != 1 (classic machine epsilon)
         inline static mpfr::mpreal epsilon(mp_prec_t precision = mpfr::mpreal::get_default_prec()) {  return  mpfr::machine_epsilon(precision); }
-		
+
         // Returns smallest eps such that x + eps != x (relative machine epsilon)
         inline static mpfr::mpreal epsilon(const mpfr::mpreal& x) {  return mpfr::machine_epsilon(x);  }
 
@@ -3113,8 +3297,8 @@ namespace std
         {
             mp_rnd_t r = mpfr::mpreal::get_default_rnd();
 
-            if(r == GMP_RNDN)  return mpfr::mpreal(0.5, precision); 
-            else               return mpfr::mpreal(1.0, precision);    
+            if(r == GMP_RNDN)  return mpfr::mpreal(0.5, precision);
+            else               return mpfr::mpreal(1.0, precision);
         }
 
         inline static const mpfr::mpreal infinity()         { return mpfr::const_infinity();     }
@@ -3125,17 +3309,17 @@ namespace std
         // Please note, exponent range is not fixed in MPFR
         static const int min_exponent = MPFR_EMIN_DEFAULT;
         static const int max_exponent = MPFR_EMAX_DEFAULT;
-        MPREAL_PERMISSIVE_EXPR static const int min_exponent10 = (int) (MPFR_EMIN_DEFAULT * 0.3010299956639811); 
-        MPREAL_PERMISSIVE_EXPR static const int max_exponent10 = (int) (MPFR_EMAX_DEFAULT * 0.3010299956639811); 
+        MPREAL_PERMISSIVE_EXPR static const int min_exponent10 = (int) (MPFR_EMIN_DEFAULT * 0.3010299956639811);
+        MPREAL_PERMISSIVE_EXPR static const int max_exponent10 = (int) (MPFR_EMAX_DEFAULT * 0.3010299956639811);
 
 #ifdef MPREAL_HAVE_DYNAMIC_STD_NUMERIC_LIMITS
 
         // Following members should be constant according to standard, but they can be variable in MPFR
-        // So we define them as functions here. 
+        // So we define them as functions here.
         //
         // This is preferable way for std::numeric_limits<mpfr::mpreal> specialization.
-        // But it is incompatible with standard std::numeric_limits and might not work with other libraries, e.g. boost. 
-        // See below for compatible implementation. 
+        // But it is incompatible with standard std::numeric_limits and might not work with other libraries, e.g. boost.
+        // See below for compatible implementation.
         inline static float_round_style round_style()
         {
             mp_rnd_t r = mpfr::mpreal::get_default_rnd();
@@ -3143,9 +3327,9 @@ namespace std
             switch (r)
             {
             case GMP_RNDN: return round_to_nearest;
-            case GMP_RNDZ: return round_toward_zero; 
-            case GMP_RNDU: return round_toward_infinity; 
-            case GMP_RNDD: return round_toward_neg_infinity; 
+            case GMP_RNDZ: return round_toward_zero;
+            case GMP_RNDU: return round_toward_infinity;
+            case GMP_RNDD: return round_toward_neg_infinity;
             default: return round_indeterminate;
             }
         }
@@ -3172,13 +3356,13 @@ namespace std
         // If possible, please use functions digits() and round_style() defined above.
         //
         // These (default) values are preserved for compatibility with existing libraries, e.g. boost.
-        // Change them accordingly to your application. 
+        // Change them accordingly to your application.
         //
         // For example, if you use 256 bits of precision uniformly in your program, then:
         // digits       = 256
-        // digits10     = 77 
+        // digits10     = 77
         // max_digits10 = 78
-        // 
+        //
         // Approximate formula for decimal digits is: digits10 = floor(log10(2) * digits). See bits2digits() for more details.
 
         static const std::float_round_style round_style = round_to_nearest;

--- a/src/amuse/community/brutus/src/Brutus.cpp
+++ b/src/amuse/community/brutus/src/Brutus.cpp
@@ -12,7 +12,7 @@ Brutus::Brutus() {
 
   setup();
 }
-Brutus::Brutus(vector<mpreal> &data) {
+Brutus::Brutus(std::vector<mpreal> &data) {
   t = "0";
   this->data = data;
   N = data.size()/7;  
@@ -24,7 +24,7 @@ Brutus::Brutus(vector<mpreal> &data) {
 
   setup();
 }
-Brutus::Brutus(mpreal &t, vector<mpreal> &data, mpreal &tolerance) {
+Brutus::Brutus(mpreal &t, std::vector<mpreal> &data, mpreal &tolerance) {
   this->t = t;
   this->data = data;
   N = data.size()/7;  
@@ -36,7 +36,7 @@ Brutus::Brutus(mpreal &t, vector<mpreal> &data, mpreal &tolerance) {
 
   setup();
 }
-Brutus::Brutus(mpreal &t, vector<mpreal> &data, mpreal &tolerance, int &numBits) {
+Brutus::Brutus(mpreal &t, std::vector<mpreal> &data, mpreal &tolerance, int &numBits) {
   this->t = t;
   this->data = data;
   N = data.size()/7;  
@@ -49,7 +49,7 @@ Brutus::Brutus(mpreal &t, vector<mpreal> &data, mpreal &tolerance, int &numBits)
   setup();
 }
 
-void Brutus::set_data(vector<mpreal> &data) {
+void Brutus::set_data(std::vector<mpreal> &data) {
   this->data = data;
   N = data.size()/7; 
 
@@ -98,7 +98,7 @@ int Brutus::get_numBits(mpreal tolerance) {
   mpreal absloge = abs( log10(tolerance) );
   return 4*(int)absloge.toLong()+32;
 }
-mpreal Brutus::fit_slope(vector<mpreal> &x, vector<mpreal> &y) {
+mpreal Brutus::fit_slope(std::vector<mpreal> &x, std::vector<mpreal> &y) {
   mpreal a = "0";
   int N = x.size();
 
@@ -142,7 +142,7 @@ void Brutus::evolve(mpreal t_end) {
     bool converged = bs.integrate(cl, dt);
 
     if(!converged) {
-      cerr << "Not converged at " << t << "!" << endl;
+      std::cerr << "Not converged at " << t << "!" << std::endl;
       exit(1);
     }
 
@@ -154,12 +154,12 @@ void Brutus::evolve(mpreal t_end) {
 mpreal Brutus::get_t() {
   return t;
 }
-vector<mpreal> Brutus::get_data() {
+std::vector<mpreal> Brutus::get_data() {
   return data;
 }
-vector<double> Brutus::get_data_double() {
+std::vector<double> Brutus::get_data_double() {
   int N = data.size()/7;
-  vector<double> v(7*N, 0);
+  std::vector<double> v(7*N, 0);
   for(int i=0; i<N; i++) {
     for(int j=0; j<7; j++) {
       v[i*7+j] = data[i*7+j].toDouble();
@@ -167,9 +167,9 @@ vector<double> Brutus::get_data_double() {
   }
   return v;
 }
-vector<string> Brutus::get_data_string() {
+std::vector<std::string> Brutus::get_data_string() {
   int N = data.size()/7;
-  vector<string> v(7*N, "0");
+  std::vector<std::string> v(7*N, "0");
   for(int i=0; i<N; i++) {
     for(int j=0; j<7; j++) {
       v[i*7+j] = data[i*7+j].toString();

--- a/src/amuse/community/brutus/src/Brutus.h
+++ b/src/amuse/community/brutus/src/Brutus.h
@@ -8,7 +8,7 @@
 class Brutus {
   mpreal t;
   int N;  
-  vector<mpreal> data;
+  std::vector<mpreal> data;
 
   mpreal tolerance;
   int numBits;
@@ -21,11 +21,11 @@ class Brutus {
   public:
 
   Brutus();
-  Brutus(vector<mpreal> &data);
-  Brutus(mpreal &t, vector<mpreal> &data, mpreal &tolerance);
-  Brutus(mpreal &t, vector<mpreal> &data, mpreal &tolerance, int &numBits);
+  Brutus(std::vector<mpreal> &data);
+  Brutus(mpreal &t, std::vector<mpreal> &data, mpreal &tolerance);
+  Brutus(mpreal &t, std::vector<mpreal> &data, mpreal &tolerance, int &numBits);
 
-  void set_data(vector<mpreal> &data);
+  void set_data(std::vector<mpreal> &data);
   void set_eta(mpreal &eta);
   void set_tolerance(mpreal &tolerance);
   void set_numBits(int &numBits);
@@ -35,15 +35,15 @@ class Brutus {
   mpreal get_tolerance();
   int get_numBits();
   int get_numBits(mpreal tolerance);
-  mpreal fit_slope(vector<mpreal> &x, vector<mpreal> &y);
+  mpreal fit_slope(std::vector<mpreal> &x, std::vector<mpreal> &y);
 
   void setup();
   void evolve(mpreal t_end);
   
   mpreal get_t();
-  vector<mpreal> get_data();
-  vector<double> get_data_double();
-  vector<string> get_data_string();
+  std::vector<mpreal> get_data();
+  std::vector<double> get_data_double();
+  std::vector<std::string> get_data_string();
 };
 
 #endif

--- a/src/amuse/community/brutus/src/Bulirsch_Stoer.cpp
+++ b/src/amuse/community/brutus/src/Bulirsch_Stoer.cpp
@@ -63,8 +63,8 @@ bool Bulirsch_Stoer::integrate(Cluster &cl, mpreal &dt) {
 bool Bulirsch_Stoer::step(Cluster &cl, mpreal &dt) {
   bool flag;
   int n;
-  vector<mpreal> h;
-  vector<Cluster> c;
+  std::vector<mpreal> h;
+  std::vector<Cluster> c;
   Cluster cl_exp0 = cl;
   Cluster cl_exp  = cl;
 
@@ -101,11 +101,11 @@ bool Bulirsch_Stoer::step(Cluster &cl, mpreal &dt) {
 
   return flag;
 }
-void Bulirsch_Stoer::extrapol(Cluster &cl_exp, vector<mpreal> &dt, vector<Cluster> &c) {
+void Bulirsch_Stoer::extrapol(Cluster &cl_exp, std::vector<mpreal> &dt, std::vector<Cluster> &c) {
   int M = dt.size();
   int N = c[0].s.size();
 
-  vector<mpreal> x_sample(M), y_sample(M), z_sample(M), vx_sample(M), vy_sample(M), vz_sample(M);
+  std::vector<mpreal> x_sample(M), y_sample(M), z_sample(M), vx_sample(M), vy_sample(M), vz_sample(M);
   for(int i=0; i<N; i++) {
     for(int j=0; j<M; j++) {
       x_sample[j]  = c[j].s[i].r[0];
@@ -123,7 +123,7 @@ void Bulirsch_Stoer::extrapol(Cluster &cl_exp, vector<mpreal> &dt, vector<Cluste
     cl_exp.s[i].v[2] = extrapolate(dt, vz_sample, "0.0");
   }
 }
-mpreal Bulirsch_Stoer::extrapolate(vector<mpreal> x, vector<mpreal> y, mpreal x0) {
+mpreal Bulirsch_Stoer::extrapolate(std::vector<mpreal> x, std::vector<mpreal> y, mpreal x0) {
   int N = x.size();
   if(N == 1) {
     return y[0];

--- a/src/amuse/community/brutus/src/Bulirsch_Stoer.h
+++ b/src/amuse/community/brutus/src/Bulirsch_Stoer.h
@@ -24,8 +24,8 @@ class Bulirsch_Stoer {
 
   bool integrate(Cluster &cl, mpreal &dt);
   bool step(Cluster &cl, mpreal &dt);
-  void extrapol(Cluster &cl_exp, vector<mpreal> &dt, vector<Cluster> &c);
-  mpreal extrapolate(vector<mpreal> x, vector<mpreal> y, mpreal x0);
+  void extrapol(Cluster &cl_exp, std::vector<mpreal> &dt, std::vector<Cluster> &c);
+  mpreal extrapolate(std::vector<mpreal> x, std::vector<mpreal> y, mpreal x0);
   bool error_control(Cluster &c1, Cluster &c2);
 };
 

--- a/src/amuse/community/brutus/src/Cluster.cpp
+++ b/src/amuse/community/brutus/src/Cluster.cpp
@@ -1,10 +1,10 @@
 #include "Cluster.h"
 
-Cluster::Cluster(vector<double> data) {
+Cluster::Cluster(std::vector<double> data) {
   int N = data.size()/7;
   s.resize(N);
   mpreal m;
-  vector<mpreal> r(3), v(3);
+  std::vector<mpreal> r(3), v(3);
   for(int i=0; i<N; i++) {
     m    = (mpreal)data[i*7+0];
     r[0] = (mpreal)data[i*7+1];
@@ -17,11 +17,11 @@ Cluster::Cluster(vector<double> data) {
   }
   this->time = 0;
 }
-Cluster::Cluster(vector<mpreal> data) {
+Cluster::Cluster(std::vector<mpreal> data) {
   int N = data.size()/7;
   s.resize(N);
   mpreal m;
-  vector<mpreal> r(3), v(3);
+  std::vector<mpreal> r(3), v(3);
   for(int i=0; i<N; i++) {
     m    = data[i*7+0];
     r[0] = data[i*7+1];
@@ -163,17 +163,17 @@ void Cluster::step(mpreal &dt) {
   updateVelocities(dt);
 }
     
-vector<mpreal> Cluster::energies() {
+std::vector<mpreal> Cluster::energies() {
   mpreal init = "0";
-  vector<mpreal> E(3), rij(3);
+  std::vector<mpreal> E(3), rij(3);
   E.assign(3,"0");
     
-  for (vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
+  for (std::vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
     E[1] += "0.5"*si->m*inner_product(si->v.begin(), si->v.end(), si->v.begin(), init); 
   }
     
-  for (vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
-    for (vector<Star>::iterator sj = si+1; sj != s.end(); ++sj) {
+  for (std::vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
+    for (std::vector<Star>::iterator sj = si+1; sj != s.end(); ++sj) {
       for (int i = 0; i != 3; ++i) 
         rij[i] = si->r[i]-sj->r[i];
       E[2] -= si->m*sj->m/sqrt(inner_product(rij.begin(), rij.end(),  rij.begin(), init)); 
@@ -183,9 +183,9 @@ vector<mpreal> Cluster::energies() {
   return E;
 }
 
-vector<double> Cluster::get_data_double() {
-  vector<double> ddata;  
-  for (vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
+std::vector<double> Cluster::get_data_double() {
+  std::vector<double> ddata;  
+  for (std::vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
     ddata.push_back(si->m.toDouble());
     ddata.push_back(si->r[0].toDouble());
     ddata.push_back(si->r[1].toDouble());
@@ -196,9 +196,9 @@ vector<double> Cluster::get_data_double() {
   }	  
   return ddata;
 }
-vector<mpreal> Cluster::get_data() {
-  vector<mpreal> ddata;  
-  for (vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
+std::vector<mpreal> Cluster::get_data() {
+  std::vector<mpreal> ddata;  
+  for (std::vector<Star>::iterator si = s.begin(); si != s.end(); ++si) {
     ddata.push_back(si->m);
     ddata.push_back(si->r[0]);
     ddata.push_back(si->r[1]);

--- a/src/amuse/community/brutus/src/Cluster.h
+++ b/src/amuse/community/brutus/src/Cluster.h
@@ -1,6 +1,4 @@
 #include <iostream>
-using namespace std;
-
 #include <vector>
 #include <cmath>
 #include <numeric> 
@@ -14,17 +12,17 @@ using namespace std;
 class Cluster : public Star { 
   public:
 
-  vector<Star> s;
+  std::vector<Star> s;
   mpreal eps2;
   mpreal time, dt, dt_last;
 
   Cluster() : Star() {}
 
-  Cluster(vector<double> data);
-  Cluster(vector<mpreal> data);
+  Cluster(std::vector<double> data);
+  Cluster(std::vector<mpreal> data);
 
-  vector<double> get_data_double();
-  vector<mpreal> get_data();    
+  std::vector<double> get_data_double();
+  std::vector<mpreal> get_data();    
 
   void calcAcceleration_dt();
   void calcAcceleration();
@@ -34,10 +32,10 @@ class Cluster : public Star {
 
   void step(mpreal &dt);
   
-  vector<mpreal> energies();
+  std::vector<mpreal> energies();
 
-  friend ostream & operator << (ostream &so, Cluster &cl) {
-    for (vector<Star>::iterator si = cl.s.begin(); si != cl.s.end(); ++si) {
+  friend std::ostream & operator << (std::ostream &so, Cluster &cl) {
+    for (std::vector<Star>::iterator si = cl.s.begin(); si != cl.s.end(); ++si) {
       so << *si;
     }
     return so;

--- a/src/amuse/community/brutus/src/Star.cpp
+++ b/src/amuse/community/brutus/src/Star.cpp
@@ -6,7 +6,7 @@ Star::Star() {
   a.assign(3,"0");
   a0.assign(3,"0");
 }
-Star::Star(mpreal m, vector<mpreal> r, vector<mpreal> v) {
+Star::Star(mpreal m, std::vector<mpreal> r, std::vector<mpreal> v) {
   this->m = m;
   this->r = r;
   this->v = v;

--- a/src/amuse/community/brutus/src/Star.h
+++ b/src/amuse/community/brutus/src/Star.h
@@ -1,6 +1,4 @@
 #include <iostream>
-using namespace std;
-
 #include <vector>
 
 #include "mpreal.h"
@@ -12,16 +10,16 @@ using namespace mpfr;
 class Star {
 public:
   mpreal m;
-  vector<mpreal> r;
-  vector<mpreal> v;
-  vector<mpreal> a, a0;
+  std::vector<mpreal> r;
+  std::vector<mpreal> v;
+  std::vector<mpreal> a, a0;
 
   Star();
-  Star(mpreal m, vector<mpreal> r, vector<mpreal> v);
+  Star(mpreal m, std::vector<mpreal> r, std::vector<mpreal> v);
 
-  friend ostream & operator << (ostream &so, const Star &si) {
+  friend std::ostream & operator << (std::ostream &so, const Star &si) {
     so << si.m << " " << si.r[0] << " "<< si.r[1] << " "<< si.r[2] << " "
-                      << si.v[0] << " "<< si.v[1] << " "<< si.v[2] << endl;
+                      << si.v[0] << " "<< si.v[1] << " "<< si.v[2] << std::endl;
     return so; 
   }
 };


### PR DESCRIPTION
This fixes #940 by replacing mpreal.h for both Brutus and Adaptb, updating Brutus to compile with newer compilers (`using namespace std;` is a bad idea because the namespace may gain new members over time that conflict with your code, as happened here in C++17), and fixes a C/C++ symbol confusion problem when linking Brutus.

I tried it out with the simple gravity simulation from `examples/textbook/gravity_minimal.py` and it works, except that adaptb doesn't implement some of the methods, but that is what it is given that it's deprecated anyway. At least they compile and run again.