### PR TITLE
Compile sakura as C++11 to avoid std::data clash

### DIFF
--- a/src/amuse/community/sakura/Makefile
+++ b/src/amuse/community/sakura/Makefile
@@ -12,20 +12,21 @@ CC = $(MPICC)
 CXX = $(MPICXX)
 
 CXXFLAGS ?= -Wall -g -O2
+CXXFLAGS += -std=c++11
 
 
 CODELIB = src/libsakura.a
 OBJ = interface.o
 
-all: sakura_worker 
+all: sakura_worker
 
 clean:
-	rm -f *.so *.o *.pyc worker_code.cc worker_code.h 
+	rm -f *.so *.o *.pyc worker_code.cc worker_code.h
 	rm -f *~ sakura_worker
 	make -C src clean
 
 $(CODELIB):
-	make -C src all
+	make -C src all CXXFLAGS="$(CXXFLAGS)"
 
 worker_code.cc: interface.py
 	$(CODE_GENERATOR) --type=c interface.py SakuraInterface -o $@
@@ -37,5 +38,5 @@ sakura_worker: worker_code.cc worker_code.h $(CODELIB) $(OBJ)
 	$(MPICXX) $(CXXFLAGS) $(SC_FLAGS) $(LDFLAGS) -I./src $< $(CODELIB) $(OBJ) -o $@  -L./src -lsakura $(SC_CLIBS)
 
 interface.o: interface.cc
-	$(MPICXX) $(CXXFLAGS) $(SC_FLAGS) -I./src -c -o $@ $< 
+	$(MPICXX) $(CXXFLAGS) $(SC_FLAGS) -I./src -c -o $@ $<
 


### PR DESCRIPTION
This tells the compiler that sakura is C++11, which keeps it from defining `std::data` from C++17, which avoids a clash with the variable named `data` and a failed compile.

Brutus had this problem too, a better solution is to get rid of `using namespace std;` which I've implemented in the new build system branch. This is just a short-term fix so that Berend can go simulate things, and it's good enough for that.