### PR TITLE
Change arguments of addstar in new_advanced_particle

### DIFF
--- a/src/amuse/community/seba/interface.cc
+++ b/src/amuse/community/seba/interface.cc
@@ -486,17 +486,11 @@ int new_advanced_particle(int * index_of_the_star, double mass,  double relative
     
     stellar_type seba_stellar_type = translate_int_to_stellar_type(type_number);    
 
-    addstar(new_node, seba_time, seba_stellar_type, seba_metallicity, 0, false);
+    addstar(new_node, seba_time, seba_stellar_type, seba_metallicity, 0, false, seba_stellar_type, relative_mass, mass - core_mass, core_mass, COcore_mass, age);
     new_node->get_starbase()->set_time_offset(seba_time);
     *index_of_the_star = next_seba_id;
     
     next_seba_id++;
-    
-    new_node->get_starbase()->set_relative_age(age);
-    new_node->get_starbase()->set_core_mass(core_mass);
-    new_node->get_starbase()->set_COcore_mass(COcore_mass);
-    new_node->get_starbase()->set_effective_radius(radius);
-    
     
     return 0;
 }


### PR DESCRIPTION
Set all arguments of addstar in new_advanced_particle -- including the relative mass, core mass, and envelope mass -- to ensure that simulations restarted with evolved stars use the correct evolved stellar masses. Prior to this change, restarting from stars with non-zero core masses resulted in the total mass being calculated from the mass plus the core mass. The relevant function (from add_star.C) is shown below:
`addstar(node * b, real t_current, stellar_type type, real z,int id,
              bool verbose, stellar_type type2, real m_rel, real m_env,
              real m_core, real mco_core, real t_rel)`

No other files are affected by this change. 