### PR TITLE
Change age to relative_age in new_advanced_particle

### DIFF
--- a/src/amuse/community/seba/interface.cc
+++ b/src/amuse/community/seba/interface.cc
@@ -486,17 +486,11 @@ int new_advanced_particle(int * index_of_the_star, double mass,  double relative
     
     stellar_type seba_stellar_type = translate_int_to_stellar_type(type_number);    
 
-    addstar(new_node, seba_time, seba_stellar_type, seba_metallicity, 0, false);
+    addstar(new_node, seba_time, seba_stellar_type, seba_metallicity, 0, false, , seba_stellar_type, relative_mass, mass - core_mass, core_mass, COcore_mass, age);
     new_node->get_starbase()->set_time_offset(seba_time);
     *index_of_the_star = next_seba_id;
     
     next_seba_id++;
-    
-    new_node->get_starbase()->set_relative_age(age);
-    new_node->get_starbase()->set_core_mass(core_mass);
-    new_node->get_starbase()->set_COcore_mass(COcore_mass);
-    new_node->get_starbase()->set_effective_radius(radius);
-    
     
     return 0;
 }

--- a/src/amuse/community/seba/interface.cc
+++ b/src/amuse/community/seba/interface.cc
@@ -464,10 +464,10 @@ int new_particle(int * index_of_the_star, double mass){
 }
 
 
-int new_advanced_particle(int * index_of_the_star, double mass,  double relative_mass, int type_number,  double age, double core_mass, double COcore_mass,  double radius){
+int new_advanced_particle(int * index_of_the_star, double mass,  double relative_mass, int type_number,  double relative_age, double core_mass, double COcore_mass,  double radius){
 
     if (relative_mass == 0) return new_particle(index_of_the_star, mass);
-    if (age < 0) return -1;
+    if (relative_age < 0) return -1;
  
     node * new_node = new node();
     new_node->set_label(next_seba_id);
@@ -486,7 +486,7 @@ int new_advanced_particle(int * index_of_the_star, double mass,  double relative
     
     stellar_type seba_stellar_type = translate_int_to_stellar_type(type_number);    
 
-    addstar(new_node, seba_time, seba_stellar_type, seba_metallicity, 0, false, , seba_stellar_type, relative_mass, mass - core_mass, core_mass, COcore_mass, age);
+    addstar(new_node, seba_time, seba_stellar_type, seba_metallicity, 0, false, seba_stellar_type, relative_mass, mass - core_mass, core_mass, COcore_mass, relative_age);
     new_node->get_starbase()->set_time_offset(seba_time);
     *index_of_the_star = next_seba_id;
     

--- a/src/amuse/community/seba/interface.py
+++ b/src/amuse/community/seba/interface.py
@@ -69,8 +69,8 @@ class SeBaInterface(CodeInterface, se.StellarEvolutionInterface, LiteratureRefer
             'stellar_type', dtype='int32', direction=function.IN, default=0,
             description="The initial stellar type of the star")
         function.addParameter(
-            'age', dtype='float64', direction=function.IN, default=0,
-            description="The initial age of the star")
+            'relative_age', dtype='float64', direction=function.IN, default=0,
+            description="The relative initial age of the star")
         function.addParameter(
             'core_mass', dtype='float64', direction=function.IN, default=0, 
             description="The initial core mass of the star")


### PR DESCRIPTION
Use the star's relative age instead of its age in new_advanced_particle in interface.cc and interface.py following an email discussion discussion with @silviatoonen (see below). 

As this builds on pull request #1097, the changes from this pull request are also included in the code below. I left it open for documentation purposes, but please feel free to close it if it easier. 

> Q from Claude: The star’s age is used in new_advanced_particle in interface.cc, but when addstar is defined in sstar/init/add_star.C, it uses the relative age as an argument instead. Which one should be used in new_advanced_particle?

> A from Silvia: Regarding the question with the ages,  there are two parameters indicating age in seba. One is the actual time that had passed,  the other one indicates where a star is on its evolution along a Stellar evolution track.  The two can be different when a star rejuvenates due to mass accretion for example.  As this is what sets the evolution,  the relative age is an important one to set in the interface when starting up the simulation again.  