### PR TITLE
Update of the mesa_r15140 interface

### DIFF
--- a/src/amuse/community/mesa_r15140/Tests/test_new_getters.py
+++ b/src/amuse/community/mesa_r15140/Tests/test_new_getters.py
@@ -1,0 +1,98 @@
+from amuse.lab import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+# This script evolves a 10 Msun single star with MESA
+# To test the getters added to the mesa interface
+
+stars = Particles(1) 
+
+stars[0].mass = 10 | units.MSun
+stars[0].metallicity = 0.02
+
+
+stellar_code = MESA(redirection="none")
+
+evo_stars = stellar_code.particles.add_particles(stars)
+
+# Standard MESA setup
+stellar_code.particles[0].set_control('initial_z',0.02)
+stellar_code.particles[0].set_kap('use_Type2_opacities',True)
+stellar_code.particles[0].set_kap('Zbase', 0.02)
+
+# Add wind mass loss
+stellar_code.particles[0].set_control('hot_wind_scheme','Dutch')
+stellar_code.particles[0].set_control('Dutch_scaling_factor',1.0)
+
+# To store data
+times = np.array([])
+
+core_radius = np.array([])
+conv_envelope_mass = np.array([])
+conv_envelope_radius = np.array([])
+wind_mass_loss_rate = np.array([])
+apsidal_motion_constant = np.array([])
+gyration_radius = np.array([])
+
+
+
+
+time = 0 | units.Myr
+
+
+# Evolve and store the data retrieved from the getters
+while time < 0.1 | units.Myr:
+	stellar_code.evolve_for(1,20|units.kyr)
+	time = (stellar_code.particles[0].age)
+	
+	core_radius_temp = stellar_code.particles[0].core_radius
+	conv_envelope_mass_temp = stellar_code.particles[0].convective_envelope_mass
+	conv_envelope_radius_temp = stellar_code.particles[0].convective_envelope_radius
+	wind_mass_loss_rate_temp = stellar_code.particles[0].wind_mass_loss_rate
+	apsidal_motion_constant_temp = stellar_code.particles[0].apsidal_motion_constant
+	gyration_radius_temp = stellar_code.particles[0].gyration_radius
+
+
+	times = np.append(times,time.value_in(units.kyr))
+	
+	core_radius = np.append(core_radius,core_radius_temp.value_in(units.RSun))
+	conv_envelope_mass = np.append(conv_envelope_mass,conv_envelope_mass_temp.value_in(units.MSun))
+	conv_envelope_radius = np.append(conv_envelope_radius,conv_envelope_radius_temp.value_in(units.RSun))
+	wind_mass_loss_rate = np.append(wind_mass_loss_rate,wind_mass_loss_rate_temp.value_in(units.MSun / units.yr))
+	apsidal_motion_constant = np.append(apsidal_motion_constant,apsidal_motion_constant_temp)
+	gyration_radius = np.append(gyration_radius,gyration_radius_temp)
+
+
+
+# After the evolution, plot the data as function of time
+
+plt.plot(times,core_radius,linewidth=2)
+plt.xlabel(r'$t$ [kyr]',fontsize=13)
+plt.ylabel(r'$R_{core}$ [R$_\odot$]',fontsize=13)
+plt.show()
+
+plt.plot(times,conv_envelope_mass,linewidth=2)
+plt.xlabel(r'$t$ [kyr]',fontsize=13)
+plt.ylabel(r'$M_{env}$ [M$_\odot$]',fontsize=13)
+plt.show()
+
+plt.plot(times,conv_envelope_radius,linewidth=2)
+plt.xlabel(r'$t$ [kyr]',fontsize=13)
+plt.ylabel(r'$R_{env}$ [R$_\odot$]',fontsize=13)
+plt.show()
+
+plt.plot(times,wind_mass_loss_rate,linewidth=2)
+plt.xlabel(r'$t$ [kyr]',fontsize=13)
+plt.ylabel(r'$\dot M$ [M$_\odot$/yr]',fontsize=13)
+plt.show()
+
+plt.plot(times,apsidal_motion_constant,linewidth=2)
+plt.xlabel(r'$t$ [kyr]',fontsize=13)
+plt.ylabel(r'$k_2$',fontsize=13)
+plt.show()
+
+plt.plot(times,gyration_radius,linewidth=2)
+plt.xlabel(r'$t$ [kyr]',fontsize=13)
+plt.ylabel(r'$r_g$',fontsize=13)
+plt.show()

--- a/src/amuse/community/mesa_r15140/Tests/test_updated_evolve_until.py
+++ b/src/amuse/community/mesa_r15140/Tests/test_updated_evolve_until.py
@@ -1,0 +1,85 @@
+from amuse.lab import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+# This script evolves a 10 Msun single star with MESA
+# To test the updated evolve function (evolve_until in mesa_interface.f90)
+
+stars = Particles(1)
+
+stars[0].mass = 10 | units.MSun
+stars[0].metallicity = 0.02
+
+
+stellar_code = MESA(redirection="none")
+
+evo_stars = stellar_code.particles.add_particles(stars)
+
+# Standard MESA setup
+stellar_code.particles[0].set_control('initial_z',0.02)
+stellar_code.particles[0].set_kap('use_Type2_opacities',True)
+stellar_code.particles[0].set_kap('Zbase', 0.02)
+
+
+# To store time and timestep
+times = np.array([])
+time_step = np.array([])
+
+
+time = 0 | units.Myr
+
+
+# Subsequent calls to evolve function (the updated function is evolve_until in mesa_interface.f90)
+# To check that the timestep can increase
+# In the previous version it would be prevented from increasing when the evolve function was called
+# multiple times in a row
+
+# With the update, it increases freely up to the maximum allowed value, i.e. the value given as argument
+# to evolve_for
+
+
+while time < 0.02 | units.Myr:
+	time = (stellar_code.particles[0].age)
+	dt = stellar_code.particles[0].time_step
+
+	times = np.append(times,time.value_in(units.kyr))
+	time_step = np.append(time_step,dt.value_in(units.kyr))
+
+	stellar_code.evolve_for(1,1|units.kyr)
+
+
+
+while time < 0.06 | units.Myr:
+	time = (stellar_code.particles[0].age)
+	dt = stellar_code.particles[0].time_step
+
+	times = np.append(times,time.value_in(units.kyr))
+	time_step = np.append(time_step,dt.value_in(units.kyr))
+
+	stellar_code.evolve_for(1,5|units.kyr)
+
+
+while time < 0.12 | units.Myr:
+	time = (stellar_code.particles[0].age)
+	dt = stellar_code.particles[0].time_step
+
+	times = np.append(times,time.value_in(units.kyr))
+	time_step = np.append(time_step,dt.value_in(units.kyr))
+
+	stellar_code.evolve_for(1,10|units.kyr)
+
+
+
+# After the evolution, the timesteps are plotted as function of time. The three visible plateau
+# correspond to the value given as argument to evolve_for (1 kyr, 5 kyrs, 10 kyrs),
+# and indicate that the timestep was able to reach the maximum allowed value.
+
+# When running the same script with the previous evolve_until subroutine, the time step is cut at
+# the end of each call to evolve_until and can not increase freely to reach the maximum allowed value,
+# which is why the plateau are not seen in this case.
+
+plt.plot(times,time_step,linewidth=2)
+plt.xlabel(r'$t$ [kyr]',fontsize=13)
+plt.ylabel(r'd$t$ [kyr]',fontsize=13)
+plt.show()

--- a/src/amuse/community/mesa_r15140/interface.py
+++ b/src/amuse/community/mesa_r15140/interface.py
@@ -238,14 +238,91 @@ class MESAInterface(
             , description="The current core mass of the star, where hydrogen abundance is <= h1_boundary_limit")
         function.result_type = 'int32'
         return function
+        
+    @legacy_function
+    def get_core_radius():
+        """
+        Retrieve the current core radius of the star, where hydrogen abundance is <= h1_boundary_limit
+        """
+        function = LegacyFunctionSpecification()
+        function.can_handle_array = True
+        function.addParameter('index_of_the_star', dtype='int32', direction=function.IN
+            , description="The index of the star to get the value of")
+        function.addParameter('core_radius', dtype='float64', direction=function.OUT
+            , description="The current core radius of the star, where hydrogen abundance is <= h1_boundary_limit")
+        function.result_type = 'int32'
+        return function
 
+    @legacy_function
+    def get_convective_envelope_mass():
+        """
+        Retrieve the size (in mass) of the convective envelope of the star
+        """
+        function = LegacyFunctionSpecification()
+        function.can_handle_array = True
+        function.addParameter('index_of_the_star', dtype='int32', direction=function.IN
+            , description="The index of the star to get the value of")
+        function.addParameter('convective_envelope_mass', dtype='float64', direction=function.OUT
+            , description="The current convective envelope mass of the star")
+        function.result_type = 'int32'
+        return function
+
+    @legacy_function
+    def get_convective_envelope_radius():
+        """
+        Retrieve the size (in radius) of the convective envelope of the star
+        """
+        function = LegacyFunctionSpecification()
+        function.can_handle_array = True
+        function.addParameter('index_of_the_star', dtype='int32', direction=function.IN
+            , description="The index of the star to get the value of")
+        function.addParameter('convective_envelope_radius', dtype='float64', direction=function.OUT
+            , description="The current convective envelope radius of the star")
+        function.result_type = 'int32'
+        return function
+        
     @remote_function(can_handle_array=True)
     def get_mass_loss_rate(index_of_the_star='i'):
         """
         Retrieve the current mass loss rate of the star. (positive for winds, negative for accretion)
         """
         returns (mass_change='d' | units.MSun/units.julianyr)
-
+    
+    @remote_function(can_handle_array=True)
+    def get_wind_mass_loss_rate(index_of_the_star='i'):
+        """
+        Retrieve the current mass loss rate of the star. (only winds)
+        """
+        returns (mass_change='d' | units.MSun/units.julianyr)
+    
+    @legacy_function
+    def get_apsidal_motion_constant():
+        """
+        Retrieve the apsidal motion constant k2, assuming a spherical star without accounting for rotation
+        """
+        function = LegacyFunctionSpecification()
+        function.can_handle_array = True
+        function.addParameter('index_of_the_star', dtype='int32', direction=function.IN
+            , description="The index of the star to get the value of")
+        function.addParameter('apsidal_motion_constant', dtype='float64', direction=function.OUT
+            , description="The current apsidal motion constant k2 of the star")
+        function.result_type = 'int32'
+        return function
+    
+    @legacy_function
+    def get_gyration_radius():
+        """
+        Retrieve the gyration radius I/MR**2
+        """
+        function = LegacyFunctionSpecification()
+        function.can_handle_array = True
+        function.addParameter('index_of_the_star', dtype='int32', direction=function.IN
+            , description="The index of the star to get the value of")
+        function.addParameter('gyration_radius', dtype='float64', direction=function.OUT
+            , description="The current gyration radius of the star")
+        function.result_type = 'int32'
+        return function
+    
     @remote_function(can_handle_array=True)
     def get_manual_mass_transfer_rate(index_of_the_star='i'):
         """
@@ -1306,7 +1383,13 @@ class MESA(StellarEvolution, InternalStellarStructure):
             handler.add_getter(particle_set_name, 'get_mass', names=('mass',))
             handler.add_setter(particle_set_name, 'set_mass', names=('mass',))
             handler.add_getter(particle_set_name, 'get_core_mass', names=('core_mass',))
+            handler.add_getter(particle_set_name, 'get_core_radius', names=('core_radius',))
+            handler.add_getter(particle_set_name, 'get_convective_envelope_mass', names = ('convective_envelope_mass',))
+            handler.add_getter(particle_set_name, 'get_convective_envelope_radius', names = ('convective_envelope_radius',))
             handler.add_getter(particle_set_name, 'get_mass_loss_rate', names=('wind',))
+            handler.add_getter(particle_set_name, 'get_wind_mass_loss_rate', names=('wind_mass_loss_rate',))
+            handler.add_getter(particle_set_name, 'get_apsidal_motion_constant', names=('apsidal_motion_constant',))
+            handler.add_getter(particle_set_name, 'get_gyration_radius', names=('gyration_radius',))
             handler.add_getter(particle_set_name, 'get_age', names=('age',))
             handler.add_setter(particle_set_name, 'set_age', names=('age',))
             handler.add_getter(particle_set_name, 'get_time_step', names=('time_step',))
@@ -1488,9 +1571,39 @@ class MESA(StellarEvolution, InternalStellarStructure):
             (units.MSun, handler.ERROR_CODE,)
         )
         handler.add_method(
+            "get_core_radius",
+            (handler.INDEX,),
+            (units.RSun, handler.ERROR_CODE,)
+        )
+        handler.add_method(
+            "get_convective_envelope_mass",
+            (handler.INDEX,),
+            (units.MSun, handler.ERROR_CODE,)
+        )
+        handler.add_method(
+            "get_convective_envelope_radius",
+            (handler.INDEX,),
+            (units.RSun, handler.ERROR_CODE,)
+        )
+        handler.add_method(
             "get_mass_loss_rate",
             (handler.INDEX,),
             (units.MSun / units.julianyr, handler.ERROR_CODE,)
+        )
+        handler.add_method(
+            "get_wind_mass_loss_rate",
+            (handler.INDEX,),
+            (units.MSun / units.julianyr, handler.ERROR_CODE,)
+        )
+        handler.add_method(
+            "get_apsidal_motion_constant",
+            (handler.INDEX,),
+            (handler.NO_UNIT, handler.ERROR_CODE,)
+        )
+        handler.add_method(
+            "get_gyration_radius",
+            (handler.INDEX,),
+            (handler.NO_UNIT, handler.ERROR_CODE,)
         )
         handler.add_method(
             "get_manual_mass_transfer_rate",
@@ -1557,6 +1670,12 @@ class MESA(StellarEvolution, InternalStellarStructure):
         handler.add_method(
             "evolve_for",
             (handler.INDEX, units.julianyr),
+            (handler.ERROR_CODE,)
+        )
+        
+        handler.add_method(
+            "evolve_one_step",
+            (handler.INDEX),
             (handler.ERROR_CODE,)
         )
 

--- a/src/amuse/community/mesa_r15140/mesa_interface.f90
+++ b/src/amuse/community/mesa_r15140/mesa_interface.f90
@@ -117,7 +117,7 @@ module mesa_interface
         s% job% saved_model_name = trim(filename)
 
         s% job% create_pre_main_sequence_model = .false.
-        
+
     end subroutine load_saved_model
 
 
@@ -132,7 +132,7 @@ module mesa_interface
 
         s% job% load_saved_model = .false.
         s% job% create_pre_main_sequence_model = .false.
-        
+
     end subroutine load_zams_model
 
 
@@ -167,7 +167,7 @@ module mesa_interface
         integer, intent(out) :: ierr
 
         call star_write_model(id, filename, ierr)
-        
+
     end subroutine save_mesa_model
 
 
@@ -210,7 +210,7 @@ module mesa_interface
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
 
-        call init_callback(id) ! Call here and in evolve_controls as there are options that 
+        call init_callback(id) ! Call here and in evolve_controls as there are options that
                                ! need to be set before and after the other inlist options get set
         id_from_read_star_job = id
 
@@ -232,7 +232,7 @@ module mesa_interface
             ierr = 0
             call star_ptr(id, s, ierr)
             if (ierr /= 0) return
-            
+
            ! This is a local copy of extras_controls,
            ! Plese add your changes to the version in run_star_extras.f90 not this one
 
@@ -242,30 +242,30 @@ module mesa_interface
             s% job% check_after_step_timing = 0
             s% job% time0_initial = 0
             s% calculate_Brunt_N2 = .true.
-    
+
             call init_callback(id)
 
             ! Set zbase if its not been set yet
-            if(s%kap_rq% zbase == -1) s%kap_rq% zbase = s%initial_z            
+            if(s%kap_rq% zbase == -1) s%kap_rq% zbase = s%initial_z
 
             ! Override photo_directory otherwise we look in photos/ instead of ./
-            ! This does nothing for 15140 but later versions can use this to set 
+            ! This does nothing for 15140 but later versions can use this to set
             ! the folder for the restart photo to the current directory.
             if(len_trim(restart_name(id)) > 0) then
                 s%photo_directory = '.'
             end if
 
             call rse_extras_controls(id, ierr)
-  
-        
+
+
          end subroutine extras_controls
 
-        
+
     end subroutine finish_init_star
 
     subroutine remove_star(id, ierr)
         integer, intent(in) :: id
-        integer, intent(out) :: ierr 
+        integer, intent(out) :: ierr
 
         call free_star(id, ierr)
         if (failed('free_star',ierr)) return
@@ -276,7 +276,7 @@ module mesa_interface
         integer, intent(out) :: num
 
         num =  max_star_handles
- 
+
     end subroutine max_num_stars
 
 
@@ -323,12 +323,12 @@ module mesa_interface
         !call chdir(output_folder)
 
         call star_ptr(id, s, ierr)
-        if (failed('star_ptr',ierr)) return   
+        if (failed('star_ptr',ierr)) return
 
         mesa_dir = mesa_dir_in
 
         call const_init(mesa_dir_in, ierr)
-        if (failed('const_init',ierr)) return 
+        if (failed('const_init',ierr)) return
 
         mesa_data_dir = mesa_data_dir_in
 
@@ -350,7 +350,7 @@ module mesa_interface
         s% terminal_interval = 1
         s% write_header_frequency = 100
 
-        mesa_temp_caches_dir = trim(temp_dir) 
+        mesa_temp_caches_dir = trim(temp_dir)
 
         s% report_ierr = .false.
 
@@ -364,7 +364,7 @@ module mesa_interface
     subroutine update_star_job(id, ierr)
         integer, intent(in) :: id
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         ierr = MESA_SUCESS
 
@@ -382,7 +382,7 @@ module mesa_interface
         integer, intent(in) :: id
         character(len=*), intent(out) :: net_name
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         ierr = MESA_SUCESS
 
@@ -398,7 +398,7 @@ module mesa_interface
         integer, intent(in) :: id
         character(len=*), intent(in) :: net_name
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         ierr = MESA_SUCESS
 
@@ -502,7 +502,7 @@ module mesa_interface
     subroutine do_evolve_one_step(id, result, ierr)
         integer, intent(in) :: id
         integer, intent(out) :: result, ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         integer :: model_number
         logical :: continue_evolve_loop, first_try
@@ -516,33 +516,33 @@ module mesa_interface
         call before_step_loop(s% id, ierr)
         if (failed('before_step_loop',ierr)) return
 
-        result = s% extras_start_step(id)  
-        if (result /= keep_going) return      
+        result = s% extras_start_step(id)
+        if (result /= keep_going) return
 
         first_try = .true.
-        
+
         step_loop: do ! may need to repeat this loop
-        
+
            if (stop_is_requested(s)) then
               continue_evolve_loop = .false.
               result = terminate
               exit
            end if
-        
+
            result = star_evolve_step(id, first_try)
            if (result == keep_going) result = star_check_model(id)
            if (result == keep_going) result = s% extras_check_model(id)
-           if (result == keep_going) result = star_pick_next_timestep(id)            
+           if (result == keep_going) result = star_pick_next_timestep(id)
            if (result == keep_going) exit step_loop
-           
+
            model_number = get_model_number(id, ierr)
            if (failed('get_model_number',ierr)) return
-                          
+
            if (result == retry .and. s% job% report_retries) then
               write(*,'(i6,3x,a,/)') model_number, &
                  'retry reason ' // trim(result_reason_str(s% result_reason))
            end if
-           
+
            if (result == redo) then
               result = star_prepare_to_redo(id)
            end if
@@ -560,7 +560,7 @@ module mesa_interface
         call after_step_loop(s% id, s% inlist_fname, &
             dbg, result, ierr)
         if (failed('after_step_loop',ierr)) return
-        
+
         call do_saves(id, ierr)
         if (failed('do_saves',ierr)) return
 
@@ -583,7 +583,7 @@ module mesa_interface
     subroutine do_solve_one_step_pre(id, result, ierr)
         integer, intent(in) :: id
         integer, intent(out) :: result, ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         integer :: model_number
         logical :: continue_evolve_loop, first_try
@@ -597,8 +597,8 @@ module mesa_interface
         call before_step_loop(s% id, ierr)
         if (failed('before_step_loop',ierr)) return
 
-        result = s% extras_start_step(id)  
-        if (result /= keep_going) return      
+        result = s% extras_start_step(id)
+        if (result /= keep_going) return
 
 
     end subroutine do_solve_one_step_pre
@@ -608,7 +608,7 @@ module mesa_interface
         integer, intent(in) :: id
         logical, intent(in) :: first_try
         integer, intent(out) :: result, ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         integer :: model_number
         logical :: continue_evolve_loop
@@ -623,7 +623,7 @@ module mesa_interface
         result = star_evolve_step(id, first_try)
         if (result == keep_going) result = star_check_model(id)
         if (result == keep_going) result = s% extras_check_model(id)
-        if (result == keep_going) result = star_pick_next_timestep(id)            
+        if (result == keep_going) result = star_pick_next_timestep(id)
         if (result == keep_going) return
 
     end subroutine do_solve_one_step
@@ -632,7 +632,7 @@ module mesa_interface
     subroutine do_solve_one_step_post(id, result, ierr)
         integer, intent(in) :: id
         integer, intent(out) :: result, ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         integer :: model_number
         logical :: continue_evolve_loop, first_try
@@ -649,7 +649,7 @@ module mesa_interface
         call after_step_loop(s% id, s% inlist_fname, &
             dbg, result, ierr)
         if (failed('after_step_loop',ierr)) return
-        
+
         call do_saves(id, ierr)
         if (failed('do_saves',ierr)) return
 
@@ -662,41 +662,67 @@ module mesa_interface
         integer, intent(in) :: id
         real(dp), intent(in) :: delta_t
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s  
-        integer :: result
+        type (star_info), pointer :: s
+        integer :: result, count
         logical,parameter :: dbg=.false.
-        real(dp) :: old_age
+        real(dp) :: end_time, dt_save
 
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
 
-        old_age = s% max_age 
+        ! (LS 2024)
+        ! Update of evolve_until in case subroutine is called several times subsequently.
 
-        s% max_age = s% star_age + delta_t
-        s% num_adjusted_dt_steps_before_max_age =  -1
+        ! In the previous version, the timestep was automatically reduced at the end of
+        ! the evolve loop so that the star age reach max_age. In a subsequent call to
+        ! evolve_until, the evolution would start again with this reduced timestep, which
+        ! could in some cases prevent the timestep from increasing.
 
-        evolve_loop: do 
+        ! End time of evolution
+        end_time = s% star_age + delta_t
+
+        ! To check whether the evolve loop was entered
+        count = 0
+
+        ! Evolve loop while end_time not reached
+        ! Use of epsilon(0.0d0) to avoid precision issues
+        do while (s% star_age + s% dt_next/secyer  < end_time*(1.0d0 - epsilon(0.0d0)))
             call do_evolve_one_step(id, result, ierr)
+            count = count + 1
             if (result /= keep_going) then
                 if (s% result_reason == result_reason_normal) then
-                    exit evolve_loop
+                    exit
                 else
                     ierr = -1
-                    exit evolve_loop
+                    exit
                 end if
             end if
             s% doing_first_model_of_run = .false.
-        end do evolve_loop
+        end do
 
-        ! In case you want to evolve further
-        s% max_age = old_age
-        if(s% dt_next==0) s% dt_next = s% dt
+        ! Save the next timestep MESA would have required if it was not imposed by end_time
+        dt_save = s% dt_next
+
+        ! Set the timestep required to reach end_time
+        s% dt_next = (end_time - s% star_age)*secyer
+
+        ! Evolve one last step to reach end_time
+        call do_evolve_one_step(id, result, ierr)
+        if (result /= keep_going) then
+            if (s% result_reason /= result_reason_normal) then
+                 ierr = -1
+            end if
+        end if
+
+        ! If several evolve steps were performed, set the timestep for the future evolution
+        ! to the value it would have reached without the condition to finish at end_time
+        if (count /= 0) then
+            s% dt_next = dt_save
+        endif
 
         s% doing_first_model_of_run = .false.
 
     end subroutine evolve_until
-
-
 
 
 ! ***********************************************************************
@@ -743,7 +769,7 @@ module mesa_interface
         integer, intent(in) :: id
         real(dp), intent(in) :: dt
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s 
+        type (star_info), pointer :: s
 
         call star_ptr(id, s, ierr)
         if (failed('set_dt',ierr)) return
@@ -785,17 +811,17 @@ module mesa_interface
     subroutine relax_to_new_comp(id, xa, xqs, ierr)
         integer, intent(in) :: id
         real(dp), intent(in) :: xa(:,:), xqs(:)
-        type (star_info), pointer :: s   
+        type (star_info), pointer :: s
         integer, intent(out) :: ierr
         integer :: k
         real(dp) :: max_age
-        ierr=0 
+        ierr=0
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
 
         if(s%species /= size(xa,dim=1)) then
             ierr = -50
-            return 
+            return
         end if
 
         call star_relax_composition(id, s% job% num_steps_to_relax_composition, &
@@ -808,7 +834,7 @@ module mesa_interface
     subroutine relax_to_new_entropy(id, xqs, temperature, rho, ierr)
         integer, intent(in) :: id
         real(dp), intent(in) :: xqs(:), temperature(:), rho(:)
-        type (star_info), pointer :: s   
+        type (star_info), pointer :: s
         integer, intent(out) :: ierr
         real(dp), allocatable, dimension(:) :: entropy
         real(dp), dimension(num_eos_basic_results) :: res,d_dlnd, d_dlnT, d_dabar, d_dzbar
@@ -1039,7 +1065,7 @@ module mesa_interface
 
     end subroutine get_next_timestep
 
- 
+
     integer function reverse_zone_id(id, zone, ierr)
         integer, intent(in) :: id, zone
         integer, intent(out) :: ierr
@@ -1063,7 +1089,7 @@ module mesa_interface
         integer, intent(in) :: id, net_id
         character(*), intent(out) :: name
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s    
+        type (star_info), pointer :: s
 
         name=''
 
@@ -1087,7 +1113,7 @@ module mesa_interface
         character(len=*), intent(in) :: iso_name
         integer, intent(out) :: ierr
         type (star_info), pointer :: s
-        integer :: k    
+        integer :: k
 
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
@@ -1108,8 +1134,8 @@ module mesa_interface
         integer, intent(in) :: net_id
         real(dp), intent(out) :: mass
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s   
-        integer :: species_id 
+        type (star_info), pointer :: s
+        integer :: species_id
 
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
@@ -1129,8 +1155,8 @@ module mesa_interface
         integer, intent(in) :: net_id
         real(dp), intent(out) :: mass
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s   
-        integer :: species_id 
+        type (star_info), pointer :: s
+        integer :: species_id
 
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
@@ -1140,7 +1166,7 @@ module mesa_interface
             return
         end if
 
-        mass = dot_product(s% xa(net_id,1:s% nz),s% dq(1:s% nz))/sum(s% dq(1:s% nz)) 
+        mass = dot_product(s% xa(net_id,1:s% nz),s% dq(1:s% nz))/sum(s% dq(1:s% nz))
         mass = mass*s% xmstar/Msun
 
     end subroutine get_total_mass_species
@@ -1150,8 +1176,8 @@ module mesa_interface
         integer, intent(in) :: net_id
         real(dp), intent(out) :: mass
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s   
-        integer :: species_id 
+        type (star_info), pointer :: s
+        integer :: species_id
 
         mass = -1
 
@@ -1161,7 +1187,7 @@ module mesa_interface
         if(zone<0 .or. zone> s%nz) then
             ierr = -2
             return
-        end if 
+        end if
 
         if(net_id < 1 .or. net_id > s% species) then
             ierr =-3
@@ -1176,12 +1202,12 @@ module mesa_interface
         integer, intent(in) :: id
         integer, intent(out) :: time
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s   
+        type (star_info), pointer :: s
 
         call star_ptr(id, s, ierr)
         if (failed('star_ptr',ierr)) return
 
-        time = s% job% after_step_timing 
+        time = s% job% after_step_timing
 
     end subroutine time_of_step
 
@@ -1192,7 +1218,7 @@ module mesa_interface
         character(len=*), intent(in) :: name
         real(dp), intent(out) :: val
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s   
+        type (star_info), pointer :: s
 
         ierr = 0
         call star_ptr(id, s, ierr)
@@ -1204,7 +1230,7 @@ module mesa_interface
         end if
 
         select case(name)
-            case('extra_heat') 
+            case('extra_heat')
                 val = s% extra_heat(k)
             case default
                 ierr = -3
@@ -1219,7 +1245,7 @@ module mesa_interface
         character(len=*), intent(in) :: name
         real(dp), intent(in) :: val
         integer, intent(out) :: ierr
-        type (star_info), pointer :: s   
+        type (star_info), pointer :: s
 
         ierr = 0
         call star_ptr(id, s, ierr)
@@ -1231,7 +1257,7 @@ module mesa_interface
         end if
 
         select case(name)
-            case('extra_heat') 
+            case('extra_heat')
                 s% extra_heat(k) = val
             case default
                 ierr = -3
@@ -1256,15 +1282,15 @@ module mesa_interface
         call gyre_init(gyre_in)
 
         ! Set constants
-    
+
         call gyre_set_constant('G_GRAVITY', standard_cgrav)
         call gyre_set_constant('C_LIGHT', clight)
         call gyre_set_constant('A_RADIATION', crad)
-    
+
         call gyre_set_constant('M_SUN', Msun)
         call gyre_set_constant('R_SUN', Rsun)
         call gyre_set_constant('L_SUN', Lsun)
-    
+
         call gyre_set_constant('GYRE_DIR', TRIM(mesa_dir)//'/gyre/gyre')
 
 
@@ -1278,7 +1304,7 @@ module mesa_interface
         integer, intent(in) :: id, mode_l
         integer, intent(out) :: ierr
         logical, intent(in) :: add_center_point, keep_surface_point, add_atmosphere
-        type (star_info), pointer :: s  
+        type (star_info), pointer :: s
         real(dp), allocatable     :: global_data(:)
         real(dp), allocatable     :: point_data(:,:)
         integer                   :: ipar(1)
@@ -1310,18 +1336,18 @@ module mesa_interface
     contains
 
         subroutine process_mode_ (md, ipar, rpar, retcode)
-    
+
          type(mode_t), intent(in) :: md
          integer, intent(inout)   :: ipar(:)
          real(dp), intent(inout)  :: rpar(:)
          integer, intent(out)     :: retcode
-   
+
          integer               :: k, unit
          complex(dp)           :: cfreq
          real(dp)              :: freq, growth
          type(grid_t)          :: gr
-          
-         retcode= 0 
+
+         retcode= 0
          ipar(1) = 0
          cfreq = md% freq('HZ')
          gr = md%grid()


### PR DESCRIPTION
Update of the mesa_r15140 interface, adding getters required to make it compatible with TRES:
- get_core_radius
- get_convective_envelope_mass
- get_convective_envelope_radius
- get_wind_mass_loss_rate
- get_apsidal_motion_constant
- get_gyration_radius

Update of the evolve_until subroutine in mesa_interface.f90 solving timestep issues occuring in the previous version when the subroutine was called multiple times in a row.

The modified script files are interface.py, interface.f90 and mesa_interface.f90, all in src/amuse/community/mesa_r15140.

Tests scripts are provided in src/amuse/community/mesa_r15140/Tests.