### PR TITLE
Update SeBa version

### DIFF
--- a/src/amuse/community/seba/download.py
+++ b/src/amuse/community/seba/download.py
@@ -93,7 +93,7 @@ def new_option_parser():
     result = OptionParser()
     result.add_option(
         "--seba-version",
-        default='94e9b1d6ba1466d288a12e3afaa1eba5bca6ddca',
+        default='2d8088ad03a4323514780e19e5895fbcac42e0ec',
         dest="seba_version",
         help="SeBa commit hash to download",
         type="string"

--- a/src/amuse/community/seba/interface.cc
+++ b/src/amuse/community/seba/interface.cc
@@ -6,12 +6,15 @@
 // AMUSE STOPPING CONDITIONS SUPPORT
 #include <stopcond.h>
 
+// Get std::xxx to match SeBa commit 382b590
+// #include <stdinc.h>
+
 #include <map>
 
 static node * seba_root = 0;
 static node * seba_insertion_point = 0;
 static int next_seba_id = 1;
-static map<int, nodeptr> mapping_from_id_to_node;
+static std::map<int, nodeptr> mapping_from_id_to_node;
 static double seba_metallicity = 0.02;
 static double seba_time = 0.0;
 static stellar_type start_type = Main_Sequence;
@@ -505,7 +508,7 @@ int new_advanced_particle(int * index_of_the_star, double mass,  double relative
 
 int delete_star(int index_of_the_star){
     
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         return -1;
     } else {
@@ -531,7 +534,7 @@ int recommit_particles(){
 
 node * get_seba_node_from_index(int index_of_the_star, int * errorcode)
 {
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         *errorcode = -1;
         return 0;
@@ -929,7 +932,7 @@ int new_binary(
 
 int delete_binary(int index_of_the_star){
     
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         return -1;
     } else {
@@ -997,7 +1000,7 @@ int get_children_of_binary(
     
     *child1_index = -1;
     *child2_index = -1;
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         return -1;
     } else {


### PR DESCRIPTION
This pull request updates the SeBa version in AMUSE to use the changes implemented in `5dff550` preserving the stellar properties at restart. There are two changes made in this pull request:
1. SeBa version changed to commit `2d8088a` (see [here](https://github.com/amusecode/SeBa/commit/2d8088ad03a4323514780e19e5895fbcac42e0ec))
2. Use of `std::map` instead of `map` in `/src/amuse/community/seba.interface.cc` to match the style change made in SeBa [here](https://github.com/amusecode/SeBa/commit/382b5904609b1a44577f1d652c2eba34f9192616). Without this change, the seba worker does not compile with any version of SeBa more recent than September 2023.