### PR TITLE
Fix bug with particle properties of new stars in SeBa

### DIFF
--- a/src/amuse/community/seba/download.py
+++ b/src/amuse/community/seba/download.py
@@ -93,7 +93,7 @@ def new_option_parser():
     result = OptionParser()
     result.add_option(
         "--seba-version",
-        default='94e9b1d6ba1466d288a12e3afaa1eba5bca6ddca',
+        default='2d8088ad03a4323514780e19e5895fbcac42e0ec',
         dest="seba_version",
         help="SeBa commit hash to download",
         type="string"

--- a/src/amuse/community/seba/interface.cc
+++ b/src/amuse/community/seba/interface.cc
@@ -6,12 +6,15 @@
 // AMUSE STOPPING CONDITIONS SUPPORT
 #include <stopcond.h>
 
+// Get std::xxx to match SeBa commit 382b590
+// #include <stdinc.h>
+
 #include <map>
 
 static node * seba_root = 0;
 static node * seba_insertion_point = 0;
 static int next_seba_id = 1;
-static map<int, nodeptr> mapping_from_id_to_node;
+static std::map<int, nodeptr> mapping_from_id_to_node;
 static double seba_metallicity = 0.02;
 static double seba_time = 0.0;
 static stellar_type start_type = Main_Sequence;
@@ -505,7 +508,7 @@ int new_advanced_particle(int * index_of_the_star, double mass,  double relative
 
 int delete_star(int index_of_the_star){
     
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         return -1;
     } else {
@@ -531,7 +534,7 @@ int recommit_particles(){
 
 node * get_seba_node_from_index(int index_of_the_star, int * errorcode)
 {
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         *errorcode = -1;
         return 0;
@@ -929,7 +932,7 @@ int new_binary(
 
 int delete_binary(int index_of_the_star){
     
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         return -1;
     } else {
@@ -997,7 +1000,7 @@ int get_children_of_binary(
     
     *child1_index = -1;
     *child2_index = -1;
-    map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
+    std::map<int, nodeptr>::iterator i = mapping_from_id_to_node.find(index_of_the_star);
     if(i == mapping_from_id_to_node.end()) {
         return -1;
     } else {

--- a/src/amuse/community/seba/interface.cc
+++ b/src/amuse/community/seba/interface.cc
@@ -456,8 +456,8 @@ int new_particle(int * index_of_the_star, double mass){
         new_node->set_elder_sister(seba_insertion_point);
         seba_insertion_point = new_node;
     }
-    
-    addstar(new_node, seba_time, start_type, seba_metallicity, 0, false);
+
+    addstar(new_node, seba_time, start_type, seba_metallicity, 0, false, start_type, mass, mass, 0, 0, 0);
     new_node->get_starbase()->set_time_offset(seba_time);
     *index_of_the_star = next_seba_id;
     


### PR DESCRIPTION
This fixes issue [#1119](https://github.com/amusecode/amuse/issues/1119) by explicitly setting the relative mass and core/envelope masses of new stars, rather than only stars from restarts. The tests associated with this bug fix and the updated restart capabilities of SeBa are outlined in PR [#1122](https://github.com/amusecode/amuse/pull/1122). 