### PR TITLE
Include test particle calculations in Ph4

### DIFF
--- a/src/amuse/community/ph4/interface.cc
+++ b/src/amuse/community/ph4/interface.cc
@@ -787,12 +787,16 @@ int get_center_of_mass_position(double * x, double * y, double * z)
     real mtot = 0;
     vec cmx(0,0,0);
     for (int j = 0; j < jd->nj; j++) {
-	mtot += jd->mass[j];
-	for (int k = 0; k < 3; k++) cmx[k] += jd->mass[j]*jd->pos[j][k];
-    }
-    *x = cmx[0]/mtot;
-    *y = cmx[1]/mtot;
-    *z = cmx[2]/mtot;
+        if (jd->mass[j] > _TINY_){
+            mtot += jd->mass[j];
+            for (int k = 0; k < 3; k++){
+                cmx[k] += jd->mass[j]*jd->pos[j][k];
+            }
+        }
+        *x = cmx[0]/mtot;
+        *y = cmx[1]/mtot;
+        *z = cmx[2]/mtot;
+        }
     return 0;
 }
 


### PR DESCRIPTION
Modified a couple lines on interface.cc and src/idata.cc to optimise calculations including test particles. Collision detection ignores test particles colliding with one another.