### PR TITLE
Version archives for release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+VERSION export-subst

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,6 @@
+# This file is used to record the version of AMUSE in a .tar.gz archive made using git
+# archive. The build system will pick it up from here if it is not building from a git
+# repository but from that tar.gz file.
+
+$Format:%(describe:match=v*)$
+

--- a/src/amuse/rfi/tools/dir_templates/pyproject-base.toml
+++ b/src/amuse/rfi/tools/dir_templates/pyproject-base.toml
@@ -24,6 +24,9 @@ distance = "{{next_version}}.dev{{distance}}+{{vcs}}{{rev}}"
 dirty = "{{base_version}}+d{{build_date:%Y%m%d}}"
 distance-dirty = "{{next_version}}.dev{{distance}}+{{vcs}}{{rev}}.d{{build_date:%Y%m%d}}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_{code}/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 
@@ -38,7 +41,7 @@ exclude = [
 artifacts = ["amuse_{code}/{code}_worker"]
 
 [tool.pytest.ini_options]
-pythonpath = ["amuse_{code}/tests/", "../../../../../tests"]
+pythonpath = ["amuse_{code}/tests/"]
 
 testpaths = ["amuse_{code}/tests"]
 

--- a/src/amuse/rfi/tools/dir_templates/pyproject-extra.toml
+++ b/src/amuse/rfi/tools/dir_templates/pyproject-extra.toml
@@ -22,6 +22,9 @@ distance = "{{next_version}}.dev{{distance}}+{{vcs}}{{rev}}"
 dirty = "{{base_version}}+d{{build_date:%Y%m%d}}"
 distance-dirty = "{{next_version}}.dev{{distance}}+{{vcs}}{{rev}}.d{{build_date:%Y%m%d}}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_{code}/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_aarsethzare/packages/amuse-aarsethzare/pyproject.toml
+++ b/src/amuse_aarsethzare/packages/amuse-aarsethzare/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_aarsethzare/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_adaptb/packages/amuse-adaptb/pyproject.toml
+++ b/src/amuse_adaptb/packages/amuse-adaptb/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_adaptb/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_athena/packages/amuse-athena/pyproject.toml
+++ b/src/amuse_athena/packages/amuse-athena/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_athena/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_bhtree/packages/amuse-bhtree/pyproject.toml
+++ b/src/amuse_bhtree/packages/amuse-bhtree/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_bhtree/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_brutus/packages/amuse-brutus/pyproject.toml
+++ b/src/amuse_brutus/packages/amuse-brutus/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_brutus/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_bse/packages/amuse-bse/pyproject.toml
+++ b/src/amuse_bse/packages/amuse-bse/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_bse/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_capreole/packages/amuse-capreole/pyproject.toml
+++ b/src/amuse_capreole/packages/amuse-capreole/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_capreole/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_etics/packages/amuse-etics-cuda/pyproject.toml
+++ b/src/amuse_etics/packages/amuse-etics-cuda/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_etics/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_evtwin/packages/amuse-evtwin/pyproject.toml
+++ b/src/amuse_evtwin/packages/amuse-evtwin/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_evtwin/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_fastkick/packages/amuse-fastkick-cuda/pyproject.toml
+++ b/src/amuse_fastkick/packages/amuse-fastkick-cuda/pyproject.toml
@@ -22,6 +22,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_fastkick/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_fastkick/packages/amuse-fastkick/pyproject.toml
+++ b/src/amuse_fastkick/packages/amuse-fastkick/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_fastkick/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_fi/packages/amuse-fi/pyproject.toml
+++ b/src/amuse_fi/packages/amuse-fi/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_fi/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_fractalcluster/packages/amuse-fractalcluster/pyproject.toml
+++ b/src/amuse_fractalcluster/packages/amuse-fractalcluster/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_fractalcluster/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_gadget2/packages/amuse-gadget2/pyproject.toml
+++ b/src/amuse_gadget2/packages/amuse-gadget2/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_gadget2/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_galactics/packages/amuse-galactics/pyproject.toml
+++ b/src/amuse_galactics/packages/amuse-galactics/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_galactics/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_galaxia/packages/amuse-galaxia/pyproject.toml
+++ b/src/amuse_galaxia/packages/amuse-galaxia/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_galaxia/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_halogen/packages/amuse-halogen/pyproject.toml
+++ b/src/amuse_halogen/packages/amuse-halogen/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_halogen/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_hermite/packages/amuse-hermite/pyproject.toml
+++ b/src/amuse_hermite/packages/amuse-hermite/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_hermite/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_hermite_grx/packages/amuse-hermite-grx/pyproject.toml
+++ b/src/amuse_hermite_grx/packages/amuse-hermite-grx/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_hermite_grx/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_higpus/packages/amuse-higpus-cuda/pyproject.toml
+++ b/src/amuse_higpus/packages/amuse-higpus-cuda/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_higpus/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_hop/packages/amuse-hop/pyproject.toml
+++ b/src/amuse_hop/packages/amuse-hop/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_hop/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_huayno/packages/amuse-huayno-opencl/pyproject.toml
+++ b/src/amuse_huayno/packages/amuse-huayno-opencl/pyproject.toml
@@ -22,6 +22,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_huayno/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_huayno/packages/amuse-huayno-openmp/pyproject.toml
+++ b/src/amuse_huayno/packages/amuse-huayno-openmp/pyproject.toml
@@ -22,6 +22,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_huayno/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_huayno/packages/amuse-huayno/pyproject.toml
+++ b/src/amuse_huayno/packages/amuse-huayno/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_huayno/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_kepler/packages/amuse-kepler/pyproject.toml
+++ b/src/amuse_kepler/packages/amuse-kepler/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_kepler/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_kepler_orbiters/packages/amuse-kepler-orbiters/pyproject.toml
+++ b/src/amuse_kepler_orbiters/packages/amuse-kepler-orbiters/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_kepler_orbiters/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_krome/packages/amuse-krome/pyproject.toml
+++ b/src/amuse_krome/packages/amuse-krome/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_krome/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mameclot/packages/amuse-mameclot/pyproject.toml
+++ b/src/amuse_mameclot/packages/amuse-mameclot/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mameclot/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mercury/packages/amuse-mercury/pyproject.toml
+++ b/src/amuse_mercury/packages/amuse-mercury/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mercury/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mesa_r15140/packages/amuse-mesa-r15140/pyproject.toml
+++ b/src/amuse_mesa_r15140/packages/amuse-mesa-r15140/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mesa_r15140/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mesa_r2208/packages/amuse-mesa-r2208/pyproject.toml
+++ b/src/amuse_mesa_r2208/packages/amuse-mesa-r2208/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mesa_r2208/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mi6/packages/amuse-mi6-sapporo2/pyproject.toml
+++ b/src/amuse_mi6/packages/amuse-mi6-sapporo2/pyproject.toml
@@ -22,6 +22,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mi6/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mi6/packages/amuse-mi6/pyproject.toml
+++ b/src/amuse_mi6/packages/amuse-mi6/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mi6/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mikkola/packages/amuse-mikkola/pyproject.toml
+++ b/src/amuse_mikkola/packages/amuse-mikkola/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mikkola/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mmams/packages/amuse-mmams/pyproject.toml
+++ b/src/amuse_mmams/packages/amuse-mmams/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mmams/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mobse/packages/amuse-mobse/pyproject.toml
+++ b/src/amuse_mobse/packages/amuse-mobse/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mobse/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mocassin/packages/amuse-mocassin/pyproject.toml
+++ b/src/amuse_mocassin/packages/amuse-mocassin/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mocassin/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mosse/packages/amuse-mosse/pyproject.toml
+++ b/src/amuse_mosse/packages/amuse-mosse/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mosse/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_mpiamrvac/packages/amuse-mpiamrvac/pyproject.toml
+++ b/src/amuse_mpiamrvac/packages/amuse-mpiamrvac/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_mpiamrvac/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_nbody6xx/packages/amuse-nbody6xx/pyproject.toml
+++ b/src/amuse_nbody6xx/packages/amuse-nbody6xx/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_nbody6xx/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_petar/packages/amuse-petar/pyproject.toml
+++ b/src/amuse_petar/packages/amuse-petar/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_petar/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_ph4/packages/amuse-ph4-sapporo/pyproject.toml
+++ b/src/amuse_ph4/packages/amuse-ph4-sapporo/pyproject.toml
@@ -22,6 +22,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_ph4/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_ph4/packages/amuse-ph4/pyproject.toml
+++ b/src/amuse_ph4/packages/amuse-ph4/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_ph4/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_phantom/packages/amuse-phantom/pyproject.toml
+++ b/src/amuse_phantom/packages/amuse-phantom/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_phantom/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_phigrape/packages/amuse-phigrape-sapporo/pyproject.toml
+++ b/src/amuse_phigrape/packages/amuse-phigrape-sapporo/pyproject.toml
@@ -22,6 +22,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_phigrape/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_phigrape/packages/amuse-phigrape/pyproject.toml
+++ b/src/amuse_phigrape/packages/amuse-phigrape/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_phigrape/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_rebound/packages/amuse-rebound/pyproject.toml
+++ b/src/amuse_rebound/packages/amuse-rebound/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_rebound/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_sakura/packages/amuse-sakura/pyproject.toml
+++ b/src/amuse_sakura/packages/amuse-sakura/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_sakura/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_seba/packages/amuse-seba/pyproject.toml
+++ b/src/amuse_seba/packages/amuse-seba/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_seba/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_secularmultiple/packages/amuse-secularmultiple/pyproject.toml
+++ b/src/amuse_secularmultiple/packages/amuse-secularmultiple/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_secularmultiple/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_sei/packages/amuse-sei/pyproject.toml
+++ b/src/amuse_sei/packages/amuse-sei/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_sei/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_smalln/packages/amuse-smalln/pyproject.toml
+++ b/src/amuse_smalln/packages/amuse-smalln/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_smalln/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_sphray/packages/amuse-sphray/pyproject.toml
+++ b/src/amuse_sphray/packages/amuse-sphray/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_sphray/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_sse/packages/amuse-sse/pyproject.toml
+++ b/src/amuse_sse/packages/amuse-sse/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_sse/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_symple/packages/amuse-symple/pyproject.toml
+++ b/src/amuse_symple/packages/amuse-symple/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_symple/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_tupan/packages/amuse-tupan/pyproject.toml
+++ b/src/amuse_tupan/packages/amuse-tupan/pyproject.toml
@@ -22,6 +22,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_tupan/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_twobody/packages/amuse-twobody/pyproject.toml
+++ b/src/amuse_twobody/packages/amuse-twobody/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_twobody/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/amuse_vader/packages/amuse-vader/pyproject.toml
+++ b/src/amuse_vader/packages/amuse-vader/pyproject.toml
@@ -21,6 +21,9 @@ distance = "{next_version}.dev{distance}+{vcs}{rev}"
 dirty = "{base_version}+d{build_date:%Y%m%d}"
 distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "amuse_vader/support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -35,6 +35,9 @@ distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 [tool.versioningit.write]
 file = "amuse/_version.py"
 
+[tool.versioningit.vcs]
+method = { module = "version_helper", value = "get_amuse_version", module-dir = "../support/shared" }
+
 [tool.hatch.build]
 skip-excluded-dirs = true
 

--- a/support/shared/version_helper.py
+++ b/support/shared/version_helper.py
@@ -1,0 +1,44 @@
+"""Version packaging helper
+
+We use versioningit to automatically get a version for the packages we build from the
+current git repository. When building from a tarball however, which is what we instruct
+users to do, there is no git history for versioningit to inspect, and it will give an
+error. There's a method that has git write the version to the pyproject.toml file when
+creating the tarball using git archive, but that only works for a single pyproject.toml
+file and we have many.
+
+So, we have git write the version to a VERSION file in the root instead, and then we
+have this plug-in for versioningit that checks that if we don't have a git repository.
+"""
+from versioningit.core import VCSDescription
+from versioningit.errors import NotSdistError, NotVCSError
+from versioningit.git import describe_git
+
+from pathlib import Path
+
+
+def load_version(version_file: Path):
+    version = None
+    if version_file.exists():
+        with version_file.open('r') as f:
+            for line in f:
+                if line.strip().startswith('#') or line.strip() == '':
+                    continue
+                version = line.strip()
+
+    return version
+
+
+def get_amuse_version(project_dir, params):
+    """Find the current version of AMUSE"""
+    try:
+        return describe_git(project_dir=project_dir, params=params)
+    except (NotVCSError, NotSdistError):
+        proj_dir = Path(project_dir)
+
+        version = load_version(proj_dir.parents[1] / 'VERSION')
+
+        if version is None:
+            version = load_version(proj_dir.parents[4] / 'VERSION')
+
+        return VCSDescription(version, 'exact', None, {})


### PR DESCRIPTION
This adds a VERSION file in the root containing a template that is filled out with the current version by git when a tarball is created using `git archive`. It also extends the Python package builds to use that version if we're not building from a git repository.

Note that git looks only for full git tags, not lightweight ones as we've been using so far. So this will require using `git tag -a vxxxx.y.z` to tag releases from now on. There's an option to also take lightweight tags into account, but it seems to be broken. Anyway, for tagging releases full tags are the standard, so we might as well do that.

With this merged and releases tagged appropriately, users will be able to install from a tarball, which saves download time and bandwidth and can be done with curl, which is available by default on macOS and most Linux installations and so saves an additional git installation step.

