### PR TITLE
Improve make 3.81 support

### DIFF
--- a/lib/sapporo_light/Makefile
+++ b/lib/sapporo_light/Makefile
@@ -86,7 +86,9 @@ $(DYNAMIC_LIB): $(OBJS) $(CUOBJS)
 	$(NVCC) $(NVCCFLAGS) -c $< -o $@
 
 $(PKG_CONFIG_FILE):
-	$(file >$@,$(PKG_CONFIG_CONTENTS))
+	# the file function is not available on old macOS make, so we make do with this
+	printf '' >$@
+	$(foreach line,$(PKG_CONFIG_CONTENTS),printf '%s\n' '$(line)' >>$@;)
 
 
 .PHONY: clean

--- a/src/amuse/rfi/tools/dir_templates/Makefile_cxx
+++ b/src/amuse/rfi/tools/dir_templates/Makefile_cxx
@@ -16,8 +16,7 @@ VERSION = VERSION
 	##### Modify URL as needed #####
 	$(DOWNLOAD) https://github.com/{code}/{code}/archive/$(VERSION).tar.gz >$@
 
-PATCHES := $(file < patches/series)
-PATCHES := $(patsubst %,%,$(PATCHES))    # replace newlines with spaces
+PATCHES := $(shell cat patches/series)
 
 src/{code}-$(VERSION): {code}.tar.gz
 	##### Modify as needed #####

--- a/src/amuse/rfi/tools/dir_templates/Makefile_fortran
+++ b/src/amuse/rfi/tools/dir_templates/Makefile_fortran
@@ -16,8 +16,7 @@ VERSION = VERSION
 	##### Modify URL as needed #####
 	$(DOWNLOAD) https://github.com/{code}/{code}/archive/$(VERSION).tar.gz >$@
 
-PATCHES := $(file < patches/series)
-PATCHES := $(patsubst %,%,$(PATCHES))    # replace newlines with spaces
+PATCHES := $(shell cat patches/series)
 
 src/{code}-$(VERSION): {code}.tar.gz
 	##### Modify as needed #####

--- a/src/amuse_mesa_r15140/Makefile
+++ b/src/amuse_mesa_r15140/Makefile
@@ -42,9 +42,7 @@ src/mesa-$(MESA_VERSION).zip:
 
 MESA_DIR := src/mesa-$(MESA_VERSION)
 
-PATCHES := $(file < patches/series_mesa)
-PATCHES := $(patsubst %,%,$(PATCHES))    # replace newlines with spaces
-
+PATCHES := $(shell cat patches/series)
 
 $(MESA_DIR): src/mesa-$(MESA_VERSION).zip
 	cd src && unzip -q ../$<

--- a/src/amuse_mesa_r2208/Makefile
+++ b/src/amuse_mesa_r2208/Makefile
@@ -12,8 +12,7 @@ support/config.mk:
 mesa_r2208.zip:
 	$(DOWNLOAD) https://zenodo.org/record/2603017/files/mesa-r2208.zip >$@
 
-PATCHES := $(file < patches/series)
-PATCHES := $(patsubst %,%,$(PATCHES))    # replace newlines with spaces
+PATCHES := $(shell cat patches/series)
 
 src/mesa: mesa_r2208.zip
 	mkdir -p src

--- a/src/amuse_mocassin/Makefile
+++ b/src/amuse_mocassin/Makefile
@@ -14,8 +14,7 @@ VERSION = 2.02.70
 mocassin.$(VERSION).tar.gz:
 	$(DOWNLOAD) https://amuse.strw.leidenuniv.nl/codes/mocassin.$(VERSION).tar.gz >$@
 
-PATCHES := $(file < patches/series)
-PATCHES := $(patsubst %,%,$(PATCHES))    # replace newlines with spaces
+PATCHES := $(shell cat patches/series)
 
 src:
 	mkdir -p src

--- a/src/amuse_mpiamrvac/Makefile
+++ b/src/amuse_mpiamrvac/Makefile
@@ -14,8 +14,7 @@ VERSION = r187
 mpiamrvac.tar.gz:
 	$(DOWNLOAD) http://amuse.strw.leidenuniv.nl/codes/mpiamrvac-$(VERSION).tgz >$@
 
-PATCHES := $(file < patches/series)
-PATCHES := $(patsubst %,%,$(PATCHES))    # replace newlines with spaces
+PATCHES := $(shell cat patches/series)
 
 src/mpiamrvac: | mpiamrvac.tar.gz
 	tar xf $|

--- a/support/shared/lib-targets.mk
+++ b/support/shared/lib-targets.mk
@@ -91,7 +91,9 @@ $(DYNAMIC_LIB): $(OBJS)
 	$(FC) $(FCFLAGS) -c -o $*.o $<
 
 $(PKG_CONFIG_FILE):
-	$(file >$@,$(PKG_CONFIG_CONTENTS))
+	# the file function is not available on old macOS make, so we make do with this
+	printf '' >$@
+	$(foreach line,$(PKG_CONFIG_CONTENTS),printf '%s\n' '$(line)' >>$@;)
 
 
 ifdef DYNAMIC_LIB_MPI
@@ -106,7 +108,9 @@ endif
 	$(MPIFC) $(FCFLAGS) $(CFLAGS_MPI) -c -o $*.mo $<
 
 $(PKG_CONFIG_FILE_MPI):
-	$(file >$@,$(PKG_CONFIG_CONTENTS_MPI))
+	# the file function is not available on old macOS make, so we make do with this
+	printf '' >$@
+	$(foreach line,$(PKG_CONFIG_CONTENTS_MPI),printf '%s\n' '$(line)' >>$@;)
 
 
 # Clean up


### PR DESCRIPTION
macOS XCode comes with GNU make 3.81, which is almost 20 years old and doesn't have some of the more modern features. Presumably Apple's GPL allergies keep it from updating. Still, if you install AMUSE in a venv on a mac then you may end up using this version of make, so it would be nice if we could build with it.

This PR removes the use of the `$(file ...)` function, which was added in GNU make 4.0.