### PR TITLE
Update SeBa patch with missing flag

### DIFF
--- a/src/amuse_seba/toolbox.patch
+++ b/src/amuse_seba/toolbox.patch
@@ -3,8 +3,8 @@ index 63009a5..f4f744f 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -1,4 +1,4 @@
--CXXFLAGS  += -I./include -I./include/star -DHAVE_CONFIG_H -DTOOLBOX
-+CXXFLAGS  += -I./include -I./include/star -DHAVE_CONFIG_H
+-CXXFLAGS  += -I./include -I./include/star -DHAVE_CONFIG_H -DTOOLBOX -Wconversion
++CXXFLAGS  += -I./include -I./include/star -DHAVE_CONFIG_H -Wconversion
  LDLIBS	  += -Lsstar -lsstar -Lnode -lnode -Lstd -lstd -lm
  CFLAGS    += -O
  CXXFLAGS  += -O


### PR DESCRIPTION
Update patch with missing/added warning from the SeBa Makefile Fixes #1159 
Thanks to @risojevicv