### PR TITLE
Fix MESA build I broke in 420dbe5841

### DIFF
--- a/src/amuse_mesa_r15140/Makefile
+++ b/src/amuse_mesa_r15140/Makefile
@@ -42,7 +42,7 @@ src/mesa-$(MESA_VERSION).zip:
 
 MESA_DIR := src/mesa-$(MESA_VERSION)
 
-PATCHES := $(shell cat patches/series)
+PATCHES := $(shell cat patches/series_mesa)
 
 $(MESA_DIR): src/mesa-$(MESA_VERSION).zip
 	cd src && unzip -q ../$<


### PR DESCRIPTION
In 420dbe5841, I changed the Makefiles to remove the use of the `$(file ...)` function, because it's not available in the ancient version of bash that macos ships. I made a mistake there that causes MESA r15140 not to be patched properly, and didn't notice it because once you have a downloaded, unpacked and patched copy of the source, the build system doesn't touch it.

This patch fixes this and makes it possible to build MESA r15140 again.