### PR TITLE
Make arctan2 work with ScalarQuantities

### DIFF
--- a/src/amuse/units/trigo.py
+++ b/src/amuse/units/trigo.py
@@ -10,8 +10,8 @@ arcsin = lambda x: numpy.arcsin(x) | rad
 arccos = lambda x: numpy.arccos(x) | rad
 arctan = lambda x: numpy.arctan(x) | rad
 arctan2 = lambda x, y: numpy.arctan2(
-    x.value_in(x.unit),
-    y.value_in(x.unit),
+    x.value_in(x.unit) if isinstance(x, quantities.Quantity) else x,
+    y.value_in(x.unit) if isinstance(x, quantities.Quantity) else y,
 ) | rad
 
 

--- a/src/amuse/units/trigo.py
+++ b/src/amuse/units/trigo.py
@@ -9,7 +9,10 @@ tan = lambda x: numpy.tan(1.0 * x)
 arcsin = lambda x: numpy.arcsin(x) | rad
 arccos = lambda x: numpy.arccos(x) | rad
 arctan = lambda x: numpy.arctan(x) | rad
-arctan2 = lambda x, y: numpy.arctan2(x, y) | rad
+arctan2 = lambda x, y: numpy.arctan2(
+    x.value_in(x.unit),
+    y.value_in(x.unit),
+) | rad
 
 
 def to_rad(angle):

--- a/src/tests/ticket_tests/test_issue1180.py
+++ b/src/tests/ticket_tests/test_issue1180.py
@@ -1,0 +1,36 @@
+import pytest
+from amuse.support.testing import amusetest
+
+from amuse.units import units
+from amuse.units.trigo import arctan2
+
+
+class TestsForIssue1180(amusetest.TestCase):
+
+    def test_arctan2_without_units(self):
+        "Test when input has no units"
+        x = 1.0
+        y = 2.0
+        result = arctan2(x, y).value_in(units.rad)
+        assert result == pytest.approx(0.4636476, 1e-7)
+
+    def test_arctan2_with_units(self):
+        "Test when input has units"
+        x = 1.0 | units.m
+        y = 2.0 | units.m
+        result = arctan2(x, y).value_in(units.rad)
+        assert result == pytest.approx(0.4636476, 1e-7)
+
+    def test_arctan2_with_units_and_no_units(self):
+        "Test when input has units and no units (should fail)"
+        x = 1.0 | units.m
+        y = 2.0
+        with pytest.raises(AttributeError):
+            result = arctan2(x, y).value_in(units.rad)
+
+    def test_arctan2_with_different_units(self):
+        "Test when input has different units"
+        x = 1.0 | units.m
+        y = 2.0e-3 | units.km
+        result = arctan2(x, y).value_in(units.rad)
+        assert result == pytest.approx(0.4636476, 1e-7)


### PR DESCRIPTION
Ensures that x and y use the same unit, which is otherwise ignored (it is divided out).