### PR TITLE
Use python-gil package on conda (#1214)

### DIFF
--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' pytest
+        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' pytest
 
       # - name: Configure OpenMPI
       #      run: |

--- a/.github/workflows/test-seba.yml
+++ b/.github/workflows/test-seba.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' pytest
+        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' pytest
 
         #    - name: Configure OpenMPI
         #      run: |

--- a/support/setup/dependencies.sh
+++ b/support/setup/dependencies.sh
@@ -33,7 +33,7 @@
 
 # MESA r15140 fails its tests when compiled with gfortran 14
 
-DEPS_conda="c-compiler cxx-compiler fortran-compiler 'gfortran<14' python pkgconfig"
+DEPS_conda="c-compiler cxx-compiler fortran-compiler 'gfortran<14' python-gil pkgconfig"
 DEPS_conda="${DEPS_conda} coreutils patch"
 DEPS_conda="${DEPS_conda} curl tar unzip gzip bzip2 xz perl bison make cmake openmpi"
 DEPS_conda="${DEPS_conda} gsl fftw gmp mpfr hdf5 netcdf4 qhull healpix_cxx libopenblas"


### PR DESCRIPTION
Updates the installer to suggest installing `python-gil` when using conda, rather than `python`. That will ensure we don't get a free-threading implementation, which causes problems with pip-installing packages.

This also updates the CI accordingly.