### PR TITLE
Try using MPICH on macOS to avoid crashes

### DIFF
--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -69,7 +69,7 @@ jobs:
         PRTE_MCA_if_include: lo,eth0
         OMPI_MCA_pmix_server_max_wait: 10
       run: |
-        export PYTEST_OPTS='-x' && ./setup test amuse-framework
+        ./setup test amuse-framework
 
     - name: Save build logs
       run: |


### PR DESCRIPTION
The CI isn't working on macOS because we're getting an unknown MPI error. This switches to MPICH on macOS, see if that works...