### PR TITLE
Add a check for mixed-source conda environments to ./setup

### DIFF
--- a/setup
+++ b/setup
@@ -77,6 +77,9 @@ configure() {
     if [ "a${ENV_TYPE}" = "a" ] ; then
         print_environment_step
         can_install="no"
+    elif [ "a${MIXED_CONDA_PACKAGES}" != "a" ] && [ "a${AMUSE_ENABLE_MIXED_PACKAGES}" = "a" ] ; then
+        print_mixed_packages
+        can_install="no"
     elif [ "a${HAVE_PIP}" = "a" ] || [ "a${HAVE_WHEEL}" = "a" ] ; then
         print_pip_wheel_step
         can_install="no"

--- a/support/setup/environment.sh
+++ b/support/setup/environment.sh
@@ -77,6 +77,30 @@ detect_installed_packages() {
 }
 
 
+# Determine whether we have a Conda environment with mixed packages
+#
+# Users of Anaconda have the Anaconda channels set by default, and if they then add
+# conda-forge and start installing packages will too often end up with some packages
+# from one source and some from the other. This leads to some very weird errors.
+#
+# This checks whether everything is installed either from conda-forge or by pip, and
+# sets MIXED_CONDA_PACKAGES to a list of packages that are not from conda-forge or pip.
+# If we're not in a conda environment or everything is fine, then MIXED_CONDA_PACKAGES
+# will be an empty string.
+check_mixed_conda_packages() {
+    MIXED_CONDA_PACKAGES=""
+    if [ "a${ENV_TYPE}" = "aconda" ] ; then
+        ALIEN_PACKAGES="$(echo "${CONDA_LIST}" | tr '^' '\n' | grep -v '^#.*\|conda-forge\|pypi' | cut -d ' ' -f 1,4)"
+        if [ "a${ALIEN_PACKAGES}" != "a" ] ; then
+            MIXED_CONDA_PACKAGES=''
+            for p in ${ALIEN_PACKAGES} ; do
+                MIXED_CONDA_PACKAGES="${MIXED_CONDA_PACKAGES} ${p}"
+            done
+        fi
+    fi
+}
+
+
 # Determine if we have the required features to build the framework
 #
 # This uses the following variables:
@@ -212,6 +236,7 @@ find_packages() {
 analyse_environment() {
     detect_environments
     detect_installed_packages
+    check_mixed_conda_packages
     check_build_framework
     check_build_sapporo_light
     find_packages

--- a/support/setup/help.sh
+++ b/support/setup/help.sh
@@ -134,6 +134,25 @@ again to continue."
 }
 
 
+print_mixed_packages() {
+    # Note that MIXED_CONDA_PACKAGES starts with a space
+    printf '%b\n' "${BOLD}${COLOR_YELLOW}* (error) Fix mixed-source packages *${COLOR_END}${END_BOLD}
+
+Installation is disabled because packages from mixed sources were found in your Conda
+environment. This can cause some very weird problems. AMUSE is designed and tested with
+packages from conda-forge. The following packages were not installed from conda-forge:
+
+   ${MIXED_CONDA_PACKAGES}
+
+To reinstall them from conda-forge, you can try:
+
+    conda install --channel conda-forge --override-channels${MIXED_CONDA_PACKAGES}
+
+If you're sure you know what you're doing, then you can disable this check by setting
+the environment variable AMUSE_ENABLE_MIXED_PACKAGES to 1 and running ./setup again."
+}
+
+
 print_pip_wheel_step() {
     printf '%b\n' "${BOLD}${COLOR_YELLOW}* (2/4) Install pip and wheel *${COLOR_END}${END_BOLD}
 


### PR DESCRIPTION
This extends the installer to check the conda environment (if we're in one) for packages that were not installed from conda-forge or pypi, but from some other conda channel. It warns the user in that case, and explains how to reinstall the affected packages from conda-forge.

There's also an override for experts, in case people want to combine AMUSE with some package that is only available from a custom channel.

Fixes #1190.