### PR TITLE
Fix version detection to work with older gmakes

### DIFF
--- a/support/shared/version.mk
+++ b/support/shared/version.mk
@@ -1,7 +1,8 @@
 AMUSE_VERSION := $(patsubst v%,%,$(shell git describe --tags))
 
 ifeq (,$(AMUSE_VERSION))
-    AMUSE_VERSION := $(shell grep -v '^#' ../../VERSION)
+    H := #
+    AMUSE_VERSION := $(shell grep -v '^$H' ../../VERSION)
 endif
 
 export AMUSE_VERSION


### PR DESCRIPTION
I've tested this with gmake 4.4.1, 4.3, 4.2.1, 4.2, and even 3.81, and could reproduce the problem on versions before 4.3. With this fix applied, it works with all of the above versions, although building with gmake 3.81 doesn't work for unrelated reasons. That's fine, it's extremely old and macOS users can install a newer make with all the other dependencies.

Fixes #1188.