### PR TITLE
Use standard __version__ variable for version

### DIFF
--- a/src/amuse/__init__.py
+++ b/src/amuse/__init__.py
@@ -56,7 +56,4 @@ def get_data(path):
     return os.path.join(_AMUSE_ROOT, "data", path)
 
 
-try:
-    from amuse._version import __version__
-except ImportError:
-    __version__ = "unknown version"
+from amuse._version import __version__

--- a/src/amuse/support/literature.py
+++ b/src/amuse/support/literature.py
@@ -17,10 +17,7 @@ from os.path import exists
 from collections import namedtuple
 from docutils import nodes
 from amuse.support import exceptions
-try:
-    from amuse._version import version as amuse_version
-except ImportError:
-    amuse_version = "unknown version"
+from amuse._version import __version__ as amuse_version
 
 import amuse
 
@@ -283,11 +280,11 @@ class LiteratureReferencesMixIn(object):
             version = importlib.import_module(
                 '.._version',
                 cls.__module__
-            ).version
+            ).__version__
         except (ImportError, ValueError):
             try:
-                from amuse.version import version
-                version = f"framework {version}"
+                from amuse._version import __version__
+                version = f"framework {__version__}"
             except ImportError:
                 version = "unknown version"
         return version


### PR DESCRIPTION
It turns out hatchling only writes `__version__`, so we'll have to make do without the non-standard `version`. This updates the literature subsystem to import and use that so that we get correct versions again.

I've also removed the catch, which will cause AMUSE to crash if the version isn't found in the future. That should never happen on a correct install (including a development install, because `pip install -e` will create `_version.py` also in that case. If it does happen, then we want to know and fix it, not silently ignore the problem.

Fixes #1187.