### PR TITLE
Fix incorrect symlink generation in amusifier

### DIFF
--- a/src/amuse/rfi/tools/create_dir.py
+++ b/src/amuse/rfi/tools/create_dir.py
@@ -84,14 +84,13 @@ def _make_support(code_dir: Path, language: str, variables: Dict[str, str]) -> N
     for tmpl, path in tmpls_paths.items():
         _instantiate_template(tmpl, support_dir / path.format(**variables), variables)
 
-    # TODO: this needs to be updated when we move the codes out of community/
-    shared_base = code_dir / ".." / ".." / ".." / "support" / "shared"
+    shared_base = code_dir / ".." / ".." / "support" / "shared"
     shared_dir = support_dir / "shared"
     if shared_base.exists():
         # We're probably inside the AMUSE tree, so we make a symlink like for the other
         # embedded codes. This avoids having to update many copies of e.g. a broken m4
         # macro.
-        shared_dir.symlink_to(shared_base)
+        shared_dir.symlink_to(Path("..") / ".." / ".." / "support" / "shared")
     else:
         shared_dir.mkdir()
         for src, dst in _files_support.items():


### PR DESCRIPTION
This fixes #1185, and it fixes the code to generate `support/shared` as a link again when creating a new code dir at `src/amuse_<code>`.