### PR TITLE
Make build compatible with GNU make 3.81 (#1246)

### DIFF
--- a/src/amuse_gadget2/Makefile
+++ b/src/amuse_gadget2/Makefile
@@ -24,8 +24,11 @@ build_%:
 build_%/makefile_options: makefile_options_% | build_%
 	cp makefile_options_$* $@
 
-build_%/$(CODELIB) build_%/allvars.o &: build_%/makefile_options FORCE
+build_%/$(CODELIB): build_%/makefile_options FORCE
 	$(MAKE) -C build_$* -f ../src/Makefile -j $(CPU_COUNT) all VPATH=../src
+
+build_%/allvars.o: build_%/$(CODELIB) FORCE
+	@true
 
 
 # Load code configuration


### PR DESCRIPTION
This tweaks the Gadget2 outer makefile to avoid a "mixed" (it isn't really, from what I can see, but make is complaining anyway) rule, which makes it possible to build AMUSE using GNU make 3.81. This is relevant because that version gets installed by XCode by default, and MacPorts installs GNU make as `gmake`, and our m4 macro tries `make` before `gmake`, and so it finds 3.81.

An alternative may be to modify the macro to detect GNU make >=4, but this seems to be the only issue building with 3.81, and it's easily fixed.

Tested also on @christianboily's machine.

Fixes #1246.