### PR TITLE
Mesa-r15140: ensure makedepf90 configure does not get overwritten

### DIFF
--- a/src/amuse_mesa_r15140/Makefile
+++ b/src/amuse_mesa_r15140/Makefile
@@ -114,6 +114,7 @@ src/bin/fpx3_deps: | src/fpx3_deps
 
 $(MESA_DIR)/utils/makedepf90-2.8.8: | $(MESA_DIR)
 	cd $(MESA_DIR)/utils && tar xzf makedepf90-2.8.8.tar.gz -m
+    touch $(MESA_DIR)/utils/makedepf90-2.8.8/configure
 
 src/bin/makedepf90: | $(MESA_DIR)/utils/makedepf90-2.8.8 src/bin
 	cd $(MESA_DIR)/utils/makedepf90-2.8.8 && ./configure


### PR DESCRIPTION
On macOS, `make` tries to run `autoconf`, which causes building Mesa to fail. The reason is that the configure file is slightly out-of-date. This fixes that. One of the weirder bugs I've seen...