### PR TITLE
Fix clash with LIBS in environment

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,5 @@
 .PHONY: Makefile
-LIBS = $(filter-out Makefile sapporo_light, $(wildcard *))
+AMUSE_LIBS = $(filter-out Makefile sapporo_light, $(wildcard *))
 
 
 # We build sapporo_light separately and only on demand, because it needs CUDA and we
@@ -10,9 +10,9 @@ LIBS = $(filter-out Makefile sapporo_light, $(wildcard *))
 
 
 .PHONY: install uninstall clean distclean
-install uninstall clean distclean: $(LIBS)
+install uninstall clean distclean: $(AMUSE_LIBS)
 
-.PHONY: $(LIBS)
-$(LIBS):
+.PHONY: $(AMUSE_LIBS)
+$(AMUSE_LIBS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 


### PR DESCRIPTION
The `libs/Makefile` makes a list of AMUSE library names in a variable called `LIBS`. This name is also commonly used to specify libraries to link with (e.g. `-lsomething` statements), and so may be set in the environment, in which case the build fails. This changes the variable name used to `AMUSE_LIBS` to avoid that problem.