### PR TITLE
Fix Tupan test failures with numpy ≥2.4.0 (fixes #1256)

### DIFF
--- a/src/amuse_tupan/interface.py
+++ b/src/amuse_tupan/interface.py
@@ -572,17 +572,17 @@ class Tupan(GravitationalDynamics, GravityFieldCode):
     def define_methods(self, handler):
         GravitationalDynamics.define_methods(self, handler)
 
-        handler.add_method(
-            "get_eta",
-            (),
-            (handler.NO_UNIT, handler.ERROR_CODE,)
-        )
+        # handler.add_method(
+        #     "get_eta",
+        #     (),
+        #     (handler.NO_UNIT, handler.ERROR_CODE,)
+        # )
 
-        handler.add_method(
-            "set_eta",
-            (handler.NO_UNIT,),
-            (handler.ERROR_CODE,)
-        )
+        # handler.add_method(
+        #     "set_eta",
+        #     (handler.NO_UNIT,),
+        #     (handler.ERROR_CODE,)
+        # )
 
         handler.add_method(
             "get_time",

--- a/src/amuse_tupan/interface.py
+++ b/src/amuse_tupan/interface.py
@@ -572,18 +572,6 @@ class Tupan(GravitationalDynamics, GravityFieldCode):
     def define_methods(self, handler):
         GravitationalDynamics.define_methods(self, handler)
 
-        # handler.add_method(
-        #     "get_eta",
-        #     (),
-        #     (handler.NO_UNIT, handler.ERROR_CODE,)
-        # )
-
-        # handler.add_method(
-        #     "set_eta",
-        #     (handler.NO_UNIT,),
-        #     (handler.ERROR_CODE,)
-        # )
-
         handler.add_method(
             "get_time",
             (),

--- a/src/amuse_tupan/interface.py
+++ b/src/amuse_tupan/interface.py
@@ -1,10 +1,10 @@
 
-from amuse.datamodel.particles import Particle, Particles
 from amuse.community import *
 from amuse.community.interface.gd import GravitationalDynamicsInterface
 from amuse.community.interface.gd import GravitationalDynamics
 from amuse.community.interface.gd import SinglePointGravityFieldInterface
 from amuse.community.interface.gd import GravityFieldCode
+from amuse.datamodel.particles import Particle, Particles
 from amuse.rfi.core import PythonCodeInterface
 
 import sys
@@ -62,7 +62,7 @@ class TupanImplementation(object):
     def commit_particles(self):
         ps = ParticleSystem(nstars=len(self.particles))
         for (i, p) in enumerate(self.particles):
-            ps.id[i] = i
+            ps.id[i] = p.id
             ps.mass[i] = p.mass
             ps.radius[i] = p.radius   # XXX: 'radius' is not yet used in Tupan.
             ps.eps2[i] = self.eps2/2
@@ -95,6 +95,7 @@ class TupanImplementation(object):
         vx, vy, vz,
     ):
         ps = Particle()
+        ps.id = len(self.particles)
         ps.mass = mass
         ps.radius = radius
         ps.x = x
@@ -103,7 +104,7 @@ class TupanImplementation(object):
         ps.vx = vx
         ps.vy = vy
         ps.vz = vz
-        index_of_the_particle.value = len(self.particles)
+        index_of_the_particle.value = ps.id
         self.particles.add_particle(ps)
 
         return 0

--- a/src/amuse_tupan/interface.py
+++ b/src/amuse_tupan/interface.py
@@ -1,5 +1,5 @@
 
-
+from amuse.datamodel.particles import Particle, Particles
 from amuse.community import *
 from amuse.community.interface.gd import GravitationalDynamicsInterface
 from amuse.community.interface.gd import GravitationalDynamics
@@ -38,7 +38,7 @@ class TupanImplementation(object):
         self.integrator_method = "sia21h.dkd"
         self.pn_order = 0
         self.clight = None
-        self.particles = []
+        self.particles = Particles()
         self.particles_initialized = False
 
     def initialize_code(self):
@@ -60,43 +60,52 @@ class TupanImplementation(object):
         return 0
 
     def commit_particles(self):
-        num = len(self.particles)
-        ps = ParticleSystem(nstars=num)
+        ps = ParticleSystem(nstars=len(self.particles))
         for (i, p) in enumerate(self.particles):
             ps.id[i] = i
             ps.mass[i] = p.mass
             ps.radius[i] = p.radius   # XXX: 'radius' is not yet used in Tupan.
             ps.eps2[i] = self.eps2/2
-            ps.rx[i] = p.rx
-            ps.ry[i] = p.ry
-            ps.rz[i] = p.rz
+            ps.rx[i] = p.x
+            ps.ry[i] = p.y
+            ps.rz[i] = p.z
             ps.vx[i] = p.vx
             ps.vy[i] = p.vy
             ps.vz[i] = p.vz
-        self.integrator = Integrator(self.eta,
-                                     self.time_begin,
-                                     ps,
-                                     method=self.integrator_method,
-                                     pn_order=self.pn_order,
-                                     clight=self.clight)
+
+        self.integrator = Integrator(
+            self.eta,
+            self.time_begin,
+            ps,
+            method=self.integrator_method,
+            pn_order=self.pn_order,
+            clight=self.clight
+        )
         return 0
 
     def synchronize_model(self):
         return 0
 
-    def new_particle(self, index_of_the_particle,
-                     mass, radius, x, y, z, vx, vy, vz):
-        ps = ParticleSystem(nstars=1)
-        ps.mass[0] = mass
-        ps.radius[0] = radius
-        ps.rx[0] = x
-        ps.ry[0] = y
-        ps.rz[0] = z
-        ps.vx[0] = vx
-        ps.vy[0] = vy
-        ps.vz[0] = vz
-        self.particles.append(ps)
-        index_of_the_particle.value = len(self.particles)-1
+    def new_particle(
+        self,
+        index_of_the_particle,
+        mass,
+        radius,
+        x, y, z,
+        vx, vy, vz,
+    ):
+        ps = Particle()
+        ps.mass = mass
+        ps.radius = radius
+        ps.x = x
+        ps.y = y
+        ps.z = z
+        ps.vx = vx
+        ps.vy = vy
+        ps.vz = vz
+        index_of_the_particle.value = len(self.particles)
+        self.particles.add_particle(ps)
+
         return 0
 
     def set_state(self, index_of_the_particle,

--- a/src/amuse_tupan/packages/amuse-tupan/pyproject.toml
+++ b/src/amuse_tupan/packages/amuse-tupan/pyproject.toml
@@ -3,8 +3,7 @@ name = "amuse-tupan"
 dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
-    "amuse-framework",
-    "amuse_tupan"
+    "amuse-framework"
 ]
 
 [build-system]
@@ -44,4 +43,3 @@ pythonpath = ["amuse_tupan/tests/"]
 testpaths = ["amuse_tupan/tests"]
 
 addopts = "--import-mode=append"    # test the installed package
-

--- a/src/amuse_tupan/tests/test_tupan.py
+++ b/src/amuse_tupan/tests/test_tupan.py
@@ -174,52 +174,24 @@ class TestTupan(TestWithMPI):
         instance.cleanup_code()
         instance.stop()
 
-    def xtest02(self):
+    def test02(self):
         if MODULES_MISSING:
             self.skip("Failed to import a module required for Tupan")
-        print("Testing Tupan parameters")
+        print("Testing Tupan default parameters")
         instance = self.new_instance_of_an_optional_code(Tupan, self.default_converter)
         instance.initialize_code()
 
-        self.assertEqual(instance.parameters.epsilon_squared,
-            instance.unit_converter.to_si(0.0 | nbody_system.length**2))
-        self.assertEqual(instance.parameters.timestep_parameter, 0.125)
-
-        for par, value in [('epsilon_squared_star_star', 0.0 | nbody_system.length**2),
-                ('epsilon_squared_star_blackhole', 0.0 | nbody_system.length**2),
-                ('epsilon_squared_blackhole_blackhole', 0.0 | nbody_system.length**2),
-                ('initial_timestep_parameter', 1.0e-4),
-                ('timestep_parameter_stars', 0.1),
-                ('timestep_parameter_supermassive_black_holes', 0.4),
-                ('timestep_parameter_intermediate_mass_black_holes', 0.4),
-                ('max_relative_energy_error', 5.0e-5),
-                ('maximum_timestep', 1.0/1024.0 | nbody_system.time),
-                ('smbh_mass', 1.0 | nbody_system.mass)]:
-            self.assertEqual(instance.unit_converter.to_si(value),
-                getattr(instance.parameters, par))
-            setattr(instance.parameters, par, 3.0 | value.unit)
-            self.assertEqual(instance.unit_converter.to_si(3.0 | value.unit),
-                getattr(instance.parameters, par))
-
-        # epsilon_squared is an alias for epsilon_squared_star_star, so epsilon_squared also has become 3:
-        self.assertEqual(instance.parameters.epsilon_squared,
-            instance.unit_converter.to_si(3.0 | nbody_system.length**2))
-        instance.parameters.epsilon_squared = 0.1 | nbody_system.length**2
-        self.assertEqual(instance.parameters.epsilon_squared,
-            instance.unit_converter.to_si(0.1 | nbody_system.length**2))
-        # timestep_parameter is an alias for timestep_parameter_stars, so timestep_parameter also has become 3:
-        self.assertEqual(instance.parameters.timestep_parameter, 3.0)
-        instance.parameters.timestep_parameter = 0.01
-        self.assertEqual(instance.parameters.timestep_parameter, 0.01)
-
-        self.assertEqual(instance.parameters.include_smbh, False)
-        instance.parameters.include_smbh = True
-        self.assertEqual(instance.parameters.include_smbh, True)
-        self.assertEqual(instance.parameters.calculate_postnewtonian, True)
-        instance.parameters.calculate_postnewtonian = False
-        self.assertEqual(instance.parameters.calculate_postnewtonian, False)
-
-        self.assertEqual(instance.parameters.drink, "Vodka martini. Shaken, not stirred.")
+        self.assertEquals(instance.parameters.timestep_parameter, 0.03125)
+        self.assertEquals(
+            instance.parameters.epsilon_squared,
+            instance.unit_converter.to_si(0.0 | nbody_system.length**2)
+        )
+        self.assertEquals(
+            instance.parameters.begin_time,
+            instance.unit_converter.to_si(0.0 | nbody_system.time)
+        )
+        self.assertEquals(instance.parameters.integrator_method, 'sia21h.dkd')
+        self.assertEquals(instance.parameters.pn_order, 0)
 
         instance.stop()
 


### PR DESCRIPTION
Fixes amusecode/amuse#1256

Problem: 
Tupan tests fail with numpy ≥2.4.0 due to incompatible dtype handling in `commit_particles`. The method was assigning 0-dimensional np.ndarray objects to `ParticleSystem` attributes instead of scalars.

Solution: Refactored particle management to use amuse.datamodel.particle module.
- `new_particle`: Changed to instantiate `Particle` objects and accumulate them in a `Particles` object (instead of creating single-element `ParticleSystem` instances)
- `commit_particles`: Convert the accumulated `Particles` object to a `ParticleSystem` before passing to Tupan

Test Status:
All uncommented tests pass. Tests `xtest04`, `xtest08`, `xtest10` remain commented because they test unimplemented features (stopping conditions, `get_gravity_at_point`).

Additional Changes:
- Removed redundant `get_eta` and `set_eta` from Tupan methods as they are already defined as parameters.
- Refactored TestTupan::test02 as it was testing parameters that do not exist.
- Removed Tupan being listed as a dependency of Tupan in the pyproject.toml