### PR TITLE
Improve framework CI running

### DIFF
--- a/.github/workflows/test-compat-conda.yml
+++ b/.github/workflows/test-compat-conda.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - setup
+      - support/**
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-compat-venv-apt.yml
+++ b/.github/workflows/test-compat-venv-apt.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - setup
+      - support/**
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -5,10 +5,14 @@ on:
     paths:
       - .github/workflows/test-framework.yml
       - 'src/amuse/**'
+      - 'lib/**'
+      - 'src/tests/**'
   pull_request:
     paths:
       - .github/workflows/test-framework.yml
       - 'src/amuse/**'
+      - 'lib/**'
+      - 'src/tests/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This extends the framework CI tests to run if there are changes to the libraries or the framework tests, rather than only to the Python code.

It also runs the all-up compat tests for PRs only if the PR changes the installer, otherwise only the specific tests for framework or code will be run.

Fixes #1271