### PR TITLE
Add GPU tests on the new self-hosted runner

### DIFF
--- a/.github/workflows/test-etics-cuda.yml
+++ b/.github/workflows/test-etics-cuda.yml
@@ -1,0 +1,72 @@
+name: Test AMUSE etics
+
+on:
+  push:
+    paths:
+      - .github/workflows/test-etics-cuda.yml
+      - 'src/amuse_etics/**'
+  pull_request:
+    paths:
+      - .github/workflows/test-etics-cuda.yml
+      - 'src/amuse_etics/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: [self-hosted, amusebuilder]
+
+    strategy:
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
+
+    - name: Show conda info
+      run: |
+        conda info
+        conda list
+
+    - name: Install dependencies
+      run: |
+        conda install c-compiler cxx-compiler fortran-compiler gfortran python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' cuda-toolkit pytest
+
+    - name: Configure OpenMPI
+      run: |
+        mkdir -p "$HOME/.openmpi"
+        echo "btl_tcp_if_include = lo" >>"$HOME/.openmpi/mca-params.conf"
+        echo "rmaps_base_oversubscribe = true" >>"$HOME/.openmpi/mca-params.conf"
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Build etics CUDA
+      run: |
+        ./setup install amuse-etics-cuda
+
+    - name: Ensure we test only the installed package
+      run: |
+        ./setup distclean
+
+    - name: Test etics
+      run: |
+        ./setup test amuse-etics-cuda
+
+    - name: Archive build logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-${{ matrix.os }}
+        path: ${{ github.workspace }}/support/logs/
+        if-no-files-found: warn

--- a/.github/workflows/test-fastkick-cuda.yml
+++ b/.github/workflows/test-fastkick-cuda.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake 'openmpi<5' gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' cuda-toolkit pytest
+        conda install c-compiler cxx-compiler fortran-compiler gfortran python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' cuda-toolkit pytest
 
     - name: Configure OpenMPI
       run: |

--- a/.github/workflows/test-fastkick-cuda.yml
+++ b/.github/workflows/test-fastkick-cuda.yml
@@ -1,0 +1,72 @@
+name: Test AMUSE fastkick with CUDA
+
+on:
+  push:
+    paths:
+      - .github/workflows/test-fastkick-cuda.yml
+      - 'src/amuse_fastkick/**'
+  pull_request:
+    paths:
+      - .github/workflows/test-fastkick-cuda.yml
+      - 'src/amuse_fastkick/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: [self-hosted, amusebuilder]
+
+    strategy:
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
+
+    - name: Show conda info
+      run: |
+        conda info
+        conda list
+
+    - name: Install dependencies
+      run: |
+        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake 'openmpi<5' gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' pytest
+
+    - name: Configure OpenMPI
+      run: |
+        mkdir -p "$HOME/.openmpi"
+        echo "btl_tcp_if_include = lo" >>"$HOME/.openmpi/mca-params.conf"
+        echo "rmaps_base_oversubscribe = true" >>"$HOME/.openmpi/mca-params.conf"
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Build fastkick CUDA
+      run: |
+        ./setup install amuse-fastkick-cuda
+
+    - name: Ensure we test only the installed package
+      run: |
+        ./setup distclean
+
+    - name: Test fastkick
+      run: |
+        ./setup test amuse-fastkick-cuda
+
+    - name: Archive build logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-${{ matrix.os }}
+        path: ${{ github.workspace }}/support/logs/
+        if-no-files-found: warn

--- a/.github/workflows/test-fastkick-cuda.yml
+++ b/.github/workflows/test-fastkick-cuda.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake 'openmpi<5' gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' pytest
+        conda install c-compiler cxx-compiler fortran-compiler 'gfortran<14' python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake 'openmpi<5' gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' cuda-toolkit pytest
 
     - name: Configure OpenMPI
       run: |

--- a/.github/workflows/test-higpus-cuda.yml
+++ b/.github/workflows/test-higpus-cuda.yml
@@ -1,0 +1,72 @@
+name: Test AMUSE higpus
+
+on:
+  push:
+    paths:
+      - .github/workflows/test-higpus-cuda.yml
+      - 'src/amuse_higpus/**'
+  pull_request:
+    paths:
+      - .github/workflows/test-higpus-cuda.yml
+      - 'src/amuse_higpus/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: [self-hosted, amusebuilder]
+
+    strategy:
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
+
+    - name: Show conda info
+      run: |
+        conda info
+        conda list
+
+    - name: Install dependencies
+      run: |
+        conda install c-compiler cxx-compiler fortran-compiler gfortran python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' cuda-toolkit pytest
+
+    - name: Configure OpenMPI
+      run: |
+        mkdir -p "$HOME/.openmpi"
+        echo "btl_tcp_if_include = lo" >>"$HOME/.openmpi/mca-params.conf"
+        echo "rmaps_base_oversubscribe = true" >>"$HOME/.openmpi/mca-params.conf"
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Build higpus CUDA
+      run: |
+        ./setup install amuse-higpus-cuda
+
+    - name: Ensure we test only the installed package
+      run: |
+        ./setup distclean
+
+    - name: Test higpus
+      run: |
+        ./setup test amuse-higpus-cuda
+
+    - name: Archive build logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-${{ matrix.os }}
+        path: ${{ github.workspace }}/support/logs/
+        if-no-files-found: warn

--- a/.github/workflows/test-huayno-opencl.yml
+++ b/.github/workflows/test-huayno-opencl.yml
@@ -1,0 +1,72 @@
+name: Test AMUSE huayno
+
+on:
+  push:
+    paths:
+      - .github/workflows/test-huayno-opencl.yml
+      - 'src/amuse_huayno/**'
+  pull_request:
+    paths:
+      - .github/workflows/test-huayno-opencl.yml
+      - 'src/amuse_huayno/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: [self-hosted, amusebuilder]
+
+    strategy:
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
+
+    - name: Show conda info
+      run: |
+        conda info
+        conda list
+
+    - name: Install dependencies
+      run: |
+        conda install c-compiler cxx-compiler fortran-compiler gfortran python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' cuda-toolkit pytest
+
+    - name: Configure OpenMPI
+      run: |
+        mkdir -p "$HOME/.openmpi"
+        echo "btl_tcp_if_include = lo" >>"$HOME/.openmpi/mca-params.conf"
+        echo "rmaps_base_oversubscribe = true" >>"$HOME/.openmpi/mca-params.conf"
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Build huayno CUDA
+      run: |
+        ./setup install amuse-huayno-opencl
+
+    - name: Ensure we test only the installed package
+      run: |
+        ./setup distclean
+
+    - name: Test huayno
+      run: |
+        ./setup test amuse-huayno-opencl
+
+    - name: Archive build logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-${{ matrix.os }}
+        path: ${{ github.workspace }}/support/logs/
+        if-no-files-found: warn

--- a/.github/workflows/test-ph4-sapporo.yml
+++ b/.github/workflows/test-ph4-sapporo.yml
@@ -1,0 +1,72 @@
+name: Test AMUSE ph4-sapporo
+
+on:
+  push:
+    paths:
+      - .github/workflows/test-ph4-sapporo.yml
+      - 'src/amuse_ph4/**'
+  pull_request:
+    paths:
+      - .github/workflows/test-ph4-sapporo.yml
+      - 'src/amuse_ph4/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: [self-hosted, amusebuilder]
+
+    strategy:
+      fail-fast: false
+
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        channels: conda-forge
+        channel-priority: strict
+
+    - name: Show conda info
+      run: |
+        conda info
+        conda list
+
+    - name: Install dependencies
+      run: |
+        conda install c-compiler cxx-compiler fortran-compiler gfortran python-gil pkgconfig coreutils patch curl tar unzip gzip bzip2 xz perl bison make cmake openmpi gsl fftw gmp mpfr hdf5 netcdf4 libopenblas liblapack zlib pip wheel 'docutils>=0.6' 'mpi4py>=1.1.0' 'numpy>=1.2.2' 'h5py>=1.1.0' cuda-toolkit pytest
+
+    - name: Configure OpenMPI
+      run: |
+        mkdir -p "$HOME/.openmpi"
+        echo "btl_tcp_if_include = lo" >>"$HOME/.openmpi/mca-params.conf"
+        echo "rmaps_base_oversubscribe = true" >>"$HOME/.openmpi/mca-params.conf"
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Build ph4 CUDA
+      run: |
+        ./setup install amuse-ph4-sapporo
+
+    - name: Ensure we test only the installed package
+      run: |
+        ./setup distclean
+
+    - name: Test ph4
+      run: |
+        ./setup test amuse-ph4-sapporo
+
+    - name: Archive build logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: logs-${{ matrix.os }}
+        path: ${{ github.workspace }}/support/logs/
+        if-no-files-found: warn


### PR DESCRIPTION
This adds GitHub Actions workflows for the GPU codes, running on the new self-hosted runner in Leiden.